### PR TITLE
feat(api): Add pagination metadata to Variable module

### DIFF
--- a/apps/api/src/variable/service/variable.service.ts
+++ b/apps/api/src/variable/service/variable.service.ts
@@ -521,7 +521,7 @@ export class VariableService {
         }
       },
       skip: page * limit,
-      take: Number(limit),
+      take: limit,
       orderBy: {
         [sort]: order
       }
@@ -615,8 +615,8 @@ export class VariableService {
     })
 
     const metadata = paginate(totalCount, `/variable/${projectId}`, {
-      page: Number(page),
-      limit: Number(limit),
+      page,
+      limit,
       sort,
       order,
       search

--- a/apps/api/src/variable/variable.e2e.spec.ts
+++ b/apps/api/src/variable/variable.e2e.spec.ts
@@ -36,6 +36,7 @@ import { mockDeep } from 'jest-mock-extended'
 import { RedisClientType } from 'redis'
 import { UserService } from '../user/service/user.service'
 import { UserModule } from '../user/user.module'
+import { QueryTransformPipe } from '../common/query.transform.pipe'
 
 describe('Variable Controller Tests', () => {
   let app: NestFastifyApplication
@@ -82,6 +83,8 @@ describe('Variable Controller Tests', () => {
     variableService = moduleRef.get(VariableService)
     eventService = moduleRef.get(EventService)
     userService = moduleRef.get(UserService)
+
+    app.useGlobalPipes(new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()

--- a/apps/api/src/variable/variable.e2e.spec.ts
+++ b/apps/api/src/variable/variable.e2e.spec.ts
@@ -575,16 +575,16 @@ describe('Variable Controller Tests', () => {
   it('should be able to fetch all variables', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/variable/${project1.id}`,
+      url: `/variable/${project1.id}?page=0&limit=10`,
       headers: {
         'x-e2e-user-email': user1.email
       }
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json().length).toBe(1)
+    expect(response.json().items.length).toBe(1)
 
-    const { variable, values } = response.json()[0]
+    const { variable, values } = response.json().items[0]
     expect(variable).toBeDefined()
     expect(values).toBeDefined()
     expect(values.length).toBe(1)
@@ -592,6 +592,21 @@ describe('Variable Controller Tests', () => {
     expect(values[0].environment.id).toBe(environment1.id)
     expect(variable.id).toBe(variable1.id)
     expect(variable.name).toBe('Variable 1')
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/variable/${project1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/variable/${project1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/variable/${project1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
   })
 
   it('should not be able to fetch all variables if the user has no access to the project', async () => {


### PR DESCRIPTION
## Description

- Paginated response support for `getAllVariablesOfProject()` for variable.service.ts under API.
- Updated test cases to reflect the reponse.

Fixes #342 

## Future Improvements

N/A

## Screenshots of relevant screens
Glance of metadata checks:
![image](https://github.com/user-attachments/assets/8db9c1b5-fe0f-4ec7-90c2-4e0b50f4d9db)

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required. 