### PR TITLE
test: Add event E2E tests

### DIFF
--- a/apps/api/src/api-key/api-key.e2e.spec.ts
+++ b/apps/api/src/api-key/api-key.e2e.spec.ts
@@ -9,6 +9,7 @@ import { MockMailService } from '../mail/services/mock.service'
 import { AppModule } from '../app/app.module'
 import { Test } from '@nestjs/testing'
 import { ApiKey, User } from '@prisma/client'
+import cleanUp from '../common/cleanup'
 
 describe('Api Key Role Controller Tests', () => {
   let app: NestFastifyApplication
@@ -194,10 +195,6 @@ describe('Api Key Role Controller Tests', () => {
   })
 
   afterAll(async () => {
-    await prisma.apiKey.deleteMany()
-    await prisma.user.deleteMany()
-
-    await prisma.$disconnect()
-    await app.close()
+    await cleanUp(prisma)
   })
 })

--- a/apps/api/src/common/cleanup.ts
+++ b/apps/api/src/common/cleanup.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client'
+
+export default async function cleanUp(prisma: PrismaClient) {
+  await prisma.$transaction([
+    prisma.workspaceMemberRoleAssociation.deleteMany(),
+    prisma.workspaceMember.deleteMany(),
+    prisma.workspaceRole.deleteMany(),
+    prisma.workspace.deleteMany(),
+    prisma.secret.deleteMany(),
+    prisma.environment.deleteMany(),
+    prisma.project.deleteMany(),
+    prisma.user.deleteMany(),
+    prisma.event.deleteMany(),
+    prisma.apiKey.deleteMany()
+  ])
+}

--- a/apps/api/src/event/controller/event.controller.ts
+++ b/apps/api/src/event/controller/event.controller.ts
@@ -23,8 +23,7 @@ export class EventController {
     @Query('environmentId') environmentId: string,
     @Query('secretId') secretId: string,
     @Query('apiKeyId') apiKeyId: string,
-    @Query('workspaceRoleId') workspaceRoleId: string,
-    @Query('workspaceMemberId') workspaceMemberId: string
+    @Query('workspaceRoleId') workspaceRoleId: string
   ) {
     return this.eventService.getEvents(
       user,
@@ -34,8 +33,7 @@ export class EventController {
         environmentId,
         secretId,
         apiKeyId,
-        workspaceRoleId,
-        workspaceMemberId
+        workspaceRoleId
       },
       page,
       limit,

--- a/apps/api/src/event/event.e2e.spec.ts
+++ b/apps/api/src/event/event.e2e.spec.ts
@@ -1,0 +1,352 @@
+import {
+  FastifyAdapter,
+  NestFastifyApplication
+} from '@nestjs/platform-fastify'
+import {
+  Authority,
+  Environment,
+  EventSeverity,
+  EventSource,
+  EventTriggerer,
+  EventType,
+  Project,
+  User,
+  Workspace
+} from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { Test } from '@nestjs/testing'
+import { WorkspaceRoleModule } from '../workspace-role/workspace-role.module'
+import { AppModule } from '../app/app.module'
+import { MAIL_SERVICE } from '../mail/services/interface.service'
+import { MockMailService } from '../mail/services/mock.service'
+import { EventModule } from './event.module'
+import { UserModule } from '../user/user.module'
+import { UserService } from '../user/service/user.service'
+import cleanUp from '../common/cleanup'
+import { WorkspaceService } from '../workspace/service/workspace.service'
+import { WorkspaceModule } from '../workspace/workspace.module'
+import { ApiKeyService } from '../api-key/service/api-key.service'
+import { EnvironmentService } from '../environment/service/environment.service'
+import { WorkspaceRoleService } from '../workspace-role/service/workspace-role.service'
+import { ProjectService } from '../project/service/project.service'
+import { SecretService } from '../secret/service/secret.service'
+import { SecretModule } from '../secret/secret.module'
+import { ProjectModule } from '../project/project.module'
+import { EnvironmentModule } from '../environment/environment.module'
+import { ApiKeyModule } from '../api-key/api-key.module'
+
+const makeRequest = async (
+  app: NestFastifyApplication,
+  user: User,
+  query?: string
+) =>
+  await app.inject({
+    method: 'GET',
+    headers: {
+      'x-e2e-user-email': user.email
+    },
+    url: `/event${query ? '?' + query : ''}`
+  })
+
+describe('Event Controller Tests', () => {
+  let app: NestFastifyApplication
+  let prisma: PrismaService
+
+  let userService: UserService
+  let workspaceService: WorkspaceService
+  let apiKeyService: ApiKeyService
+  let environmentService: EnvironmentService
+  let workspaceRoleService: WorkspaceRoleService
+  let projectService: ProjectService
+  let secretService: SecretService
+
+  let user: User
+  let workspace: Workspace
+  let project: Project
+  let environment: Environment
+
+  const totalEvents = []
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        AppModule,
+        EventModule,
+        UserModule,
+        WorkspaceModule,
+        WorkspaceRoleModule,
+        SecretModule,
+        ProjectModule,
+        EnvironmentModule,
+        ApiKeyModule
+      ]
+    })
+      .overrideProvider(MAIL_SERVICE)
+      .useClass(MockMailService)
+      .compile()
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter()
+    )
+    prisma = moduleRef.get(PrismaService)
+    userService = moduleRef.get(UserService)
+    workspaceService = moduleRef.get(WorkspaceService)
+    apiKeyService = moduleRef.get(ApiKeyService)
+    environmentService = moduleRef.get(EnvironmentService)
+    workspaceRoleService = moduleRef.get(WorkspaceRoleService)
+    projectService = moduleRef.get(ProjectService)
+    secretService = moduleRef.get(SecretService)
+
+    await app.init()
+    await app.getHttpAdapter().getInstance().ready()
+
+    await cleanUp(prisma)
+
+    user = await prisma.user.create({
+      data: {
+        email: 'johndoe@keyshade.xyz',
+        name: 'John Doe'
+      }
+    })
+  })
+
+  it('should be able to fetch a user event', async () => {
+    const updatedUser = await userService.updateSelf(user, {
+      isOnboardingFinished: true
+    })
+    user = updatedUser
+
+    expect(updatedUser).toBeDefined()
+
+    const response = await makeRequest(app, user)
+
+    totalEvents.push({
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.USER,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.USER_UPDATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(totalEvents)
+  })
+
+  it('should be able to fetch API key event', async () => {
+    const newApiKey = await apiKeyService.createApiKey(user, {
+      name: 'My API key',
+      authorities: [Authority.READ_API_KEY]
+    })
+
+    expect(newApiKey).toBeDefined()
+
+    const response = await makeRequest(app, user, `apiKeyId=${newApiKey.id}`)
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.API_KEY,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.API_KEY_ADDED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([event])
+  })
+
+  it('should be able to fetch a workspace event', async () => {
+    const newWorkspace = await workspaceService.createWorkspace(user, {
+      name: 'My workspace',
+      description: 'Some description'
+    })
+    workspace = newWorkspace
+
+    expect(newWorkspace).toBeDefined()
+
+    const response = await makeRequest(
+      app,
+      user,
+      `workspaceId=${newWorkspace.id}`
+    )
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.WORKSPACE,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.WORKSPACE_CREATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([event])
+  })
+
+  it('should be able to fetch a project event', async () => {
+    const newProject = await projectService.createProject(user, workspace.id, {
+      name: 'My project',
+      description: 'Some description',
+      environments: [],
+      storePrivateKey: false
+    })
+    project = newProject
+
+    expect(newProject).toBeDefined()
+
+    const response = await makeRequest(app, user, `projectId=${newProject.id}`)
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.PROJECT,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.PROJECT_CREATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([event])
+  })
+
+  it('should be able to fetch an environment event', async () => {
+    const newEnvironment = await environmentService.createEnvironment(
+      user,
+      {
+        name: 'My environment',
+        description: 'Some description',
+        isDefault: false
+      },
+      project.id
+    )
+    environment = newEnvironment
+
+    expect(newEnvironment).toBeDefined()
+
+    const response = await makeRequest(
+      app,
+      user,
+      `environmentId=${newEnvironment.id}`
+    )
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.ENVIRONMENT,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.ENVIRONMENT_ADDED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([event])
+  })
+
+  it('should be able to fetch a secret event', async () => {
+    const newSecret = await secretService.createSecret(
+      user,
+      {
+        name: 'My secret',
+        value: 'My value',
+        environmentId: environment.id,
+        rotateAfter: '720'
+      },
+      project.id
+    )
+
+    expect(newSecret).toBeDefined()
+
+    const response = await makeRequest(app, user, `secretId=${newSecret.id}`)
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.SECRET,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.SECRET_ADDED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([event])
+  })
+
+  it('should be able to fetch a workspace role event', async () => {
+    const newWorkspaceRole = await workspaceRoleService.createWorkspaceRole(
+      user,
+      workspace.id,
+      {
+        name: 'My role',
+        description: 'Some description',
+        colorCode: '#000000',
+        authorities: [],
+        projectIds: [project.id]
+      }
+    )
+
+    expect(newWorkspaceRole).toBeDefined()
+
+    const response = await makeRequest(
+      app,
+      user,
+      `workspaceRoleId=${newWorkspaceRole.id}`
+    )
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.WORKSPACE_ROLE,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.WORKSPACE_ROLE_CREATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([event])
+  })
+
+  it('should be able to fetch all events', async () => {
+    const response = await makeRequest(app, user)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(totalEvents)
+  })
+
+  afterAll(async () => {
+    await cleanUp(prisma)
+  })
+})

--- a/apps/api/src/event/service/event.service.ts
+++ b/apps/api/src/event/service/event.service.ts
@@ -19,7 +19,6 @@ export class EventService {
       secretId?: string
       apiKeyId?: string
       workspaceRoleId?: string
-      workspaceMemberId?: string
     },
     page: number,
     limit: number,
@@ -73,21 +72,23 @@ export class EventService {
     } else if (context.apiKeyId) {
       whereCondition['sourceApiKeyId'] = context.apiKeyId
     } else if (context.workspaceRoleId) {
+      const workspaceRole = await this.prisma.workspaceRole.findUnique({
+        where: {
+          id: context.workspaceRoleId
+        },
+        include: {
+          workspace: true
+        }
+      })
       await getWorkspaceWithAuthority(
         user.id,
-        context.workspaceRoleId,
+        workspaceRole.workspace.id,
         Authority.READ_WORKSPACE_ROLE,
         this.prisma
       )
       whereCondition['sourceWorkspaceRoleId'] = context.workspaceRoleId
-    } else if (context.workspaceMemberId) {
-      await getWorkspaceWithAuthority(
-        user.id,
-        context.workspaceMemberId,
-        Authority.READ_USERS,
-        this.prisma
-      )
-      whereCondition['sourceWorkspaceMembershipId'] = context.workspaceMemberId
+    } else {
+      whereCondition['sourceUserId'] = user.id
     }
 
     // Get the events

--- a/apps/api/src/prisma/migrations/20240212183333_update_event/migration.sql
+++ b/apps/api/src/prisma/migrations/20240212183333_update_event/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [WORKSPACE_MEMBER] on the enum `EventSource` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "EventSource_new" AS ENUM ('SECRET', 'API_KEY', 'ENVIRONMENT', 'PROJECT', 'WORKSPACE', 'WORKSPACE_ROLE', 'USER');
+ALTER TABLE "Event" ALTER COLUMN "source" TYPE "EventSource_new" USING ("source"::text::"EventSource_new");
+ALTER TYPE "EventSource" RENAME TO "EventSource_old";
+ALTER TYPE "EventSource_new" RENAME TO "EventSource";
+DROP TYPE "EventSource_old";
+COMMIT;

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -15,7 +15,6 @@ enum EventSource {
   WORKSPACE
   WORKSPACE_ROLE
   USER
-  WORKSPACE_MEMBER
 }
 
 enum EventTriggerer {

--- a/apps/api/src/workspace-role/workspace-role.e2e.spec.ts
+++ b/apps/api/src/workspace-role/workspace-role.e2e.spec.ts
@@ -16,6 +16,7 @@ import { MAIL_SERVICE } from '../mail/services/interface.service'
 import { MockMailService } from '../mail/services/mock.service'
 import { Test } from '@nestjs/testing'
 import { v4 } from 'uuid'
+import cleanUp from '../common/cleanup'
 
 describe('Workspace Role Controller Tests', () => {
   let app: NestFastifyApplication
@@ -45,13 +46,7 @@ describe('Workspace Role Controller Tests', () => {
     await app.init()
     await app.getHttpAdapter().getInstance().ready()
 
-    await prisma.$transaction([
-      prisma.user.deleteMany(),
-      prisma.project.deleteMany(),
-      prisma.workspace.deleteMany(),
-      prisma.workspaceRole.deleteMany(),
-      prisma.workspaceMember.deleteMany()
-    ])
+    await cleanUp(prisma)
 
     const aliceId = v4()
     const bobId = v4()
@@ -906,15 +901,6 @@ describe('Workspace Role Controller Tests', () => {
   })
 
   afterAll(async () => {
-    await prisma.$transaction([
-      prisma.user.deleteMany(),
-      prisma.project.deleteMany(),
-      prisma.workspace.deleteMany(),
-      prisma.workspaceRole.deleteMany(),
-      prisma.workspaceMember.deleteMany()
-    ])
-
-    await prisma.$disconnect()
-    await app.close()
+    await cleanUp(prisma)
   })
 })

--- a/apps/api/src/workspace/controller/workspace.controller.ts
+++ b/apps/api/src/workspace/controller/workspace.controller.ts
@@ -59,14 +59,18 @@ export class WorkspaceController {
     return this.workspaceService.deleteWorkspace(user, workspaceId)
   }
 
-  @Post(':workspaceId/add-users')
+  @Post(':workspaceId/invite-users')
   @RequiredApiKeyAuthorities(Authority.ADD_USER)
   async addUsers(
     @CurrentUser() user: User,
     @Param('workspaceId') workspaceId: Workspace['id'],
     @Body() members: WorkspaceMemberDTO[]
   ) {
-    return this.workspaceService.addUsersToWorkspace(user, workspaceId, members)
+    return this.workspaceService.inviteUsersToWorkspace(
+      user,
+      workspaceId,
+      members
+    )
   }
 
   @Delete(':workspaceId/remove-users')

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -8,5 +8,5 @@
     "target": "es2021"
   },
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/event/event.e2e.spec.ts"]
 }

--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -9,6 +9,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "src/event/event.e2e.spec.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "test": "nx run-many -t test --parallel",
     "test:api": "nx run api:test",
     "e2e:api:prepare": "docker compose down && docker compose -f docker-compose-test.yml up -d && NODE_ENV='e2e' DATABASE_URL='postgresql://prisma:prisma@localhost:5432/tests' pnpm run db:deploy-migrations",
-    "e2e:api": "pnpm run e2e:api:prepare && NODE_ENV='e2e' DATABASE_URL='postgresql://prisma:prisma@localhost:5432/tests' nx run api:test:e2e -- --coverage --coverageDirectory=coverage-e2e/api --coverageReporters=json && pnpm run e2e:api:teardown",
+    "e2e:api": "pnpm run e2e:api:prepare && NODE_ENV='e2e' DATABASE_URL='postgresql://prisma:prisma@localhost:5432/tests' nx run api:test:e2e --skip-nx-cache -- --coverage --coverageDirectory=coverage-e2e/api --coverageReporters=json && pnpm run e2e:api:teardown",
     "e2e:api:teardown": "docker compose -f docker-compose-test.yml down",
     "test:web": "nx run web:test",
     "test:workspace": "nx run workspace:test",


### PR DESCRIPTION
## **User description**
## Description

Add E2E test suite for event controller


___

## **Type**
enhancement, tests


___

## **Description**
- Introduced a centralized `cleanUp` utility function for database cleanup in tests.
- Simplified the `createEvent` function logic and improved error logging.
- Added comprehensive E2E tests for the event controller.
- Streamlined event fetching logic by removing `workspaceMemberId` handling and refining workspace role-related logic.
- Renamed `add-users` endpoint to `invite-users` in the workspace controller to better reflect its functionality.
- Enhanced workspace user invitation logic and updated related event creation.
- Simplified the `EventSource` enum in the Prisma schema by removing `WORKSPACE_MEMBER`.
- Updated TypeScript configuration files to include new E2E test file.
- Modified the E2E test script in `package.json` to use the `--skip-nx-cache` flag.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api-key.e2e.spec.ts</strong><dd><code>Refactor Cleanup Logic in Api Key E2E Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/api-key.e2e.spec.ts
<li>Replaced manual cleanup logic with a call to the <code>cleanUp</code> utility <br>function in <code>afterAll</code> hook.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-6562811269d6b42c99951dca3009d7754fd60e6e6c20a3a89c69c86414fe4234">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cleanup.ts</strong><dd><code>Introduce Cleanup Utility Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/cleanup.ts
<li>Introduced a new <code>cleanUp</code> utility function to centralize the cleanup <br>logic for database entities.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-a1f31075feeace772910b837a11c444d5c53c7e37fb0379ac4eb8d6e14775e44">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-event.ts</strong><dd><code>Simplify Event Creation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/create-event.ts
<li>Simplified the <code>createEvent</code> function by removing specific entity <br>handling and using a more generic approach.<br> <li> Improved error logging by including event data in the log output.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-479e4200e81256ca7adcfbc91b283ad9e6e214bcd60e992954c87539e60b38c6">+32/-95</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>event.controller.ts</strong><dd><code>Streamline Event Controller Query Parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/event/controller/event.controller.ts
<li>Removed handling for <code>workspaceMemberId</code> query parameter in event <br>fetching endpoint.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-2d6de8ccbf5a17051a8829ce70d022690669c9b971ff4cfbe5bfd873be02f19a">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>event.service.ts</strong><dd><code>Refine Event Fetching Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/event/service/event.service.ts
<li>Removed handling for <code>workspaceMemberId</code> in event fetching logic.<br> <li> Added logic to fetch workspace role information when filtering events <br>by <code>workspaceRoleId</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-bdcc00beac2cc963775cf8d6fc5a1c7ad5a1a179b374063592889b20c1aeb8fc">+11/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace-role.e2e.spec.ts</strong><dd><code>Refactor Cleanup Logic in Workspace Role E2E Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace-role/workspace-role.e2e.spec.ts
<li>Replaced manual cleanup logic with a call to the <code>cleanUp</code> utility <br>function in <code>afterAll</code> hook.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-8cb77aad66a47879970bb3d9086df36f7477e273caf90a319c589e7a221cd30b">+3/-17</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.controller.ts</strong><dd><code>Rename Workspace User Addition Endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/controller/workspace.controller.ts
<li>Renamed <code>add-users</code> endpoint to <code>invite-users</code> to better reflect its <br>functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-97a7dec6a517fcb0f1f7b43973822237aed3fcf897f60e1bcc0237eb0e2fe8d7">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Enhance Workspace User Invitation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts
<li>Renamed <code>addUsersToWorkspace</code> to <code>inviteUsersToWorkspace</code> and updated its <br>logic to support user invitations.<br> <li> Updated workspace deletion event creation to remove the direct <br>workspace entity reference.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+28/-20</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Simplify Event Source Enum in Prisma Schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/schema.prisma
<li>Removed <code>WORKSPACE_MEMBER</code> from <code>EventSource</code> enum, simplifying event <br>source options.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-24191263d57c55d02e0cdf394de15225b628d1da20bd826b1541b59b6b02adb4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>event.e2e.spec.ts</strong><dd><code>Add Event Controller E2E Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/event/event.e2e.spec.ts
<li>Added comprehensive E2E tests for the event controller, covering <br>various event types and scenarios.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-e3b2a34abdd21ac689f251a13fc249d534413e3c14ed8a6ae7374021b1663fe2">+352/-0</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>tsconfig.app.json</strong><dd><code>Update TypeScript App Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/tsconfig.app.json
<li>Included <code>src/event/event.e2e.spec.ts</code> in the TypeScript compilation <br>context for the application.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-422316420dd93b13739ae5cb2d437e4a41b84b79812049ee22c26645d73bf5ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tsconfig.spec.json</strong><dd><code>Update TypeScript Test Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/tsconfig.spec.json
<li>Included <code>src/event/event.e2e.spec.ts</code> in the TypeScript compilation <br>context for tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-21b3d5855a77c7d021343eb655f3922fc01db202d69a252face8733684a2ce29">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Modify E2E Test Script in Package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json
<li>Modified the <code>e2e:api</code> script to include the <code>--skip-nx-cache</code> flag for <br>E2E tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/140/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
