### PR TITLE
docs: fix typo in environment-variables.md

### DIFF
--- a/docs/contributing-to-keyshade/environment-variables.md
+++ b/docs/contributing-to-keyshade/environment-variables.md
@@ -12,7 +12,7 @@ Here's the description of the environment variables used in the project. You can
 * **SUPABASE\_API\_URL**: The URL of the Supabase API. This is used by the [Supabase Client](https://supabase.io/docs/reference/javascript/supabase-client) to connect to the Supabase API. Make sure you create a Supabase project and get the API URL from the project settings.
 * **SUPABASE\_ANON\_KEY**: The anonymous key of the Supabase project. This is used by the Supabase Client to connect to the Supabase API. Make sure you create a Supabase project and get the anonymous key from the project settings.
 * **SMTP\_HOST**: This is used to send out emails from the backend.&#x20;
-* **SMTP\_PORT:** The SMPT port as specified by your SMPT provider.
+* **SMTP\_PORT:** The SMTP port as specified by your SMTP provider.
 * **SMTP\_EMAIL\_ADDRESS:** The email address you want to be sending out the emails from.
 * **SMTP\_PASSWORD:** The app password for your email account. &#x20;
 * **GITHUB\_CLIENT\_ID, GITHUB\_CLIENT\_SECRET, GITHUB\_CALLBACK\_URL:** These settings can be configured by adding an OAuth app in your GitHub account's developer section. Please note that it's not mandatory, until and unless you want to support GitHub OAuth.


### PR DESCRIPTION
## **User description**
## Description

Fixed typo in Docs/environment-variables.md file <br />


___

## **Type**
documentation


___

## **Description**
- Corrected a typo in the environment variables documentation, ensuring the correct abbreviation for SMTP is used.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>environment-variables.md</strong><dd><code>Fix Typo in Environment Variables Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/contributing-to-keyshade/environment-variables.md
<li>Corrected the typo from "SMPT" to "SMTP" in the description of the <br><code>SMTP_PORT</code> environment variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/163/files#diff-2bf98f3c57ba5baaa3603870cea1ee6984fea12550638d22e65bfe23f3234af1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

