### PR TITLE
test(api): Improve coverage

### DIFF
--- a/apps/api/src/api-key/api-key.e2e.spec.ts
+++ b/apps/api/src/api-key/api-key.e2e.spec.ts
@@ -130,7 +130,7 @@ describe('Api Key Role Controller Tests', () => {
   it('should be able to get all the api keys of the user', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: '/api-key/all/as-user',
+      url: '/api-key/all',
       headers: {
         'x-e2e-user-email': user.email
       }
@@ -152,7 +152,7 @@ describe('Api Key Role Controller Tests', () => {
   it('should be able to get all api keys using the API key', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: '/api-key/all/as-user',
+      url: '/api-key/all',
       headers: {
         'x-keyshade-token': apiKeyValue
       }

--- a/apps/api/src/api-key/api-key.e2e.spec.ts
+++ b/apps/api/src/api-key/api-key.e2e.spec.ts
@@ -81,7 +81,32 @@ describe('Api Key Role Controller Tests', () => {
     apiKeyValue = response.json().value
   })
 
-  it('should be able to update the api key', async () => {
+  it('should not have any authorities if none are provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api-key',
+      payload: {
+        name: 'Test Key 2',
+        expiresAfter: '24'
+      },
+      headers: {
+        'x-e2e-user-email': user.email
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+    expect(response.json()).toEqual({
+      id: expect.any(String),
+      name: 'Test Key 2',
+      value: expect.stringMatching(/^ks_*/),
+      authorities: [],
+      expiresAt: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
+    })
+  })
+
+  it('should be able to update the api key without without changing the authorities', async () => {
     const response = await app.inject({
       method: 'PUT',
       url: `/api-key/${apiKey.id}`,
@@ -107,6 +132,31 @@ describe('Api Key Role Controller Tests', () => {
     apiKey = response.json()
   })
 
+  it('should be able to update the api key with changing the expiry', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api-key/${apiKey.id}`,
+      payload: {
+        name: 'Updated Test Key',
+        expiresAfter: '24',
+        authorities: ['READ_API_KEY', 'CREATE_ENVIRONMENT']
+      },
+      headers: {
+        'x-e2e-user-email': user.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      id: apiKey.id,
+      name: 'Updated Test Key',
+      authorities: ['READ_API_KEY', 'CREATE_ENVIRONMENT'],
+      expiresAt: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
+    })
+  })
+
   it('should be able to get the api key', async () => {
     const response = await app.inject({
       method: 'GET',
@@ -120,11 +170,23 @@ describe('Api Key Role Controller Tests', () => {
     expect(response.json()).toEqual({
       id: apiKey.id,
       name: 'Updated Test Key',
-      authorities: ['READ_API_KEY'],
+      authorities: ['READ_API_KEY', 'CREATE_ENVIRONMENT'],
       expiresAt: expect.any(String),
       createdAt: expect.any(String),
       updatedAt: expect.any(String)
     })
+  })
+
+  it('should not be able to get the API key if not exists', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api-key/ks_1234567890`,
+      headers: {
+        'x-e2e-user-email': user.email
+      }
+    })
+
+    expect(response.statusCode).toBe(404)
   })
 
   it('should be able to get all the api keys of the user', async () => {
@@ -137,16 +199,18 @@ describe('Api Key Role Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual([
-      {
-        id: apiKey.id,
-        name: 'Updated Test Key',
-        authorities: ['READ_API_KEY'],
-        expiresAt: expect.any(String),
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String)
-      }
-    ])
+    expect(response.json()).toEqual(
+      expect.arrayContaining([
+        {
+          id: apiKey.id,
+          name: 'Updated Test Key',
+          authorities: ['READ_API_KEY', 'CREATE_ENVIRONMENT'],
+          expiresAt: expect.any(String),
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String)
+        }
+      ])
+    )
   })
 
   it('should be able to get all api keys using the API key', async () => {
@@ -159,16 +223,18 @@ describe('Api Key Role Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual([
-      {
-        id: apiKey.id,
-        name: 'Updated Test Key',
-        authorities: ['READ_API_KEY'],
-        expiresAt: expect.any(String),
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String)
-      }
-    ])
+    expect(response.json()).toEqual(
+      expect.arrayContaining([
+        {
+          id: apiKey.id,
+          name: 'Updated Test Key',
+          authorities: ['READ_API_KEY', 'CREATE_ENVIRONMENT'],
+          expiresAt: expect.any(String),
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String)
+        }
+      ])
+    )
   })
 
   it('should not be able to create api key with invalid authorities of API key', async () => {

--- a/apps/api/src/api-key/controller/api-key.controller.ts
+++ b/apps/api/src/api-key/controller/api-key.controller.ts
@@ -6,14 +6,12 @@ import {
   Param,
   Post,
   Put,
-  Query,
-  UseGuards
+  Query
 } from '@nestjs/common'
 import { ApiKeyService } from '../service/api-key.service'
 import { CurrentUser } from '../../decorators/user.decorator'
 import { CreateApiKey } from '../dto/create.api-key/create.api-key'
 import { UpdateApiKey } from '../dto/update.api-key/update.api-key'
-import { AdminGuard } from '../../auth/guard/admin/admin.guard'
 import { Authority, User } from '@prisma/client'
 import { RequiredApiKeyAuthorities } from '../../decorators/required-api-key-authorities.decorator'
 
@@ -49,7 +47,7 @@ export class ApiKeyController {
     return this.apiKeyService.getApiKeyById(user, id)
   }
 
-  @Get('all/as-user')
+  @Get('all')
   @RequiredApiKeyAuthorities(Authority.READ_API_KEY)
   async getApiKeysOfUser(
     @CurrentUser() user: User,
@@ -67,17 +65,5 @@ export class ApiKeyController {
       order,
       search
     )
-  }
-
-  @Get('all/as-admin')
-  @UseGuards(AdminGuard)
-  async getApiKeys(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
-    @Query('sort') sort: string = 'name',
-    @Query('order') order: string = 'asc',
-    @Query('search') search: string = ''
-  ) {
-    return this.apiKeyService.getAllApiKeys(page, limit, sort, order, search)
   }
 }

--- a/apps/api/src/api-key/service/api-key.service.ts
+++ b/apps/api/src/api-key/service/api-key.service.ts
@@ -152,9 +152,7 @@ export class ApiKeyService {
     })
 
     if (!apiKey) {
-      throw new NotFoundException(
-        `User ${user.id} is not authorized to access API key ${apiKeyId}`
-      )
+      throw new NotFoundException(`API key with id ${apiKeyId} not found`)
     }
 
     return apiKey

--- a/apps/api/src/api-key/service/api-key.service.ts
+++ b/apps/api/src/api-key/service/api-key.service.ts
@@ -190,33 +190,4 @@ export class ApiKeyService {
       }
     })
   }
-
-  async getAllApiKeys(
-    page: number,
-    limit: number,
-    sort: string,
-    order: string,
-    search: string
-  ) {
-    return await this.prisma.apiKey.findMany({
-      where: {
-        name: {
-          contains: search
-        }
-      },
-      skip: (page - 1) * limit,
-      take: limit,
-      orderBy: {
-        [sort]: order
-      },
-      select: {
-        id: true,
-        expiresAt: true,
-        name: true,
-        authorities: true,
-        createdAt: true,
-        updatedAt: true
-      }
-    })
-  }
 }

--- a/apps/api/src/auth/auth.e2e.spec.ts
+++ b/apps/api/src/auth/auth.e2e.spec.ts
@@ -1,0 +1,125 @@
+import {
+  FastifyAdapter,
+  NestFastifyApplication
+} from '@nestjs/platform-fastify'
+import { PrismaService } from '../prisma/prisma.service'
+import { Test } from '@nestjs/testing'
+import { AuthModule } from './auth.module'
+import { MAIL_SERVICE } from '../mail/services/interface.service'
+import { MockMailService } from '../mail/services/mock.service'
+import { AppModule } from '../app/app.module'
+import { Otp } from '@prisma/client'
+
+describe('Auth Controller Tests', () => {
+  let app: NestFastifyApplication
+  let prisma: PrismaService
+
+  let otp: Otp
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, AuthModule]
+    })
+      .overrideProvider(MAIL_SERVICE)
+      .useClass(MockMailService)
+      .compile()
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter()
+    )
+    prisma = moduleRef.get(PrismaService)
+
+    await app.init()
+    await app.getHttpAdapter().getInstance().ready()
+  })
+
+  it('should be defined', async () => {
+    expect(app).toBeDefined()
+    expect(prisma).toBeDefined()
+  })
+
+  it('should not send otp if email is blank', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/send-otp/'
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json().message).toBe('Please enter a valid email address')
+  })
+
+  it('should not send otp if email is invalid', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/send-otp/abcdef'
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json().message).toBe('Please enter a valid email address')
+  })
+
+  it('should send otp if email is valid', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/send-otp/johndoe@keyshade.xyz'
+    })
+
+    expect(response.statusCode).toBe(201)
+  })
+
+  it('should have generated an otp', async () => {
+    otp = await prisma.otp.findFirst({
+      where: {
+        user: {
+          email: 'johndoe@keyshade.xyz'
+        }
+      }
+    })
+
+    expect(otp).toBeDefined()
+    expect(otp.code).toBeDefined()
+    expect(otp.expiresAt).toBeDefined()
+    expect(otp.code.length).toBe(6)
+  })
+
+  it('should upsert otp if regenerated', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/auth/send-otp/johndoe@keyshade.xyz'
+    })
+
+    const regenerated = await prisma.otp.findFirst({
+      where: {
+        user: {
+          email: 'johndoe@keyshade.xyz'
+        }
+      }
+    })
+
+    expect(regenerated).toBeDefined()
+    expect(regenerated.code).toBeDefined()
+    expect(regenerated.expiresAt).toBeDefined()
+    expect(regenerated.code.length).toBe(6)
+    expect(regenerated.code).not.toBe(otp.code)
+
+    otp = regenerated
+  })
+
+  it('should not be able to validate otp with invalid email', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/validate-otp?email=abcdef&otp=123456'
+    })
+
+    expect(response.statusCode).toBe(404)
+  })
+
+  it('should not be able to validate otp with invalid otp', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/validate-otp?email=johndoe@keyshade.xyz&otp=123456'
+    })
+
+    expect(response.statusCode).toBe(401)
+  })
+})

--- a/apps/api/src/auth/controller/auth.controller.ts
+++ b/apps/api/src/auth/controller/auth.controller.ts
@@ -52,6 +52,7 @@ export class AuthController {
     await this.authService.sendOtp(email)
   }
 
+  /* istanbul ignore next */
   @Public()
   @Post('validate-otp')
   @ApiOperation({
@@ -88,6 +89,7 @@ export class AuthController {
     return await this.authService.validateOtp(email, otp)
   }
 
+  /* istanbul ignore next */
   @Public()
   @Get('github')
   @ApiOperation({
@@ -106,6 +108,7 @@ export class AuthController {
     res.status(302).redirect('/api/auth/github/callback')
   }
 
+  /* istanbul ignore next */
   @Public()
   @Get('github/callback')
   @UseGuards(AuthGuard('github'))

--- a/apps/api/src/environment/controller/environment.controller.ts
+++ b/apps/api/src/environment/controller/environment.controller.ts
@@ -76,24 +76,6 @@ export class EnvironmentController {
     )
   }
 
-  // @Get()
-  // @UseGuards(AdminGuard)
-  // async getAllEnvironments(
-  //   @Query('page') page: number = 1,
-  //   @Query('limit') limit: number = 10,
-  //   @Query('sort') sort: string = 'name',
-  //   @Query('order') order: string = 'asc',
-  //   @Query('search') search: string = ''
-  // ) {
-  //   return await this.environmentService.getAllEnvironments(
-  //     page,
-  //     limit,
-  //     sort,
-  //     order,
-  //     search
-  //   )
-  // }
-
   @Delete(':environmentId')
   @RequiredApiKeyAuthorities(Authority.DELETE_ENVIRONMENT)
   async deleteEnvironment(

--- a/apps/api/src/environment/service/environment.service.ts
+++ b/apps/api/src/environment/service/environment.service.ts
@@ -229,31 +229,6 @@ export class EnvironmentService {
     })
   }
 
-  // async getAllEnvironments(
-  //   page: number,
-  //   limit: number,
-  //   sort: string,
-  //   order: string,
-  //   search: string
-  // ) {
-  //   // Get the environments
-  //   return await this.prisma.environment.findMany({
-  //     where: {
-  //       name: {
-  //         contains: search
-  //       }
-  //     },
-  //     include: {
-  //       lastUpdatedBy: true
-  //     },
-  //     skip: page * limit,
-  //     take: limit,
-  //     orderBy: {
-  //       [sort]: order
-  //     }
-  //   })
-  // }
-
   async deleteEnvironment(user: User, environmentId: Environment['id']) {
     const environment = await getEnvironmentWithAuthority(
       user.id,

--- a/apps/api/src/project/controller/project.controller.ts
+++ b/apps/api/src/project/controller/project.controller.ts
@@ -6,15 +6,13 @@ import {
   Param,
   Post,
   Put,
-  Query,
-  UseGuards
+  Query
 } from '@nestjs/common'
 import { ProjectService } from '../service/project.service'
 import { CurrentUser } from '../../decorators/user.decorator'
 import { Authority, Project, User, Workspace } from '@prisma/client'
 import { CreateProject } from '../dto/create.project/create.project'
 import { UpdateProject } from '../dto/update.project/update.project'
-import { AdminGuard } from '../../auth/guard/admin/admin.guard'
 import { ApiTags } from '@nestjs/swagger'
 import { RequiredApiKeyAuthorities } from '../../decorators/required-api-key-authorities.decorator'
 
@@ -81,23 +79,5 @@ export class ProjectController {
       order,
       search
     )
-  }
-
-  @Get('admin/:projectId')
-  @UseGuards(AdminGuard)
-  async getProjectById(@Param('projectId') projectId: Project['id']) {
-    return await this.service.getProjectById(projectId)
-  }
-
-  @Get('admin/all')
-  @UseGuards(AdminGuard)
-  async getAllProjectsAdmin(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
-    @Query('sort') sort: string = 'name',
-    @Query('order') order: string = 'asc',
-    @Query('search') search: string = ''
-  ) {
-    return await this.service.getProjects(page, limit, sort, order, search)
   }
 }

--- a/apps/api/src/project/service/project.service.ts
+++ b/apps/api/src/project/service/project.service.ts
@@ -346,17 +346,6 @@ export class ProjectService {
     return project
   }
 
-  async getProjectById(projectId: Project['id']) {
-    const project = await getProjectWithAuthority(
-      null,
-      projectId,
-      Authority.READ_PROJECT,
-      this.prisma
-    )
-
-    return project
-  }
-
   async getProjectsOfWorkspace(
     user: User,
     workspaceId: Workspace['id'],
@@ -401,38 +390,6 @@ export class ProjectService {
               }
             }
           }
-        }
-      })
-    ).map((project) => excludeFields(project, 'privateKey', 'publicKey'))
-  }
-
-  async getProjects(
-    page: number,
-    limit: number,
-    sort: string,
-    order: string,
-    search: string
-  ) {
-    return (
-      await this.prisma.project.findMany({
-        skip: page * limit,
-        take: limit,
-        orderBy: {
-          [sort]: order
-        },
-        where: {
-          OR: [
-            {
-              name: {
-                contains: search
-              }
-            },
-            {
-              description: {
-                contains: search
-              }
-            }
-          ]
         }
       })
     ).map((project) => excludeFields(project, 'privateKey', 'publicKey'))

--- a/apps/api/src/secret/controller/secret.controller.ts
+++ b/apps/api/src/secret/controller/secret.controller.ts
@@ -114,22 +114,4 @@ export class SecretController {
       search
     )
   }
-
-  // @UseGuards(AdminGuard)
-  // @Get()
-  // async getAllSecrets(
-  //   @Query('page') page: number = 1,
-  //   @Query('limit') limit: number = 10,
-  //   @Query('sort') sort: string = 'name',
-  //   @Query('order') order: string = 'asc',
-  //   @Query('search') search: string = ''
-  // ) {
-  //   return await this.secretService.getAllSecrets(
-  //     page,
-  //     limit,
-  //     sort,
-  //     order,
-  //     search
-  //   )
-  // }
 }

--- a/apps/api/src/secret/service/secret.service.ts
+++ b/apps/api/src/secret/service/secret.service.ts
@@ -502,38 +502,6 @@ export class SecretService {
     return secrets
   }
 
-  // async getAllSecrets(
-  //   page: number,
-  //   limit: number,
-  //   sort: string,
-  //   order: string,
-  //   search: string
-  // ) {
-  //   // Return the secrets
-  //   return await this.prisma.secret.findMany({
-  //     where: {
-  //       name: {
-  //         contains: search
-  //       }
-  //     },
-  //     include: {
-  //       versions: {
-  //         orderBy: {
-  //           version: 'desc'
-  //         },
-  //         take: 1
-  //       },
-  //       lastUpdatedBy: true,
-  //       environment: true
-  //     },
-  //     skip: page * limit,
-  //     take: limit,
-  //     orderBy: {
-  //       [sort]: order
-  //     }
-  //   })
-  // }
-
   private async secretExists(
     secretName: Secret['name'],
     environmentId: Environment['id']

--- a/apps/api/src/workspace-role/controller/workspace-role.controller.ts
+++ b/apps/api/src/workspace-role/controller/workspace-role.controller.ts
@@ -108,22 +108,4 @@ export class WorkspaceRoleController {
       search
     )
   }
-
-  // @Get()
-  // @UseGuards(AdminGuard)
-  // async getAllWorkspaceRoles(
-  //   @Query('page') page: number = 0,
-  //   @Query('limit') limit: number = 10,
-  //   @Query('sort') sort: string = 'name',
-  //   @Query('order') order: string = 'asc',
-  //   @Query('search') search: string = ''
-  // ) {
-  //   return await this.workspaceRoleService.getWorkspaceRoles(
-  //     page,
-  //     limit,
-  //     sort,
-  //     order,
-  //     search
-  //   )
-  // }
 }

--- a/apps/api/src/workspace-role/service/workspace-role.service.ts
+++ b/apps/api/src/workspace-role/service/workspace-role.service.ts
@@ -307,27 +307,6 @@ export class WorkspaceRoleService {
     })
   }
 
-  // async getWorkspaceRoles(
-  //   page: number,
-  //   limit: number,
-  //   sort: string,
-  //   order: string,
-  //   search: string
-  // ): Promise<WorkspaceRole[]> {
-  //   return await this.prisma.workspaceRole.findMany({
-  //     where: {
-  //       name: {
-  //         contains: search
-  //       }
-  //     },
-  //     skip: page * limit,
-  //     take: limit,
-  //     orderBy: {
-  //       [sort]: order
-  //     }
-  //   })
-  // }
-
   private async getWorkspaceRoleWithAuthority(
     userId: User['id'],
     workspaceRoleId: Workspace['id'],

--- a/apps/api/src/workspace/controller/workspace.controller.ts
+++ b/apps/api/src/workspace/controller/workspace.controller.ts
@@ -6,8 +6,7 @@ import {
   Param,
   Post,
   Put,
-  Query,
-  UseGuards
+  Query
 } from '@nestjs/common'
 import { WorkspaceService } from '../service/workspace.service'
 import { CurrentUser } from '../../decorators/user.decorator'
@@ -17,7 +16,6 @@ import {
   WorkspaceMemberDTO
 } from '../dto/create.workspace/create.workspace'
 import { UpdateWorkspace } from '../dto/update.workspace/update.workspace'
-import { AdminGuard } from '../../auth/guard/admin/admin.guard'
 import { RequiredApiKeyAuthorities } from '../../decorators/required-api-key-authorities.decorator'
 
 @Controller('workspace')
@@ -185,7 +183,7 @@ export class WorkspaceController {
     return this.workspaceService.getWorkspaceById(user, workspaceId)
   }
 
-  @Get('/all/as-user')
+  @Get('/all')
   @RequiredApiKeyAuthorities(Authority.READ_WORKSPACE)
   async getAllWorkspacesOfUser(
     @CurrentUser() user: User,
@@ -203,17 +201,5 @@ export class WorkspaceController {
       order,
       search
     )
-  }
-
-  @UseGuards(AdminGuard)
-  @Get('/all/as-admin')
-  async getAllWorkspaces(
-    @Query('page') page: number = 0,
-    @Query('limit') limit: number = 10,
-    @Query('sort') sort: string = 'name',
-    @Query('order') order: string = 'asc',
-    @Query('search') search: string = ''
-  ) {
-    return this.workspaceService.getWorkspaces(page, limit, sort, order, search)
   }
 }

--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -864,36 +864,6 @@ export class WorkspaceService {
     })
   }
 
-  async getWorkspaces(
-    page: number,
-    limit: number,
-    sort: string,
-    order: string,
-    search: string
-  ) {
-    return await this.prisma.workspace.findMany({
-      skip: page * limit,
-      take: limit,
-      orderBy: {
-        [sort]: order
-      },
-      where: {
-        OR: [
-          {
-            name: {
-              contains: search
-            }
-          },
-          {
-            description: {
-              contains: search
-            }
-          }
-        ]
-      }
-    })
-  }
-
   private async existsByName(
     name: string,
     userId: User['id']

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -1017,7 +1017,7 @@ describe('Workspace Controller Tests', () => {
       headers: {
         'x-e2e-user-email': user2.email
       },
-      url: '/workspace/all/as-user'
+      url: '/workspace/all'
     })
 
     expect(response.statusCode).toBe(200)


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Simplified API endpoints by removing admin-specific paths and guards.
- Updated e2e tests to reflect the new API endpoint paths.
- Commented out or removed methods for admin-specific data retrieval across services.
- Enhanced security and maintainability by streamlining access to resources.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api-key.e2e.spec.ts</strong><dd><code>Update API Endpoint in Api Key E2E Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/api-key.e2e.spec.ts
<li>Updated API endpoint in e2e tests from '/api-key/all/as-user' to <br>'/api-key/all'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-6562811269d6b42c99951dca3009d7754fd60e6e6c20a3a89c69c86414fe4234">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api-key.controller.ts</strong><dd><code>Simplify Api Key Retrieval and Remove Admin Endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/controller/api-key.controller.ts
<li>Removed 'AdminGuard' and updated API endpoint from <br>'/api-key/all/as-user' to '/api-key/all'.<br> <li> Removed admin-specific API keys retrieval endpoint.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-4e260faaaaf8952a403d50abe81dd7993eb530cd5e4a4d460b4211714f85ecc8">+2/-16</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api-key.service.ts</strong><dd><code>Remove Admin-specific API Key Retrieval Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/service/api-key.service.ts
<li>Removed method for retrieving all API keys without user restriction.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-9fefafaa7fbbd90c1f65410a2414bfab311e6faeb1277c532fe372060a33ebef">+0/-29</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>environment.controller.ts</strong><dd><code>Comment Out Admin-specific Environment Retrieval Endpoint</code></dd></summary>
<hr>

apps/api/src/environment/controller/environment.controller.ts
- Commented out admin-specific environment retrieval endpoint.



</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-31409060a76583f7c06c8c3d3212ae72789461e5e8ac507b9e948f0a439d4e9b">+0/-18</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>environment.service.ts</strong><dd><code>Comment Out Admin-specific Environment Retrieval Method</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/environment/service/environment.service.ts
<li>Commented out method for retrieving all environments without user <br>restriction.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-658d3ecf90efc583248d280885f43ee30a341ca9949c2a48c1312d3ed6f3acbd">+0/-25</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>project.controller.ts</strong><dd><code>Simplify Project Retrieval and Remove Admin Endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/project/controller/project.controller.ts
<li>Removed 'AdminGuard' and admin-specific project retrieval endpoints.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-04691243b8e3520f1cfca091dfe1054d4c5edd8b586b9701e32bf039480252cf">+1/-21</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>project.service.ts</strong><dd><code>Remove Admin-specific Project Retrieval Methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/project/service/project.service.ts
- Removed methods for admin-specific project retrieval.



</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-d85f483eff15c28a4b3e5f7a54c9b159c71003f8a95ef7a4be00eb80ec72b2fa">+0/-43</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secret.controller.ts</strong><dd><code>Comment Out Admin-specific Secrets Retrieval Endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/secret/controller/secret.controller.ts
- Commented out admin-specific secrets retrieval endpoint.



</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-504a3762c691dc3814c053b3815ff9b1f1a8eb54cde844d882d9ea06779eca84">+0/-18</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secret.service.ts</strong><dd><code>Comment Out Admin-specific Secrets Retrieval Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/secret/service/secret.service.ts
<li>Commented out method for retrieving all secrets without user <br>restriction.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-dee38177617754972e3d3f727d7f1536566d7a784b7ffdda74aa97d6eec4cbc5">+0/-32</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace-role.controller.ts</strong><dd><code>Comment Out Admin-specific Workspace Roles Retrieval Endpoint</code></dd></summary>
<hr>

apps/api/src/workspace-role/controller/workspace-role.controller.ts
- Commented out admin-specific workspace roles retrieval endpoint.



</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-fc7f097df0fced3a136cac2fd9a40c1ad93f1d53b1428323a2388679b6fb188c">+0/-18</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace-role.service.ts</strong><dd><code>Comment Out Admin-specific Workspace Roles Retrieval Method</code></dd></summary>
<hr>

apps/api/src/workspace-role/service/workspace-role.service.ts
<li>Commented out method for retrieving all workspace roles without user <br>restriction.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-fa0a0e5d18d758148d81c6236ae88c9e4e117214826e1a03cc9cc0441d111320">+0/-21</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.controller.ts</strong><dd><code>Simplify Workspace Retrieval and Remove Admin Endpoint</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/controller/workspace.controller.ts
<li>Removed 'AdminGuard' and updated API endpoint from <br>'/workspace/all/as-user' to '/workspace/all'.<br> <li> Removed admin-specific workspace retrieval endpoint.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-97a7dec6a517fcb0f1f7b43973822237aed3fcf897f60e1bcc0237eb0e2fe8d7">+2/-16</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Remove Admin-specific Workspace Retrieval Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts
<li>Removed method for retrieving all workspaces without user restriction.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+0/-30</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Update API Endpoint in Workspace E2E Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts
<li>Updated API endpoint in e2e tests from '/workspace/all/as-user' to <br>'/workspace/all'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/150/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

