### PR TITLE
test: Refactor workspace role e2e tests

### DIFF
--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -939,7 +939,8 @@ export class WorkspaceService {
         const createMember = this.prisma.user.create({
           data: {
             id: userId,
-            email: member.email
+            email: member.email,
+            isOnboardingFinished: false
           }
         })
 

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -733,6 +733,33 @@ describe('Workspace Controller Tests', () => {
     expect(event.itemId).toBeDefined()
   })
 
+  it('should have created a new user if they did not exist while inviting them to the workspace', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      headers: {
+        'x-e2e-user-email': user1.email
+      },
+      url: `/workspace/${workspace1.id}/invite-users`,
+      payload: [
+        {
+          email: 'joy@keyshade.xyz',
+          roleIds: [memberRole.id]
+        }
+      ]
+    })
+
+    expect(response.statusCode).toBe(201)
+
+    // Expect the user to have been created
+    const user = await prisma.user.findUnique({
+      where: {
+        email: 'joy@keyshade.xyz'
+      }
+    })
+
+    expect(user).toBeDefined()
+  })
+
   it('should be able to leave the workspace', async () => {
     // Create membership
     await createMembership(memberRole.id, user2.id, workspace1.id, prisma)


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Added validation in `WorkspaceService` to prevent assigning the admin role to users.
- Introduced a new method `getWorkspaceAdminRole` to fetch the admin role for a workspace.
- Updated `addMembersToWorkspace` method to include validation for admin role assignment.
- Refactored and extended end-to-end tests in `workspace.e2e.spec.ts` to cover new validation logic and other workspace functionalities.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Add validation for admin role assignment in workspace service.</code></dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts
<li>Added validation to prevent assigning admin role to users.<br> <li> Introduced <code>getWorkspaceAdminRole</code> method to fetch admin role.<br> <li> Updated <code>addMembersToWorkspace</code> to include admin role validation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/246/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+38/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Refactor and extend workspace end-to-end tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts
<li>Refactored and added new end-to-end tests for workspace <br>functionalities.<br> <li> Added tests for admin role assignment validation.<br> <li> Updated existing tests to align with new workspace service changes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/246/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+261/-181</a></td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

