### PR TITLE
feat(api): Add feature to export data of a workspace

### DIFF
--- a/apps/api/src/secret/dto/create.secret/create.secret.ts
+++ b/apps/api/src/secret/dto/create.secret/create.secret.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsOptional, IsString, Length } from 'class-validator'
+import { IsOptional, IsString, Length } from 'class-validator'
 
 export class CreateSecret {
   @IsString()
@@ -12,8 +12,8 @@ export class CreateSecret {
   @Length(0, 100)
   note: string
 
-  @IsNumber()
   @IsOptional()
+  @IsString()
   environmentId: string
 
   @IsString()

--- a/apps/api/src/variable/dto/create.variable/create.variable.ts
+++ b/apps/api/src/variable/dto/create.variable/create.variable.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsOptional, IsString, Length } from 'class-validator'
+import { IsOptional, IsString, Length } from 'class-validator'
 
 export class CreateVariable {
   @IsString()
@@ -12,7 +12,7 @@ export class CreateVariable {
   @Length(0, 100)
   note: string
 
-  @IsNumber()
+  @IsString()
   @IsOptional()
   environmentId: string
 }

--- a/apps/api/src/workspace/controller/workspace.controller.ts
+++ b/apps/api/src/workspace/controller/workspace.controller.ts
@@ -183,6 +183,15 @@ export class WorkspaceController {
     return this.workspaceService.getWorkspaceById(user, workspaceId)
   }
 
+  @Get(':workspaceId/export-data')
+  @RequiredApiKeyAuthorities(Authority.WORKSPACE_ADMIN)
+  async exportData(
+    @CurrentUser() user: User,
+    @Param('workspaceId') workspaceId: Workspace['id']
+  ) {
+    return this.workspaceService.exportData(user, workspaceId)
+  }
+
   @Get('/all')
   @RequiredApiKeyAuthorities(Authority.READ_WORKSPACE)
   async getAllWorkspacesOfUser(

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -1131,6 +1131,59 @@ describe('Workspace Controller Tests', () => {
     expect(response.json()).toEqual(expect.arrayContaining([event]))
   })
 
+  it('should not be able to export data of a non-existing workspace', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      headers: {
+        'x-e2e-user-email': user1.email
+      },
+      url: `/workspace/abc/export-data`
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Workspace with id abc not found`
+    })
+  })
+
+  it('should not be able to export data of a workspace it is not a member of', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      headers: {
+        'x-e2e-user-email': user1.email
+      },
+      url: `/workspace/${workspace1.id}/export-data`
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: `User ${user1.id} does not have the required authorities to perform the action`
+    })
+  })
+
+  it('should be able to export data of the workspace', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      headers: {
+        'x-e2e-user-email': user2.email
+      },
+      url: `/workspace/${workspace1.id}/export-data`
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    const body = response.json()
+
+    expect(body.name).toEqual(workspace1.name)
+    expect(body.description).toEqual(workspace1.description)
+    expect(body.workspaceRoles).toBeInstanceOf(Array)
+    expect(body.projects).toBeInstanceOf(Array)
+  })
+
   it('should be able to delete the workspace', async () => {
     const response = await app.inject({
       method: 'DELETE',


### PR DESCRIPTION
## **User description**
Fixes #128


___

## **Type**
enhancement, tests


___

## **Description**
- Added functionality to export data of a workspace including details, roles, projects, environments, variables, and secrets.
- Refactored `environmentId` field in `CreateSecret` and `CreateVariable` DTOs from number to string.
- Introduced a new endpoint `:workspaceId/export-data` in `WorkspaceController` with `WORKSPACE_ADMIN` authority requirement.
- Implemented `exportData` method in `WorkspaceService` to support the data export feature.
- Added comprehensive e2e tests to validate the new export data functionality, including checks for unauthorized access and successful data export.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.secret.ts</strong><dd><code>Refactor environmentId to Use String Validator in CreateSecret DTO</code></dd></summary>
<hr>

apps/api/src/secret/dto/create.secret/create.secret.ts
<li>Removed <code>IsNumber</code> import and validator from <code>environmentId</code>.<br> <li> Changed <code>environmentId</code> validator from <code>IsNumber</code> to <code>IsString</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/152/files#diff-0ba28109a277c57e22c8bdc661163b0d1f3b4ae8171a89d3fc72cf3e620529cb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create.variable.ts</strong><dd><code>Refactor environmentId to Use String Validator in CreateVariable DTO</code></dd></summary>
<hr>

apps/api/src/variable/dto/create.variable/create.variable.ts
<li>Removed <code>IsNumber</code> import and validator from <code>environmentId</code>.<br> <li> Changed <code>environmentId</code> validator from <code>IsNumber</code> to <code>IsString</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/152/files#diff-f00a0e578eb924e62fd50241ef8fb0583302b9737b42c98cf2f41b965b42c5c3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.controller.ts</strong><dd><code>Add Export Data Endpoint to Workspace Controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/controller/workspace.controller.ts
<li>Added a new endpoint <code>:workspaceId/export-data</code> to export data of a <br>workspace.<br> <li> Required <code>WORKSPACE_ADMIN</code> authority for accessing the export data <br>endpoint.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/152/files#diff-97a7dec6a517fcb0f1f7b43973822237aed3fcf897f60e1bcc0237eb0e2fe8d7">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Implement Export Data Functionality in Workspace Service</code>&nbsp; </dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts
<li>Implemented <code>exportData</code> method to gather and return workspace data.<br> <li> Data includes workspace details, roles, projects, environments, <br>variables, and secrets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/152/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+83/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Add E2E Tests for Workspace Data Export Functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts
<li>Added e2e tests for the new export data functionality.<br> <li> Tests cover unauthorized access, non-existing workspace, and <br>successful data export.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/152/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+53/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

