### PR TITLE
docs(setup): replace NX with Turbo in setup instructions

### DIFF
--- a/docs/contributing-to-keyshade/setting-things-up.md
+++ b/docs/contributing-to-keyshade/setting-things-up.md
@@ -42,13 +42,15 @@ To install the dependencies, run the following command:
 pnpm install
 ```
 
-## Installing NX
+## Installing Turbo
 
-The last step is to install NX. It is the monorepo management tool that we are using. Read more about it in [https://nx.dev](https://nx.dev). To install nx, you need to run the following command:
+The final step involves installing our monorepo management tool. We have transitioned to using Turbo to streamline our development process. To install Turbo, run the following command:
 
 ```bash
-npm i -g nx
+npm install turbo --global
 ```
+
+For more information on how to get started with Turbo, refer to the [official Turbo documentation](https://turbo.build/repo/docs).
 
 ## Installing nest CLI
 


### PR DESCRIPTION
## **User description**
## Description

This update modifies the project's setup documentation to replace the outdated NX setup instructions with the new Turbo setup instructions. This change reflects our shift to using Turbo for monorepo management, aligning the documentation with our current development practices.

Fixes #174

## Dependencies

- No new dependencies introduced. The change is in documentation only.

## Mentions

@rajdip-b

## Changes Walkthrough

**Relevant Files:**

|         | Relevant Files                                                                                                                |
|-----------------|-------------------------------------------------------------------------------|
| Documentation   |   <table>  <thead>   </tr>  </thead>  <tbody>  <tr>  <td><details><summary>##setting-things-up.md<br>`replace NX with Turbo in setup instructions`</summary><hr>docs/contributing-to-keyshade/setting-things-up.md<br><br><ul><li>Removed references to installing NX as the monorepo management tool.</li><li>Added new section detailing the installation process for Turbo, including global installation via npm.</li></ul></details></td>  <td>+1/-1</td> </tbody>  </table>               |  

## Developer's checklist

- [✅] My PR follows the style guidelines of this project
- [✅] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [ ] There are no UI/UX issues


### Documentation Update

- [✅] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [✅] I have made the necessary updates to the documentation, or no documentation changes are required.


___

## **Type**
Documentation


___

## **Description**
- Updated the setup documentation to replace NX with Turbo as the monorepo management tool.
- Provided the command for global installation of Turbo.
- Added a link to the official Turbo documentation for further reading.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setting-things-up.md</strong><dd><code>Update Setup Instructions to Use Turbo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/contributing-to-keyshade/setting-things-up.md
<li>Replaced NX installation instructions with Turbo.<br> <li> Added a command for installing Turbo globally.<br> <li> Included a reference to the official Turbo documentation.


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/175/files#diff-cef348a8823f15a58b87562625cba74999f427c52980164863ee234f45897d44">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

