### PR TITLE
test: Refactor workspace role e2e tests

### DIFF
--- a/apps/api/src/workspace-role/workspace-role.e2e.spec.ts
+++ b/apps/api/src/workspace-role/workspace-role.e2e.spec.ts
@@ -45,13 +45,7 @@ describe('Workspace Role Controller Tests', () => {
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
-      imports: [
-        AppModule,
-        WorkspaceRoleModule,
-        EventModule,
-        WorkspaceRoleModule,
-        UserModule
-      ]
+      imports: [AppModule, WorkspaceRoleModule, EventModule, UserModule]
     })
       .overrideProvider(MAIL_SERVICE)
       .useClass(MockMailService)

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -18,7 +18,6 @@ import {
   Workspace,
   WorkspaceRole
 } from '@prisma/client'
-import cleanUp from '../common/cleanup'
 import fetchEvents from '../common/fetch-events'
 import { EventService } from '../event/service/event.service'
 import { EventModule } from '../event/event.module'
@@ -1341,9 +1340,5 @@ describe('Workspace Controller Tests', () => {
       error: 'Bad Request',
       message: `You cannot transfer ownership of default workspace ${workspace1.name} (${workspace1.id})`
     })
-  })
-
-  afterAll(async () => {
-    await cleanUp(prisma)
   })
 })


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Refactored the `workspace-role.e2e.spec.ts` to use `UserService` for user creation, improving test setup and teardown with `beforeEach` and `afterEach` hooks.
- Removed direct Prisma calls for user and workspace creation in `workspace-role.e2e.spec.ts`.
- Updated test cases in `workspace-role.e2e.spec.ts` to align with the new setup.
- Removed `cleanUp` import and call in `afterAll` in `workspace.e2e.spec.ts`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace-role.e2e.spec.ts</strong><dd><code>Refactor workspace role e2e tests for improved setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace-role/workspace-role.e2e.spec.ts
<li>Refactored user creation to use <code>UserService</code>.<br> <li> Added <code>beforeEach</code> and <code>afterEach</code> hooks for test setup and teardown.<br> <li> Removed direct Prisma calls for user and workspace creation.<br> <li> Updated test cases to align with new setup.<br>


</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/248/files#diff-8cb77aad66a47879970bb3d9086df36f7477e273caf90a319c589e7a221cd30b">+107/-183</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Remove cleanup call in workspace e2e tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts
- Removed `cleanUp` import and call in `afterAll`.



</details>
    

  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/248/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

