### PR TITLE
feat(api): Create default workspace on user's creation

### DIFF
--- a/apps/api/src/auth/service/auth.service.ts
+++ b/apps/api/src/auth/service/auth.service.ts
@@ -157,27 +157,15 @@ export class AuthService {
     let user = await this.findUserByEmail(email)
     // We need to create the user if it doesn't exist yet
     if (!user) {
-      user = await this.createUser(email, name, profilePictureUrl)
+      user = await createUser(
+        {
+          email,
+          name,
+          profilePictureUrl
+        },
+        this.prisma
+      )
     }
-    return user
-  }
-
-  private async createUser(
-    email: string,
-    name: string,
-    profilePictureUrl: string
-  ) {
-    // Create the user
-    const user = await createUser(
-      {
-        email,
-        name,
-        profilePictureUrl
-      },
-      this.prisma
-    )
-    this.logger.log(`User created: ${email}`)
-
     return user
   }
 

--- a/apps/api/src/common/create-workspace.ts
+++ b/apps/api/src/common/create-workspace.ts
@@ -1,0 +1,95 @@
+import { Authority, EventSource, EventType, User } from '@prisma/client'
+import createEvent from './create-event'
+import { CreateWorkspace } from '../workspace/dto/create.workspace/create.workspace'
+import { v4 } from 'uuid'
+import { PrismaService } from '../prisma/prisma.service'
+import { Logger } from '@nestjs/common'
+
+export default async function createWorkspace(
+  user: User,
+  dto: CreateWorkspace,
+  prisma: PrismaService,
+  isDefault?: boolean
+) {
+  const workspaceId = v4()
+  const logger = new Logger('createWorkspace')
+
+  const createNewWorkspace = prisma.workspace.create({
+    data: {
+      id: workspaceId,
+      name: dto.name,
+      description: dto.description,
+      approvalEnabled: dto.approvalEnabled,
+      isFreeTier: true,
+      ownerId: user.id,
+      isDefault,
+      roles: {
+        createMany: {
+          data: [
+            {
+              name: 'Admin',
+              authorities: [Authority.WORKSPACE_ADMIN],
+              hasAdminAuthority: true,
+              colorCode: '#FF0000'
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  // Add the owner to the workspace
+  const assignOwnership = prisma.workspaceMember.create({
+    data: {
+      workspace: {
+        connect: {
+          id: workspaceId
+        }
+      },
+      user: {
+        connect: {
+          id: user.id
+        }
+      },
+      invitationAccepted: true,
+      roles: {
+        create: {
+          role: {
+            connect: {
+              workspaceId_name: {
+                workspaceId: workspaceId,
+                name: 'Admin'
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const result = await prisma.$transaction([
+    createNewWorkspace,
+    assignOwnership
+  ])
+  const workspace = result[0]
+
+  await createEvent(
+    {
+      triggeredBy: user,
+      entity: workspace,
+      type: EventType.WORKSPACE_CREATED,
+      source: EventSource.WORKSPACE,
+      title: `Workspace created`,
+      metadata: {
+        workspaceId: workspace.id,
+        name: workspace.name
+      },
+      workspaceId: workspace.id
+    },
+    prisma
+  )
+
+  logger.log(`Created workspace ${dto.name} (${workspaceId})`)
+
+  return workspace
+}

--- a/apps/api/src/prisma/migrations/20240413155927_add_default_workspace/migration.sql
+++ b/apps/api/src/prisma/migrations/20240413155927_add_default_workspace/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN     "isDefault" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -418,6 +418,7 @@ model Workspace {
   updatedAt       DateTime @updatedAt
   ownerId         String
   approvalEnabled Boolean  @default(false)
+  isDefault       Boolean  @default(false)
 
   lastUpdatedBy   User?   @relation(fields: [lastUpdatedById], references: [id], onUpdate: Cascade, onDelete: SetNull)
   lastUpdatedById String?

--- a/apps/api/src/user/dto/create.user/create.user.ts
+++ b/apps/api/src/user/dto/create.user/create.user.ts
@@ -12,7 +12,7 @@ export class CreateUserDto {
     example: 'John Doe',
     default: null
   })
-  name: string
+  name?: string
 
   @IsString()
   @IsEmail()
@@ -37,7 +37,7 @@ export class CreateUserDto {
     example: 'https://example.com/profile.jpg',
     default: null
   })
-  profilePictureUrl: string
+  profilePictureUrl?: string
 
   @IsBoolean()
   @IsOptional()
@@ -49,7 +49,7 @@ export class CreateUserDto {
     example: true,
     default: true
   })
-  isActive: boolean
+  isActive?: boolean
 
   @IsBoolean()
   @IsOptional()
@@ -61,7 +61,7 @@ export class CreateUserDto {
     example: true,
     default: false
   })
-  isOnboardingFinished: boolean
+  isOnboardingFinished?: boolean
 
   @IsBoolean()
   @IsOptional()
@@ -73,5 +73,5 @@ export class CreateUserDto {
     example: false,
     default: false
   })
-  isAdmin: boolean
+  isAdmin?: boolean
 }

--- a/apps/api/src/user/service/user.service.ts
+++ b/apps/api/src/user/service/user.service.ts
@@ -107,12 +107,22 @@ export class UserService {
   }
 
   private async deleteUserById(userId: User['id']) {
+    // Delete the default workspace of this user
+    await this.prisma.workspace.deleteMany({
+      where: {
+        ownerId: userId,
+        isDefault: true
+      }
+    })
+
     // Delete the user
     await this.prisma.user.delete({
       where: {
         id: userId
       }
     })
+
+    this.log.log(`Deleted user ${userId}`)
   }
 
   async createUser(user: CreateUserDto) {

--- a/apps/api/src/workspace/dto/create.workspace/create.workspace.ts
+++ b/apps/api/src/workspace/dto/create.workspace/create.workspace.ts
@@ -8,11 +8,11 @@ export class CreateWorkspace {
 
   @IsString()
   @IsOptional()
-  description: string
+  description?: string
 
   @IsBoolean()
   @IsOptional()
-  approvalEnabled: boolean
+  approvalEnabled?: boolean
 }
 
 export interface WorkspaceMemberDTO {

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,6 +1,3 @@
-# Set the version of docker compose to use
-version: '3.9'
-
 # The containers that compose the project
 services:
   db:


### PR DESCRIPTION
## **User description**
## Description

Creates a default workspace when a user is created. Default workspaces have these features:
- They have a `isDefault` flag set to true
- Owners are not allowed to leave the workspace or transfer its ownership 

Fixes #157


___

## **Type**
enhancement


___

## **Description**
- Introduced functionality to create a default workspace when a new user is created.
- Refactored user creation logic in AuthService and updated CreateUserDto to support optional fields.
- Added a new function for workspace creation with default workspace support and detailed logging.
- Enhanced user and workspace services to handle default workspaces, including preventing their deletion and ownership transfer.
- Updated e2e tests to cover new functionality and added cleanup utilities.
- Implemented a database migration to add an `isDefault` column to the Workspace table.
- Simplified docker-compose test configuration by removing the version specification.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.service.ts</strong><dd><code>Refactor User Creation Logic in AuthService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/auth/service/auth.service.ts
<li>Refactored user creation logic by removing the <code>createUser</code> method and <br>using the <code>createUser</code> function directly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-b133cdd3d1772bc73698061218512fd024ce1ed7cd9eaeb27858e6acb444b90b">+8/-20</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-user.ts</strong><dd><code>Implement Default Workspace Creation on New User Signup</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/create-user.ts
<li>Added functionality to create a default workspace when a new user is <br>created.<br> <li> Enhanced logging to include user and workspace creation details.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-f84f08523889c22752f3408e2931882ce2e71aff7668ab05448058aab961d310">+26/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-workspace.ts</strong><dd><code>Add Functionality to Create Default Workspaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/create-workspace.ts
<li>Introduced a new function to create workspaces with the ability to <br>mark them as default.<br> <li> Added detailed logging for workspace creation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-5cf79d38cdcb9246283cc5b3fe55e989887162960aeff74a0d279d69a59fab16">+95/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create.user.ts</strong><dd><code>Update CreateUserDto to Support Optional Fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/user/dto/create.user/create.user.ts
<li>Made <code>name</code>, <code>profilePictureUrl</code>, <code>isActive</code>, <code>isOnboardingFinished</code>, and <br><code>isAdmin</code> fields optional in <code>CreateUserDto</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-590f359b284ad21cdb472d4bb7730fc4c91ba8acf18582e6d31f038d0392bb78">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>user.service.ts</strong><dd><code>Enhance User Deletion to Remove Default Workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/user/service/user.service.ts
<li>Added logic to delete a user's default workspace upon account <br>deletion.<br> <li> Enhanced logging to include user deletion details.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-6ca55e419496e622d41d22930ddd6d7e7d9f907148c36afcae40ef6320dab922">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create.workspace.ts</strong><dd><code>Update CreateWorkspace DTO to Support Optional Fields</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/dto/create.workspace/create.workspace.ts
<li>Made <code>description</code> and <code>approvalEnabled</code> fields optional in <br><code>CreateWorkspace</code> DTO.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-c760c1ab4fbc21b71e76046a55e199b8bff73f6924dcab6615a505afc644f924">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Refactor Workspace Creation and Protect Default Workspaces</code></dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts
<li>Refactored workspace creation to use the <code>createWorkspace</code> function.<br> <li> Added checks to prevent ownership transfer and deletion of default <br>workspaces.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+17/-79</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Database Migration to Add isDefault Column to Workspace</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/migrations/20240413155927_add_default_workspace/migration.sql
<li>Added a migration to include an <code>isDefault</code> column in the <code>Workspace</code> <br>table.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-49c31d2d1d9c53b665ebdc7ac26f862a2e6226370d5587b99465b5e8fd549ebd">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma Schema to Include isDefault in Workspace Model</code></dd></summary>
<hr>

apps/api/src/prisma/schema.prisma
<li>Updated the Prisma schema to include an <code>isDefault</code> field in the <br><code>Workspace</code> model.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-24191263d57c55d02e0cdf394de15225b628d1da20bd826b1541b59b6b02adb4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>user.e2e.spec.ts</strong><dd><code>Refactor User E2E Tests and Add Default Workspace Creation Test</code></dd></summary>
<hr>

apps/api/src/user/user.e2e.spec.ts
<li>Refactored user creation in tests to use the <code>UserService</code>.<br> <li> Added cleanup utility to manage test data.<br> <li> Implemented a test to verify default workspace creation for new users.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-e033f59a1c8df8834aa27fc532b74514ecc01b9a1c0eef7c56bdff989f127094">+70/-20</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Add E2E Tests for Default Workspace Restrictions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts
<li>Added tests to ensure default workspaces cannot be deleted or have <br>their ownership transferred.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+129/-37</a></td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose-test.yml</strong><dd><code>Simplify docker-compose Test Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose-test.yml
<li>Removed version specification from the docker-compose test <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/182/files#diff-6e72fc85bdf9d7aa207102402a2de7cf7aec4109d2378b66921a5c70d07a4f1f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

