### PR TITLE
feat(chore): Update auto-assign.yaml

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -15,7 +15,40 @@ jobs:
             const comment = context.payload.comment;
             const issue = context.issue;
             const owner = "keyshade-xyz";
-            const repo = "keyshade"
+            const repo = "keyshade";
+
+            async function updateProjectStatus(issueNumber) {
+              const projectsResponse = await github.rest.projects.listForRepo({
+                owner,
+                repo,
+                per_page: 100,
+              });
+
+              for (const project of projectsResponse.data) {
+                const columnsResponse = await github.rest.projects.listColumns({
+                  project_id: project.id,
+                  per_page: 100,
+                });
+
+                const inProgressColumn = columnsResponse.data.find(column => column.name === "In Progress");
+                if (!inProgressColumn) continue;
+
+                const cardsResponse = await github.rest.projects.listCards({
+                  column_id: inProgressColumn.id,
+                  per_page: 100,
+                });
+
+                const issueCardExists = cardsResponse.data.some(card => card.content_id === issueNumber && card.content_type === "Issue");
+
+                if (!issueCardExists) {
+                  await github.rest.projects.createCard({
+                    column_id: inProgressColumn.id,
+                    content_id: issueNumber,
+                    content_type: "Issue",
+                  });
+                }
+              }
+            }
 
             if (comment.body.startsWith('/attempt')) {
               if (!issue.assignee) {
@@ -23,20 +56,23 @@ jobs:
                   owner,
                   repo,
                   issue_number: issue.number,
-                  assignees: [comment.user.login]
+                  assignees: [comment.user.login],
                 });
+
                 await github.rest.issues.createComment({
                   owner,
                   repo,
                   issue_number: issue.number,
-                  body: `Assigned the issue to @${comment.user.login}!`
+                  body: `Assigned the issue to @${comment.user.login}!`,
                 });
+
+                await updateProjectStatus(issue.number);
               } else {
                 await github.rest.issues.createComment({
                   owner,
                   repo,
                   issue_number: issue.number,
-                  body: 'This issue is already assigned. Tag a maintainer if you need to take over.'
+                  body: 'This issue is already assigned. Tag a maintainer if you need to take over.',
                 });
               }
             }


### PR DESCRIPTION
## Description

>  Whenever someone uses /attempt on any issue, the GitHub action pipeline in auto-assign.yml assigns the commenter the issue. If the issue has any project associated with it, we would like to change its current status to "In Progress". An issue might have 0 to n number of projects assigned to it, we would like auto-assign.yml to be updated in a way to change the status of all these projects.

Feature implemented in PR.

Fixes #316

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens
N/A

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.
