### PR TITLE
test: add environment e2e tests

### DIFF
--- a/apps/api/src/common/get-environment-with-authority.ts
+++ b/apps/api/src/common/get-environment-with-authority.ts
@@ -1,4 +1,4 @@
-import { ConflictException, NotFoundException } from '@nestjs/common'
+import { NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { Authority, Environment, PrismaClient, User } from '@prisma/client'
 import getCollectiveProjectAuthorities from './get-collective-project-authorities'
 
@@ -35,7 +35,7 @@ export default async function getEnvironmentWithAuthority(
     !permittedAuthorities.has(authority) &&
     !permittedAuthorities.has(Authority.WORKSPACE_ADMIN)
   ) {
-    throw new ConflictException(
+    throw new UnauthorizedException(
       `User ${userId} does not have the required authorities`
     )
   }

--- a/apps/api/src/environment/controller/environment.controller.ts
+++ b/apps/api/src/environment/controller/environment.controller.ts
@@ -6,14 +6,12 @@ import {
   Param,
   Post,
   Put,
-  Query,
-  UseGuards
+  Query
 } from '@nestjs/common'
 import { EnvironmentService } from '../service/environment.service'
 import { CurrentUser } from '../../decorators/user.decorator'
 import { CreateEnvironment } from '../dto/create.environment/create.environment'
 import { Authority, User } from '@prisma/client'
-import { AdminGuard } from '../../auth/guard/admin/admin.guard'
 import { UpdateEnvironment } from '../dto/update.environment/update.environment'
 import { ApiTags } from '@nestjs/swagger'
 import { RequiredApiKeyAuthorities } from '../../decorators/required-api-key-authorities.decorator'
@@ -78,23 +76,23 @@ export class EnvironmentController {
     )
   }
 
-  @Get()
-  @UseGuards(AdminGuard)
-  async getAllEnvironments(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
-    @Query('sort') sort: string = 'name',
-    @Query('order') order: string = 'asc',
-    @Query('search') search: string = ''
-  ) {
-    return await this.environmentService.getAllEnvironments(
-      page,
-      limit,
-      sort,
-      order,
-      search
-    )
-  }
+  // @Get()
+  // @UseGuards(AdminGuard)
+  // async getAllEnvironments(
+  //   @Query('page') page: number = 1,
+  //   @Query('limit') limit: number = 10,
+  //   @Query('sort') sort: string = 'name',
+  //   @Query('order') order: string = 'asc',
+  //   @Query('search') search: string = ''
+  // ) {
+  //   return await this.environmentService.getAllEnvironments(
+  //     page,
+  //     limit,
+  //     sort,
+  //     order,
+  //     search
+  //   )
+  // }
 
   @Delete(':environmentId')
   @RequiredApiKeyAuthorities(Authority.DELETE_ENVIRONMENT)

--- a/apps/api/src/environment/environment.e2e.spec.ts
+++ b/apps/api/src/environment/environment.e2e.spec.ts
@@ -1,0 +1,586 @@
+import { Test } from '@nestjs/testing'
+import { AppModule } from '../app/app.module'
+import { EnvironmentModule } from './environment.module'
+import { MAIL_SERVICE } from '../mail/services/interface.service'
+import { MockMailService } from '../mail/services/mock.service'
+import {
+  FastifyAdapter,
+  NestFastifyApplication
+} from '@nestjs/platform-fastify'
+import { PrismaService } from '../prisma/prisma.service'
+import cleanUp from '../common/cleanup'
+import {
+  Authority,
+  Environment,
+  EventSeverity,
+  EventSource,
+  EventTriggerer,
+  EventType,
+  Project,
+  User,
+  Workspace,
+  WorkspaceRole
+} from '@prisma/client'
+import { v4 } from 'uuid'
+import fetchEvents from '../common/fetch-events'
+import { ProjectModule } from '../project/project.module'
+import { WorkspaceService } from '../workspace/service/workspace.service'
+import { ProjectService } from '../project/service/project.service'
+import { CreateWorkspace } from '../workspace/dto/create.workspace/create.workspace'
+import { EventModule } from '../event/event.module'
+import { UserModule } from '../user/user.module'
+import { WorkspaceModule } from '../workspace/workspace.module'
+import { WorkspaceRoleModule } from '../workspace-role/workspace-role.module'
+import { SecretModule } from '../secret/secret.module'
+import { ApiKeyModule } from '../api-key/api-key.module'
+
+describe('Environment Controller Tests', () => {
+  let app: NestFastifyApplication
+  let prisma: PrismaService
+  let projectService: ProjectService
+  let workspaceService: WorkspaceService
+
+  let user1: User, user2: User
+  let workspace1: Workspace, workspace2: Workspace
+  let project1: Project
+  let environment1: Environment, environment2: Environment
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        AppModule,
+        EventModule,
+        UserModule,
+        WorkspaceModule,
+        WorkspaceRoleModule,
+        SecretModule,
+        ProjectModule,
+        EnvironmentModule,
+        ApiKeyModule
+      ]
+    })
+      .overrideProvider(MAIL_SERVICE)
+      .useClass(MockMailService)
+      .compile()
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter()
+    )
+    prisma = moduleRef.get(PrismaService)
+    projectService = moduleRef.get(ProjectService)
+    workspaceService = moduleRef.get(WorkspaceService)
+
+    await app.init()
+    await app.getHttpAdapter().getInstance().ready()
+
+    await cleanUp(prisma)
+
+    const user1Id = v4()
+    const user2Id = v4()
+
+    user1 = await prisma.user.create({
+      data: {
+        id: user1Id,
+        email: 'johndoe@keyshade.xyz',
+        name: 'John Doe',
+        isOnboardingFinished: true
+      }
+    })
+
+    user2 = await prisma.user.create({
+      data: {
+        id: user2Id,
+        email: 'janedoe@keyshade.xyz',
+        name: 'Jane Doe',
+        isOnboardingFinished: true
+      }
+    })
+
+    workspace1 = await workspaceService.createWorkspace(user1, {
+      name: 'Workspace 1',
+      description: 'Workspace 1 description'
+    })
+
+    workspace2 = await workspaceService.createWorkspace(user2, {
+      name: 'Workspace 2',
+      description: 'Workspace 2 description'
+    })
+
+    project1 = await projectService.createProject(user1, workspace1.id, {
+      name: 'Project 1',
+      description: 'Project 1 description',
+      storePrivateKey: true,
+      environments: []
+    })
+  })
+
+  it('should be defined', () => {
+    expect(app).toBeDefined()
+    expect(prisma).toBeDefined()
+  })
+
+  it('should be able to create an environment under a project', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/environment/${project1.id}`,
+      payload: {
+        name: 'Environment 1',
+        description: 'Environment 1 description',
+        isDefault: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+    expect(response.json()).toEqual({
+      id: expect.any(String),
+      name: 'Environment 1',
+      description: 'Environment 1 description',
+      isDefault: true,
+      projectId: project1.id,
+      lastUpdatedById: user1.id,
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
+    })
+
+    environment1 = response.json()
+  })
+
+  it('should ensure there is only one default environment per project', async () => {
+    const environments = await prisma.environment.findMany({
+      where: {
+        projectId: project1.id
+      }
+    })
+
+    expect(environments.length).toBe(2)
+    expect(environments.filter((e) => e.isDefault).length).toBe(1)
+  })
+
+  it('should not be able to create an environment in a project that does not exist', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/environment/123`,
+      payload: {
+        name: 'Environment 1',
+        description: 'Environment 1 description',
+        isDefault: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('Project with id 123 not found')
+  })
+
+  it('should not be able to create an environment in a project that the user does not have access to', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/environment/${project1.id}`,
+      payload: {
+        name: 'Environment 1',
+        description: 'Environment 1 description',
+        isDefault: true
+      },
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json().message).toBe(
+      `User with id ${user2.id} does not have the authority ${Authority.CREATE_ENVIRONMENT} in the project with id ${project1.id}`
+    )
+  })
+
+  it('should not be able to create a duplicate environment', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/environment/${project1.id}`,
+      payload: {
+        name: 'Environment 1',
+        description: 'Environment 1 description',
+        isDefault: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.json().message).toBe(
+      `Environment with name Environment 1 already exists in project ${project1.name} (${project1.id})`
+    )
+  })
+
+  it('should not make other environments non-default if the current environment is not the default one', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/environment/${project1.id}`,
+      payload: {
+        name: 'Environment 2',
+        description: 'Environment 2 description',
+        isDefault: false
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+    expect(response.json().name).toBe('Environment 2')
+    expect(response.json().description).toBe('Environment 2 description')
+    expect(response.json().isDefault).toBe(false)
+
+    environment2 = response.json()
+
+    const environments = await prisma.environment.findMany({
+      where: {
+        projectId: project1.id
+      }
+    })
+
+    expect(environments.length).toBe(3)
+    expect(environments.filter((e) => e.isDefault).length).toBe(1)
+  })
+
+  it('should have created a ENVIRONMENT_ADDED event', async () => {
+    const response = await fetchEvents(
+      app,
+      user1,
+      'environmentId=' + environment1.id
+    )
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.ENVIRONMENT,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.ENVIRONMENT_ADDED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
+  })
+
+  it('should be able to update an environment', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/environment/${environment1.id}`,
+      payload: {
+        name: 'Environment 1 Updated',
+        description: 'Environment 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      id: environment1.id,
+      name: 'Environment 1 Updated',
+      description: 'Environment 1 description updated',
+      isDefault: true,
+      projectId: project1.id,
+      lastUpdatedById: user1.id,
+      lastUpdatedBy: expect.any(Object),
+      secrets: [],
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
+    })
+
+    environment1 = response.json()
+  })
+
+  it('should not be able to update an environment that does not exist', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/environment/123`,
+      payload: {
+        name: 'Environment 1 Updated',
+        description: 'Environment 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('Environment with id 123 not found')
+  })
+
+  it('should not be able to update an environment that the user does not have access to', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/environment/${environment1.id}`,
+      payload: {
+        name: 'Environment 1 Updated',
+        description: 'Environment 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json().message).toBe(
+      `User ${user2.id} does not have the required authorities`
+    )
+  })
+
+  it('should not be able to update an environment to a duplicate name', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/environment/${environment1.id}`,
+      payload: {
+        name: 'Environment 2',
+        description: 'Environment 1 description updated'
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.json().message).toBe(
+      `Environment with name Environment 2 already exists in project ${project1.id}`
+    )
+  })
+
+  it('should create a ENVIRONMENT_UPDATED event', async () => {
+    const response = await fetchEvents(
+      app,
+      user1,
+      'environmentId=' + environment1.id
+    )
+
+    const event = {
+      id: expect.any(String),
+      title: expect.any(String),
+      description: expect.any(String),
+      source: EventSource.ENVIRONMENT,
+      triggerer: EventTriggerer.USER,
+      severity: EventSeverity.INFO,
+      type: EventType.ENVIRONMENT_UPDATED,
+      timestamp: expect.any(String),
+      metadata: expect.any(Object)
+    }
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(expect.arrayContaining([event]))
+  })
+
+  it('should make other environments non-default if the current environment is the default one', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/environment/${environment2.id}`,
+      payload: {
+        name: 'Environment 2 Updated',
+        description: 'Environment 2 description updated',
+        isDefault: true
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().name).toBe('Environment 2 Updated')
+    expect(response.json().description).toBe(
+      'Environment 2 description updated'
+    )
+    expect(response.json().isDefault).toBe(true)
+
+    const environments = await prisma.environment.findMany({
+      where: {
+        projectId: project1.id
+      }
+    })
+
+    expect(environments.length).toBe(3)
+    expect(environments.filter((e) => e.isDefault).length).toBe(1)
+
+    environment2 = response.json()
+    environment1.isDefault = false
+  })
+
+  it('should be able to fetch an environment', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/environment/${environment1.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().name).toBe('Environment 1 Updated')
+    expect(response.json().description).toBe(
+      'Environment 1 description updated'
+    )
+    expect(response.json().isDefault).toBe(false)
+  })
+
+  it('should not be able to fetch an environment that does not exist', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/environment/123`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('Environment with id 123 not found')
+  })
+
+  it('should not be able to fetch an environment that the user does not have access to', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/environment/${environment1.id}`,
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json().message).toBe(
+      `User ${user2.id} does not have the required authorities`
+    )
+  })
+
+  it('should be able to fetch all environments of a project', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/environment/all/${project1.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('should not be able to fetch all environments of a project that does not exist', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/environment/all/123`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('Project with id 123 not found')
+  })
+
+  it('should not be able to fetch all environments of a project that the user does not have access to', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/environment/all/${project1.id}`,
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json().message).toBe(
+      `User with id ${user2.id} does not have the authority ${Authority.READ_ENVIRONMENT} in the project with id ${project1.id}`
+    )
+  })
+
+  it('should be able to delete an environment', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/environment/${environment1.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('should not be able to delete an environment that does not exist', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/environment/123`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json().message).toBe('Environment with id 123 not found')
+  })
+
+  it('should not be able to delete an environment that the user does not have access to', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/environment/${environment2.id}`,
+      headers: {
+        'x-e2e-user-email': user2.email
+      }
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json().message).toBe(
+      `User ${user2.id} does not have the required authorities`
+    )
+  })
+
+  it('should not be able to delete the default environment of a project', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/environment/${environment2.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json().message).toBe(
+      'Cannot delete the default environment'
+    )
+  })
+
+  it('should not be able to make the only environment non-default', async () => {
+    await prisma.environment.delete({
+      where: {
+        projectId_name: {
+          projectId: project1.id,
+          name: 'Default'
+        }
+      }
+    })
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/environment/${environment2.id}`,
+      payload: {
+        isDefault: false
+      },
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json().message).toBe(
+      'Cannot make the last environment non-default'
+    )
+  })
+
+  afterAll(async () => {
+    await cleanUp(prisma)
+  })
+})

--- a/apps/api/src/environment/environment.e2e.spec.ts
+++ b/apps/api/src/environment/environment.e2e.spec.ts
@@ -18,15 +18,13 @@ import {
   EventType,
   Project,
   User,
-  Workspace,
-  WorkspaceRole
+  Workspace
 } from '@prisma/client'
 import { v4 } from 'uuid'
 import fetchEvents from '../common/fetch-events'
 import { ProjectModule } from '../project/project.module'
 import { WorkspaceService } from '../workspace/service/workspace.service'
 import { ProjectService } from '../project/service/project.service'
-import { CreateWorkspace } from '../workspace/dto/create.workspace/create.workspace'
 import { EventModule } from '../event/event.module'
 import { UserModule } from '../user/user.module'
 import { WorkspaceModule } from '../workspace/workspace.module'
@@ -41,7 +39,7 @@ describe('Environment Controller Tests', () => {
   let workspaceService: WorkspaceService
 
   let user1: User, user2: User
-  let workspace1: Workspace, workspace2: Workspace
+  let workspace1: Workspace
   let project1: Project
   let environment1: Environment, environment2: Environment
 
@@ -99,11 +97,6 @@ describe('Environment Controller Tests', () => {
     workspace1 = await workspaceService.createWorkspace(user1, {
       name: 'Workspace 1',
       description: 'Workspace 1 description'
-    })
-
-    workspace2 = await workspaceService.createWorkspace(user2, {
-      name: 'Workspace 2',
-      description: 'Workspace 2 description'
     })
 
     project1 = await projectService.createProject(user1, workspace1.id, {

--- a/apps/api/src/environment/service/environment.service.ts
+++ b/apps/api/src/environment/service/environment.service.ts
@@ -149,7 +149,7 @@ export class EnvironmentService {
           name: dto.name,
           description: dto.description,
           isDefault:
-            dto.isDefault !== undefined || dto.isDefault !== null
+            dto.isDefault !== undefined && dto.isDefault !== null
               ? dto.isDefault
               : environment.isDefault,
           lastUpdatedById: user.id
@@ -229,30 +229,30 @@ export class EnvironmentService {
     })
   }
 
-  async getAllEnvironments(
-    page: number,
-    limit: number,
-    sort: string,
-    order: string,
-    search: string
-  ) {
-    // Get the environments
-    return await this.prisma.environment.findMany({
-      where: {
-        name: {
-          contains: search
-        }
-      },
-      include: {
-        lastUpdatedBy: true
-      },
-      skip: page * limit,
-      take: limit,
-      orderBy: {
-        [sort]: order
-      }
-    })
-  }
+  // async getAllEnvironments(
+  //   page: number,
+  //   limit: number,
+  //   sort: string,
+  //   order: string,
+  //   search: string
+  // ) {
+  //   // Get the environments
+  //   return await this.prisma.environment.findMany({
+  //     where: {
+  //       name: {
+  //         contains: search
+  //       }
+  //     },
+  //     include: {
+  //       lastUpdatedBy: true
+  //     },
+  //     skip: page * limit,
+  //     take: limit,
+  //     orderBy: {
+  //       [sort]: order
+  //     }
+  //   })
+  // }
 
   async deleteEnvironment(user: User, environmentId: Environment['id']) {
     const environment = await getEnvironmentWithAuthority(
@@ -267,16 +267,6 @@ export class EnvironmentService {
     // Check if the environment is the default one
     if (environment.isDefault) {
       throw new BadRequestException('Cannot delete the default environment')
-    }
-
-    // Check if this is the last environment
-    const count = await this.prisma.environment.count({
-      where: {
-        projectId
-      }
-    })
-    if (count === 1) {
-      throw new BadRequestException('Cannot delete the last environment')
     }
 
     // Delete the environment

--- a/apps/api/src/prisma/migrations/20240216155823_add_unique_key_to_environment/migration.sql
+++ b/apps/api/src/prisma/migrations/20240216155823_add_unique_key_to_environment/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[projectId,name]` on the table `Environment` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Environment_projectId_name_key" ON "Environment"("projectId", "name");

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -204,6 +204,8 @@ model Environment {
   projectId String
 
   events Event[]
+
+  @@unique([projectId, name])
 }
 
 model Project {

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,15 +2,19 @@ codecov:
   max_report_age: 24
   require_ci_to_pass: false
 
+coverage:
+  range: 50..90 # coverage lower than 50 is red, higher than 90 green, between color code
+
+  status:
+    project:
+      default:
+        enabled: false
+
+    patch:
+      default:
+        enabled: false
+
 flag_management:
-  default_rules: # the rules that will be followed for any flag added, generally
-    carryforward: true
-    statuses:
-      - type: project
-        target: auto
-        threshold: 1%
-      - type: patch
-        target: 90%
   individual_flags:
     - name: web
       paths:


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Enhanced error handling in environment authority checks and service operations.
- Added comprehensive e2e tests for environment management, covering creation, update, deletion, and fetching operations.
- Improved validation and error messaging in environment service, particularly for operations involving default environments and duplicate names.
- Introduced a unique constraint on environment names within a project to prevent duplicates.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get-environment-with-authority.ts</strong><dd><code>Improve Error Handling in Environment Authority Check</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/get-environment-with-authority.ts
<li>Replaced <code>ConflictException</code> with <code>UnauthorizedException</code> for unauthorized <br>access attempts.


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/143/files#diff-ffb18e7d961446fcb42666d51bd97f936480c5e21c487fb3e0568b8faefda664">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>environment.e2e.spec.ts</strong><dd><code>Add Comprehensive e2e Tests for Environment Management</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/environment/environment.e2e.spec.ts
<li>Added extensive e2e tests for environment management features <br>including creation, update, deletion, and fetching of environments.<br> <li> Ensured proper error handling and validation in various scenarios such <br>as duplicate environment names, unauthorized access, and operations on <br>default environments.


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/143/files#diff-847e9eb1392a2556a0727454a36135b4286829fd713b80c2f9dfa2e7b080d900">+586/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>environment.service.ts</strong><dd><code>Enhance Environment Service with Better Validation and Error Handling</code></dd></summary>
<hr>

apps/api/src/environment/service/environment.service.ts
<li>Introduced <code>BadRequestException</code> for invalid operations such as deleting <br>the default or the last environment.<br> <li> Enhanced error messages for conflict exceptions during environment <br>creation and update.<br> <li> Fixed the logic for updating environments to correctly handle the <br>default status and prevent duplicate names within the same project.


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/143/files#diff-658d3ecf90efc583248d280885f43ee30a341ca9949c2a48c1312d3ed6f3acbd">+40/-16</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Enforce Unique Environment Names within Projects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/migrations/20240216155823_add_unique_key_to_environment/migration.sql
<li>Added a unique index on <code>projectId</code> and <code>name</code> columns in the <code>Environment</code> <br>table to enforce unique environment names within a project.


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/143/files#diff-ca9223e1fb053a8051358650ddcf29b72556230e88c2e22509bb2b761ec89e40">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma Schema to Enforce Unique Environment Names</code>&nbsp; </dd></summary>
<hr>

apps/api/src/prisma/schema.prisma
<li>Added a unique constraint on <code>projectId</code> and <code>name</code> fields in the <br><code>Environment</code> model.


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/143/files#diff-24191263d57c55d02e0cdf394de15225b628d1da20bd826b1541b59b6b02adb4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
