### PR TITLE
docs: Fix typo in organization-of-code.md

### DIFF
--- a/docs/contributing-to-keyshade/design-of-our-code/organization-of-code.md
+++ b/docs/contributing-to-keyshade/design-of-our-code/organization-of-code.md
@@ -11,7 +11,7 @@ In this section, we will discuss how our codebase is organized. We have tried to
 The `apps` directory contains all the applications that are part of the project. Each application is a separate package and has its own `package.json` file. The applications are:
 
 - [**`api`**](../../../apps/api/): The main API server that serves the REST API.
-- [**`api`**](../../../apps/web/): The web application that serves the homepage.
+- [**`web`**](../../../apps/web/): The web application that serves the homepage.
 - [**`platform`**](../../../apps/workspace/): The platform application hosts the UI that allows users to do the actual work.
 
 ## Packages under `packages` directory


### PR DESCRIPTION
### **User description**
## Description

FIX document typo from 'api' to 'web'


## Dependencies

NIL

## Future Improvements

NIL

## Mentions

NIL

## Screenshots of relevant screens

![Organization-of-code-keyshade-docs](https://github.com/keyshade-xyz/keyshade/assets/106652393/62ad356d-a70b-4fb3-b545-a0a12595ffbe)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [ ] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Documentation


___

### **Description**
- Corrected a typo in the `organization-of-code.md` file, changing the label from `api` to `web` for the web application.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>organization-of-code.md</strong><dd><code>Fix typo in the organization-of-code documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/contributing-to-keyshade/design-of-our-code/organization-of-code.md
<li>Corrected a typo in the description of the web application.<br> <li> Changed the label from <code>api</code> to <code>web</code> for the web application.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/234/files#diff-c811ca27f083800cc45dfe8e123029186077c3b884b300d5f15081291f96823b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

