### PR TITLE
feat(api): Add pagination metadata to Workspace module 

### DIFF
--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -468,7 +468,7 @@ export class WorkspaceService {
     //get all members of workspace for page with limit
     const items = await this.prisma.workspaceMember.findMany({
       skip: page * limit,
-      take: Number(limit),
+      take: limit,
       orderBy: {
         workspace: {
           [sort]: order
@@ -538,8 +538,8 @@ export class WorkspaceService {
     })
 
     const metadata = paginate(totalCount, `/workspace/${workspaceId}/members`, {
-      page: Number(page),
-      limit: Number(limit),
+      page,
+      limit,
       sort,
       order,
       search

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -1033,8 +1033,23 @@ describe('Workspace Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toBeInstanceOf(Array)
-    expect(response.json()).toHaveLength(1)
+    expect(response.json().items).toBeInstanceOf(Array)
+    expect(response.json().items).toHaveLength(1)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/workspace/${workspace1.id}/members?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/workspace/${workspace1.id}/members?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/workspace/${workspace1.id}/members?page=0&limit=10&sort=name&order=asc&search=`
+    )
   })
 
   it('should not be able to get all the members of the workspace if user is not a member', async () => {
@@ -1150,7 +1165,53 @@ describe('Workspace Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json().length).toEqual(2)
+    expect(response.json().items.length).toEqual(2)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toBe(2)
+    expect(metadata.links.self).toEqual(
+      `/workspace?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/workspace?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/workspace?page=0&limit=10&sort=name&order=asc&search=`
+    )
+  })
+
+  it('should be able to fetch the 2nd page of the workspaces the user is a member of', async () => {
+    await createMembership(memberRole.id, user2.id, workspace1.id, prisma)
+    const response = await app.inject({
+      method: 'GET',
+      headers: {
+        'x-e2e-user-email': user2.email
+      },
+      url: '/workspace?page=1&limit=1'
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().items).toHaveLength(1)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(2)
+    expect(metadata.links.self).toEqual(
+      `/workspace?page=1&limit=1&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/workspace?page=0&limit=1&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toEqual(
+      `/workspace?page=0&limit=1&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/workspace?page=1&limit=1&sort=name&order=asc&search=`
+    )
   })
 
   it('should be able to transfer the ownership of the workspace', async () => {

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -24,6 +24,7 @@ import { EventModule } from '../event/event.module'
 import { UserModule } from '../user/user.module'
 import { UserService } from '../user/service/user.service'
 import { WorkspaceService } from './service/workspace.service'
+import { QueryTransformPipe } from '../common/query.transform.pipe'
 
 const createMembership = async (
   adminRoleId: string,
@@ -74,6 +75,8 @@ describe('Workspace Controller Tests', () => {
     eventService = moduleRef.get(EventService)
     userService = moduleRef.get(UserService)
     workspaceService = moduleRef.get(WorkspaceService)
+
+    app.useGlobalPipes(new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()


### PR DESCRIPTION
## Description

- `getAllMembersOfWorkspace()` and `getWorkspacesOfUser()` in workspace.service.ts under api, now supports paginated outputs
- Modify 2 e2e tests and add 1 e2e test

Fixes #339

## Dependencies

_Mention any dependencies/packages used_

## Future Improvements
N/A

## Mentions

_Mention and tag the people_

## Screenshots of relevant screens
An extra e2e test for workspace module for varying page and limit params.
![image](https://github.com/user-attachments/assets/819c7679-e5a2-47d0-97d1-e903e925295a)

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
