### PR TITLE
feat(api): Add pagination metadata to Secret module

### DIFF
--- a/apps/api/src/secret/secret.e2e.spec.ts
+++ b/apps/api/src/secret/secret.e2e.spec.ts
@@ -596,16 +596,16 @@ describe('Secret Controller Tests', () => {
   it('should be able to fetch all secrets', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/secret/${project1.id}`,
+      url: `/secret/${project1.id}?page=0&limit=10`,
       headers: {
         'x-e2e-user-email': user1.email
       }
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json().length).toBe(1)
+    expect(response.json().items.length).toBe(1)
 
-    const { secret, values } = response.json()[0]
+    const { secret, values } = response.json().items[0]
     expect(secret.id).toBeDefined()
     expect(secret.name).toBeDefined()
     expect(secret.note).toBeDefined()
@@ -615,21 +615,36 @@ describe('Secret Controller Tests', () => {
     const value = values[0]
     expect(value.environment).toBeDefined()
     expect(value.value).not.toEqual('Secret 1 value')
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/secret/${project1.id}?decryptValue=false&page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/secret/${project1.id}?decryptValue=false&page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/secret/${project1.id}?decryptValue=false&page=0&limit=10&sort=name&order=asc&search=`
+    )
   })
 
   it('should be able to fetch all secrets decrypted', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/secret/${project1.id}?decryptValue=true`,
+      url: `/secret/${project1.id}?decryptValue=true&page=0&limit=10`,
       headers: {
         'x-e2e-user-email': user1.email
       }
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json().length).toBe(1)
+    expect(response.json().items.length).toBe(1)
 
-    const { secret, values } = response.json()[0]
+    const { secret, values } = response.json().items[0]
     expect(secret.id).toBeDefined()
     expect(secret.name).toBeDefined()
     expect(secret.note).toBeDefined()
@@ -639,6 +654,21 @@ describe('Secret Controller Tests', () => {
     const value = values[0]
     expect(value.environment).toBeDefined()
     expect(value.value).toEqual('Secret 1 value')
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/secret/${project1.id}?decryptValue=true&page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/secret/${project1.id}?decryptValue=true&page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/secret/${project1.id}?decryptValue=true&page=0&limit=10&sort=name&order=asc&search=`
+    )
   })
 
   it('should not be able to fetch all secrets decrypted if the project does not store the private key', async () => {

--- a/apps/api/src/secret/secret.e2e.spec.ts
+++ b/apps/api/src/secret/secret.e2e.spec.ts
@@ -36,6 +36,7 @@ import { RedisClientType } from 'redis'
 import { mockDeep } from 'jest-mock-extended'
 import { UserService } from '../user/service/user.service'
 import { UserModule } from '../user/user.module'
+import { QueryTransformPipe } from '../common/query.transform.pipe'
 
 describe('Secret Controller Tests', () => {
   let app: NestFastifyApplication
@@ -80,6 +81,8 @@ describe('Secret Controller Tests', () => {
     secretService = moduleRef.get(SecretService)
     eventService = moduleRef.get(EventService)
     userService = moduleRef.get(UserService)
+
+    app.useGlobalPipes(new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()

--- a/apps/api/src/secret/service/secret.service.ts
+++ b/apps/api/src/secret/service/secret.service.ts
@@ -531,7 +531,7 @@ export class SecretService {
         }
       },
       skip: page * limit,
-      take: Number(limit),
+      take: limit,
       orderBy: {
         [sort]: order
       }
@@ -632,8 +632,8 @@ export class SecretService {
       totalCount,
       `/secret/${projectId}`,
       {
-        page: Number(page),
-        limit: Number(limit),
+        page,
+        limit,
         sort,
         order,
         search


### PR DESCRIPTION
## Description
-  Add pagination metadata support for `getAllSecretsOfProject()` in secret.service.ts under API.
- Add test cases for metadata checks.

Fixes #341 

## Future Improvements

N/A

## Screenshots of relevant screens
One of the test case:
![image](https://github.com/user-attachments/assets/95a38b83-705f-4390-b921-9ab501257687)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
