### PR TITLE
test: add project e2e tests

### DIFF
--- a/apps/api/src/common/fetch-events.ts
+++ b/apps/api/src/common/fetch-events.ts
@@ -1,0 +1,16 @@
+import { User } from '@prisma/client'
+import { NestFastifyApplication } from '@nestjs/platform-fastify'
+
+export default async function fetchEvents(
+  app: NestFastifyApplication,
+  user: User,
+  query?: string
+) {
+  return await app.inject({
+    method: 'GET',
+    headers: {
+      'x-e2e-user-email': user.email
+    },
+    url: `/event${query ? '?' + query : ''}`
+  })
+}

--- a/apps/api/src/common/fetch-events.ts
+++ b/apps/api/src/common/fetch-events.ts
@@ -6,7 +6,7 @@ export default async function fetchEvents(
   user: User,
   query?: string
 ) {
-  return await app.inject({
+  return app.inject({
     method: 'GET',
     headers: {
       'x-e2e-user-email': user.email

--- a/apps/api/src/common/get-workspace-with-authority.ts
+++ b/apps/api/src/common/get-workspace-with-authority.ts
@@ -8,11 +8,17 @@ export default async function getWorkspaceWithAuthority(
   authority: Authority,
   prisma: PrismaClient
 ): Promise<Workspace> {
-  const workspace = await prisma.workspace.findUnique({
-    where: {
-      id: workspaceId
-    }
-  })
+  let workspace: Workspace
+
+  try {
+    workspace = await prisma.workspace.findUnique({
+      where: {
+        id: workspaceId
+      }
+    })
+  } catch (error) {
+    /* empty */
+  }
 
   // Check if the workspace exists or not
   if (!workspace) {

--- a/apps/api/src/common/query.transform.pipe.ts
+++ b/apps/api/src/common/query.transform.pipe.ts
@@ -11,7 +11,7 @@ export class QueryTransformPipe implements PipeTransform {
     if (metadata.type === 'query') {
       if (metadata.data === 'limit')
         return isNaN(value) || value === 0 ? 10 : parseInt(value)
-      if (metadata.data === 'page') return isNaN(value) ? 1 : parseInt(value)
+      if (metadata.data === 'page') return isNaN(value) ? 0 : parseInt(value)
     }
     return value
   }

--- a/apps/api/src/common/query.transform.pipe.ts
+++ b/apps/api/src/common/query.transform.pipe.ts
@@ -11,7 +11,7 @@ export class QueryTransformPipe implements PipeTransform {
     if (metadata.type === 'query') {
       if (metadata.data === 'limit')
         return isNaN(value) || value === 0 ? 10 : parseInt(value)
-      if (metadata.data === 'page') return isNaN(value) ? 0 : parseInt(value)
+      if (metadata.data === 'page') return isNaN(value) ? 0 : Number(value)
     }
     return value
   }

--- a/apps/api/src/environment/service/environment.service.ts
+++ b/apps/api/src/environment/service/environment.service.ts
@@ -196,7 +196,7 @@ export class EnvironmentService {
       include: {
         lastUpdatedBy: true
       },
-      skip: (page - 1) * limit,
+      skip: page * limit,
       take: limit,
       orderBy: {
         [sort]: order
@@ -221,7 +221,7 @@ export class EnvironmentService {
       include: {
         lastUpdatedBy: true
       },
-      skip: (page - 1) * limit,
+      skip: page * limit,
       take: limit,
       orderBy: {
         [sort]: order

--- a/apps/api/src/event/event.e2e.spec.ts
+++ b/apps/api/src/event/event.e2e.spec.ts
@@ -35,19 +35,7 @@ import { ProjectModule } from '../project/project.module'
 import { EnvironmentModule } from '../environment/environment.module'
 import { ApiKeyModule } from '../api-key/api-key.module'
 import createEvent from '../common/create-event'
-
-const makeRequest = async (
-  app: NestFastifyApplication,
-  user: User,
-  query?: string
-) =>
-  await app.inject({
-    method: 'GET',
-    headers: {
-      'x-e2e-user-email': user.email
-    },
-    url: `/event${query ? '?' + query : ''}`
-  })
+import fetchEvents from '../common/fetch-events'
 
 describe('Event Controller Tests', () => {
   let app: NestFastifyApplication
@@ -124,7 +112,7 @@ describe('Event Controller Tests', () => {
 
     expect(updatedUser).toBeDefined()
 
-    const response = await makeRequest(app, user)
+    const response = await fetchEvents(app, user)
 
     totalEvents.push({
       id: expect.any(String),
@@ -150,7 +138,7 @@ describe('Event Controller Tests', () => {
 
     expect(newApiKey).toBeDefined()
 
-    const response = await makeRequest(app, user, `apiKeyId=${newApiKey.id}`)
+    const response = await fetchEvents(app, user, `apiKeyId=${newApiKey.id}`)
 
     const event = {
       id: expect.any(String),
@@ -179,7 +167,7 @@ describe('Event Controller Tests', () => {
 
     expect(newWorkspace).toBeDefined()
 
-    const response = await makeRequest(
+    const response = await fetchEvents(
       app,
       user,
       `workspaceId=${newWorkspace.id}`
@@ -214,7 +202,7 @@ describe('Event Controller Tests', () => {
 
     expect(newProject).toBeDefined()
 
-    const response = await makeRequest(app, user, `projectId=${newProject.id}`)
+    const response = await fetchEvents(app, user, `projectId=${newProject.id}`)
 
     const event = {
       id: expect.any(String),
@@ -248,7 +236,7 @@ describe('Event Controller Tests', () => {
 
     expect(newEnvironment).toBeDefined()
 
-    const response = await makeRequest(
+    const response = await fetchEvents(
       app,
       user,
       `environmentId=${newEnvironment.id}`
@@ -286,7 +274,7 @@ describe('Event Controller Tests', () => {
 
     expect(newSecret).toBeDefined()
 
-    const response = await makeRequest(app, user, `secretId=${newSecret.id}`)
+    const response = await fetchEvents(app, user, `secretId=${newSecret.id}`)
 
     const event = {
       id: expect.any(String),
@@ -321,7 +309,7 @@ describe('Event Controller Tests', () => {
 
     expect(newWorkspaceRole).toBeDefined()
 
-    const response = await makeRequest(
+    const response = await fetchEvents(
       app,
       user,
       `workspaceRoleId=${newWorkspaceRole.id}`
@@ -346,14 +334,14 @@ describe('Event Controller Tests', () => {
   })
 
   it('should be able to fetch all events', async () => {
-    const response = await makeRequest(app, user)
+    const response = await fetchEvents(app, user)
 
     expect(response.statusCode).toBe(200)
     expect(response.json()).toEqual(totalEvents)
   })
 
   it('should throw an error with wrong severity value', async () => {
-    const response = await makeRequest(app, user, 'severity=WRONG')
+    const response = await fetchEvents(app, user, 'severity=WRONG')
 
     expect(response.statusCode).toBe(400)
   })

--- a/apps/api/src/prisma/migrations/20240216062710_update_project/migration.sql
+++ b/apps/api/src/prisma/migrations/20240216062710_update_project/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `apiKeyWorkspaceAuthorityId` on the `Project` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Project" DROP COLUMN "apiKeyWorkspaceAuthorityId";

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -229,7 +229,6 @@ model Project {
   environments               Environment[]
   workspaceRole              WorkspaceRole? @relation(fields: [workspaceRoleId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   workspaceRoleId            String?
-  apiKeyWorkspaceAuthorityId String?
 }
 
 model WorkspaceRole {

--- a/apps/api/src/project/project.e2e.spec.ts
+++ b/apps/api/src/project/project.e2e.spec.ts
@@ -1,0 +1,721 @@
+import {
+  FastifyAdapter,
+  NestFastifyApplication
+} from '@nestjs/platform-fastify'
+import { PrismaService } from '../prisma/prisma.service'
+import { Test } from '@nestjs/testing'
+import { AppModule } from '../app/app.module'
+import { ProjectModule } from './project.module'
+import { MAIL_SERVICE } from '../mail/services/interface.service'
+import { MockMailService } from '../mail/services/mock.service'
+import cleanUp from '../common/cleanup'
+import {
+  Authority,
+  EventSeverity,
+  EventSource,
+  EventTriggerer,
+  EventType,
+  Project,
+  User,
+  Workspace,
+  WorkspaceRole
+} from '@prisma/client'
+import { v4 } from 'uuid'
+import fetchEvents from '../common/fetch-events'
+
+describe('Project Controller Tests', () => {
+  let app: NestFastifyApplication
+  let prisma: PrismaService
+
+  let user1: User, user2: User
+  let workspace1: Workspace
+  let project1: Project, project2: Project, otherProject: Project
+  let adminRole1: WorkspaceRole
+
+  const totalEvents = []
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, ProjectModule]
+    })
+      .overrideProvider(MAIL_SERVICE)
+      .useClass(MockMailService)
+      .compile()
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter()
+    )
+    prisma = moduleRef.get(PrismaService)
+
+    await app.init()
+    await app.getHttpAdapter().getInstance().ready()
+
+    const workspace1Id = v4()
+    const workspace2Id = v4()
+    const workspace1AdminRoleId = v4()
+    const user1Id = v4(),
+      user2Id = v4()
+
+    const createUser1 = prisma.user.create({
+      data: {
+        id: user1Id,
+        email: 'johndoe@keyshade.xyz',
+        name: 'John Doe',
+        isOnboardingFinished: true
+      }
+    })
+
+    const createUser2 = prisma.user.create({
+      data: {
+        id: user2Id,
+        email: 'janedoe@keyshade.xyz',
+        name: 'Jane Doe',
+        isOnboardingFinished: true
+      }
+    })
+
+    const createUser3 = prisma.user.create({
+      data: {
+        email: 'sadie@keyshade.xyz',
+        name: 'Sadie',
+        isOnboardingFinished: true
+      }
+    })
+
+    const createWorkspace1 = prisma.workspace.create({
+      data: {
+        id: workspace1Id,
+        name: 'Workspace 1',
+        ownerId: user1Id
+      }
+    })
+
+    const createWorkspace1AdminRole = prisma.workspaceRole.create({
+      data: {
+        id: workspace1AdminRoleId,
+        name: 'Admin',
+        hasAdminAuthority: true,
+        authorities: [Authority.WORKSPACE_ADMIN],
+        workspaceId: workspace1Id
+      }
+    })
+
+    const createWorkspace1Membership1 = prisma.workspaceMember.create({
+      data: {
+        userId: user1Id,
+        workspaceId: workspace1Id,
+        invitationAccepted: true,
+        roles: {
+          create: {
+            roleId: workspace1AdminRoleId
+          }
+        }
+      }
+    })
+
+    const createWorkspace2 = prisma.workspace.create({
+      data: {
+        id: workspace2Id,
+        name: 'Workspace 2',
+        ownerId: user2Id
+      }
+    })
+
+    const createOtherProject = prisma.project.create({
+      data: {
+        name: 'Other Project',
+        description: 'Other Project description',
+        publicKey: '',
+        privateKey: '',
+        isPublic: false,
+        workspace: {
+          connect: {
+            id: workspace2Id
+          }
+        }
+      }
+    })
+
+    const result = await prisma.$transaction([
+      createUser1,
+      createUser2,
+      createUser3,
+      createWorkspace1,
+      createWorkspace1AdminRole,
+      createWorkspace1Membership1,
+      createWorkspace2,
+      createOtherProject
+    ])
+
+    user1 = result[0]
+    user2 = result[1]
+
+    workspace1 = result[3]
+
+    otherProject = result[7]
+
+    adminRole1 = result[4]
+  })
+
+  it('should be defined', async () => {
+    expect(app).toBeDefined()
+    expect(prisma).toBeDefined()
+  })
+
+  it('should allow workspace member to create a project', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/project/${workspace1.id}`,
+      payload: {
+        name: 'Project 1',
+        description: 'Project 1 description',
+        storePrivateKey: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+    expect(response.json()).toEqual({
+      id: expect.any(String),
+      name: 'Project 1',
+      description: 'Project 1 description',
+      storePrivateKey: true,
+      workspaceId: workspace1.id,
+      lastUpdatedById: user1.id,
+      isDisabled: false,
+      isPublic: false,
+      publicKey: expect.any(String),
+      privateKey: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      workspaceRoleId: null
+    })
+
+    project1 = response.json()
+  })
+
+  it('should have created a default environment', async () => {
+    const environments = await prisma.environment.findMany({
+      where: {
+        projectId: project1.id
+      }
+    })
+
+    expect(environments).toHaveLength(1)
+  })
+
+  it('should not allow workspace member to create a project with the same name', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/project/${workspace1.id}`,
+      payload: {
+        name: 'Project 1',
+        description: 'Project 1 description',
+        storePrivateKey: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.json()).toEqual({
+      statusCode: 409,
+      error: 'Conflict',
+      message: `Project with this name **Project 1** already exists`
+    })
+  })
+
+  it('should have created a PROJECT_CREATED event', async () => {
+    const response = await fetchEvents(app, user1, 'projectId=' + project1.id)
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.PROJECT,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.PROJECT_CREATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(totalEvents)
+  })
+
+  it('should have added the project to the admin role of the workspace', async () => {
+    const adminRole = await prisma.workspaceRole.findUnique({
+      where: {
+        workspaceId_name: {
+          workspaceId: workspace1.id,
+          name: 'Admin'
+        }
+      },
+      select: {
+        projects: true
+      }
+    })
+
+    expect(adminRole).toBeDefined()
+    expect(adminRole.projects).toHaveLength(1)
+    expect(adminRole.projects[0].id).toBe(project1.id)
+  })
+
+  it('should not let non-member create a project', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/project/${workspace1.id}`,
+      payload: {
+        name: 'Project 2',
+        description: 'Project 2 description',
+        storePrivateKey: true
+      },
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: `User ${user2.id} does not have the required authorities to perform the action`
+    })
+  })
+
+  it('should not be able to add project to a non existing workspace', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/project/123`,
+      payload: {
+        name: 'Project 3',
+        description: 'Project 3 description',
+        storePrivateKey: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Workspace with id 123 not found`
+    })
+  })
+
+  it('should be able to update the name and description of a project', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/project/${project1.id}`,
+      payload: {
+        name: 'Project 1 Updated',
+        description: 'Project 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      id: project1.id,
+      name: 'Project 1 Updated',
+      description: 'Project 1 description updated',
+      storePrivateKey: true,
+      workspaceId: workspace1.id,
+      lastUpdatedById: user1.id,
+      isDisabled: false,
+      isPublic: false,
+      publicKey: project1.publicKey,
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      workspaceRoleId: adminRole1.id
+    })
+
+    project1 = response.json()
+  })
+
+  it('should not be able to update the name of a project to an existing name', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/project/${project1.id}`,
+      payload: {
+        name: 'Project 1 Updated',
+        description: 'Project 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.json()).toEqual({
+      statusCode: 409,
+      error: 'Conflict',
+      message: `Project with this name **Project 1 Updated** already exists`
+    })
+  })
+
+  it('should not be able to update a non existing project', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/project/123`,
+      payload: {
+        name: 'Project 1 Updated',
+        description: 'Project 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Project with id 123 not found`
+    })
+  })
+
+  it('should not be able to update a project if the user is not a member of the workspace', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/project/${project1.id}`,
+      payload: {
+        name: 'Project 1 Updated',
+        description: 'Project 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: `User with id ${user2.id} does not have the authority UPDATE_PROJECT in the project with id ${project1.id}`
+    })
+  })
+
+  it('should have created a PROJECT_UPDATED event', async () => {
+    const response = await fetchEvents(app, user1, 'projectId=' + project1.id)
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.PROJECT,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.PROJECT_UPDATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    totalEvents.push(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(totalEvents)
+  })
+
+  it('should be able to fetch a project by its id', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/project/${project1.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      ...project1,
+      lastUpdatedById: user1.id,
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      privateKey: null,
+      secrets: []
+    })
+  })
+
+  it('should not be able to fetch a non existing project', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/project/123`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Project with id 123 not found`
+    })
+  })
+
+  it('should not be able to fetch a project if the user is not a member of the workspace', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/project/${project1.id}`,
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: `User with id ${user2.id} does not have the authority READ_PROJECT in the project with id ${project1.id}`
+    })
+  })
+
+  it('should be able to fetch all projects of a workspace', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/project/all/${workspace1.id}?page=0`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual([
+      {
+        ...project1,
+        lastUpdatedById: user1.id,
+        publicKey: undefined,
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String)
+      }
+    ])
+  })
+
+  it('should not be able to fetch all projects of a non existing workspace', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/project/all/123`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Workspace with id 123 not found`
+    })
+  })
+
+  it('should not be able to fetch all projects of a workspace if the user is not a member of the workspace', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/project/all/${workspace1.id}`,
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: `User ${user2.id} does not have the required authorities to perform the action`
+    })
+  })
+
+  // ---------------------------------------------------------
+
+  it('should not store the private key if storePrivateKey is false', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/project/${workspace1.id}`,
+      payload: {
+        name: 'Project 2',
+        description: 'Project 2 description',
+        storePrivateKey: false
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+
+    const projectId = response.json().id
+
+    project2 = await prisma.project.findUnique({
+      where: {
+        id: projectId
+      }
+    })
+
+    expect(project2).toBeDefined()
+    expect(project2.privateKey).toBeNull()
+  })
+
+  it('should create environments if provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/project/${workspace1.id}`,
+      payload: {
+        name: 'Project 3',
+        description: 'Project 3 description',
+        storePrivateKey: false,
+
+        environments: [
+          {
+            name: 'default env',
+            isDefault: true
+          },
+          {
+            name: "shouldn't be default",
+            isDefault: true
+          },
+          {
+            name: 'regular'
+          }
+        ]
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+
+    const projectId = response.json().id
+
+    const environments = await prisma.environment.findMany({
+      where: {
+        projectId
+      }
+    })
+
+    expect(environments).toHaveLength(3)
+    expect(environments[0].isDefault).toBe(true)
+    expect(environments[1].isDefault).toBe(false)
+    expect(environments[2].isDefault).toBe(false)
+  })
+
+  it('should generate new key-pair if regenerateKeyPair is true and and the project stores the private key or a private key is specified', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/project/${project1.id}`,
+      payload: {
+        regenerateKeyPair: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().publicKey).not.toBeNull()
+    expect(response.json().privateKey).not.toBeNull()
+
+    project1 = response.json()
+  })
+
+  it('should not regenerate key-pair if regenerateKeyPair is true and the project does not store the private key and a private key is not specified', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/project/${project2.id}`,
+      payload: {
+        regenerateKeyPair: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().publicKey).toEqual(project2.publicKey)
+    expect(response.json().privateKey).toBeUndefined()
+  })
+
+  it('should be able to delete a project', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/project/${project1.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('should not be able to delete a non existing project', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/project/123`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Project with id 123 not found`
+    })
+  })
+
+  it('should not be able to delete a project if the user is not a member of the workspace', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/project/${otherProject.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: `User with id ${user1.id} does not have the authority DELETE_PROJECT in the project with id ${otherProject.id}`
+    })
+  })
+
+  it('should have created a PROJECT_DELETED event', async () => {
+    const response = await fetchEvents(
+      app,
+      user1,
+      'workspaceId=' + workspace1.id
+    )
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.WORKSPACE,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.PROJECT_DELETED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
+  })
+
+  afterAll(async () => {
+    await cleanUp(prisma)
+  })
+})

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -19,19 +19,7 @@ import {
   WorkspaceRole
 } from '@prisma/client'
 import cleanUp from '../common/cleanup'
-
-const fetchEvents = async (
-  app: NestFastifyApplication,
-  user: User,
-  query?: string
-) =>
-  await app.inject({
-    method: 'GET',
-    headers: {
-      'x-e2e-user-email': user.email
-    },
-    url: `/event${query ? '?' + query : ''}`
-  })
+import fetchEvents from '../common/fetch-events'
 
 const createMembership = async (
   adminRoleId: string,
@@ -1183,6 +1171,23 @@ describe('Workspace Controller Tests', () => {
     })
 
     expect(workspace).toBeNull()
+  })
+
+  it('should not be able to delete a non existing workspace', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      headers: {
+        'x-e2e-user-email': user2.email
+      },
+      url: `/workspace/${workspace1.id}`
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Workspace with id ${workspace1.id} not found`
+    })
   })
 
   afterAll(async () => {

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -52,8 +52,6 @@ describe('Workspace Controller Tests', () => {
   let workspace1: Workspace, workspace2: Workspace
   let adminRole: WorkspaceRole, memberRole: WorkspaceRole
 
-  const totalEvents = []
-
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule, WorkspaceModule]
@@ -206,10 +204,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should have created a new role with name Admin', async () => {
@@ -344,10 +340,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should do nothing if null or empty array is sent for invitation of user', async () => {
@@ -448,10 +442,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to cancel the invitation', async () => {
@@ -513,10 +505,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to decline invitation to the workspace', async () => {
@@ -580,10 +570,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to accept the invitation to the workspace', async () => {
@@ -653,10 +641,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to leave the workspace', async () => {
@@ -735,10 +721,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to update the role of a member', async () => {
@@ -797,10 +781,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to remove users from workspace', async () => {
@@ -864,10 +846,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should not be able to update the role of a non existing member', async () => {
@@ -1147,10 +1127,8 @@ describe('Workspace Controller Tests', () => {
       metadata: expect.any(Object)
     }
 
-    totalEvents.push(event)
-
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual(totalEvents)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
   it('should be able to delete the workspace', async () => {


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added `fetchEvents` function for improved event retrieval.
- Improved error handling in project and workspace authority checks.
- Adjusted default pagination page number and fixed pagination logic in environment service.
- Refactored event E2E tests to use `fetchEvents` and added comprehensive project management E2E tests.
- Enhanced project service with correct authority checks, event logging, and fixed pagination.
- Updated database schema and added migration to remove unused `apiKeyWorkspaceAuthorityId` column.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>fetch-events.ts</strong><dd><code>Add fetchEvents Function for Event Retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/fetch-events.ts
<li>Added a new function <code>fetchEvents</code> to fetch events with optional query <br>parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-6f09555e855e7b28aa6e29d2bd37282519a96aabf152b225151309bb1a0a6d6e">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>query.transform.pipe.ts</strong><dd><code>Adjust Default Pagination Page Number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/query.transform.pipe.ts
- Adjusted default page number from 1 to 0 in `QueryTransformPipe`.



</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-7d7346ad647184fa4b5c0ddb8451965e73c6e931e23535deb10c9672522e07f0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>project.service.ts</strong><dd><code>Enhance Project Service with Correct Authority Checks and Event </code><br><code>Logging</code></dd></summary>
<hr>

apps/api/src/project/service/project.service.ts
<li>Fixed authority check for project creation to use <code>CREATE_PROJECT</code>.<br> <li> Removed unnecessary console logs in environment creation.<br> <li> Adjusted project deletion event source to <code>WORKSPACE</code> and included <br>workspace in metadata.<br> <li> Added workspace authority check in project listing.<br> <li> Fixed pagination in project and environment listing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-d85f483eff15c28a4b3e5f7a54c9b159c71003f8a95ef7a4be00eb80ec72b2fa">+18/-10</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>get-project-with-authority.ts</strong><dd><code>Improve Error Handling in Project Authority Check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/get-project-with-authority.ts
<li>Replaced <code>NotFoundException</code> with <code>UnauthorizedException</code> for unauthorized <br>access attempts.<br> <li> Added try-catch block around project retrieval to handle potential <br>errors silently.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-df750637003d3faeb24d838ca1d520cf112c16f54f6a3c26021a9aecb0d9c18c">+16/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get-workspace-with-authority.ts</strong><dd><code>Improve Workspace Retrieval Error Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/get-workspace-with-authority.ts
<li>Added try-catch block around workspace retrieval to handle potential <br>errors silently.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-a51465d32e18b981a042bd014e9b6f1f7658a565d463f820c93322bb9aaf4027">+11/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>environment.service.ts</strong><dd><code>Fix Environment Listing Pagination Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/environment/service/environment.service.ts
<li>Modified pagination calculation to start from the current page for <br>environment listing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-658d3ecf90efc583248d280885f43ee30a341ca9949c2a48c1312d3ed6f3acbd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>event.e2e.spec.ts</strong><dd><code>Refactor Event E2E Tests to Use fetchEvents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/event/event.e2e.spec.ts
<li>Replaced local <code>makeRequest</code> function with imported <code>fetchEvents</code> for <br>event fetching.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-e3b2a34abdd21ac689f251a13fc249d534413e3c14ed8a6ae7374021b1663fe2">+10/-22</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>project.e2e.spec.ts</strong><dd><code>Add Comprehensive E2E Tests for Project Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/project/project.e2e.spec.ts
<li>Added extensive E2E tests for project creation, update, deletion, and <br>listing.<br> <li> Tested project key-pair regeneration and environment creation during <br>project setup.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-f1b22baab0b4173d825570c9030ef014582bc75bb67ef2e544f0dd879ff941a2">+721/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Refactor Workspace E2E Tests and Add Deletion Test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts
<li>Removed local <code>fetchEvents</code> function definition, using the imported one <br>instead.<br> <li> Added test for attempting to delete a non-existing workspace.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+18/-13</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Database Migration to Remove Unused Column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/migrations/20240216062710_update_project/migration.sql
<li>Dropped the <code>apiKeyWorkspaceAuthorityId</code> column from the <code>Project</code> table.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-41b2e3fff28716f9b50adae3cffada5f57c4e1a82cf46b226dfdfe1c0e297889">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma Schema to Reflect Database Changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/schema.prisma
<li>Removed <code>apiKeyWorkspaceAuthorityId</code> field from the <code>Project</code> model.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/142/files#diff-24191263d57c55d02e0cdf394de15225b628d1da20bd826b1541b59b6b02adb4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
