### PR TITLE
feat(api): Add pagination metadata to Integration module

### DIFF
--- a/apps/api/src/integration/controller/integration.controller.ts
+++ b/apps/api/src/integration/controller/integration.controller.ts
@@ -66,13 +66,12 @@ export class IntegrationController {
   }
 
   /* istanbul ignore next */
-  // The e2e tests are not working, but the API calls work as expected
   @Get('all/:workspaceId')
   @RequiredApiKeyAuthorities(Authority.READ_INTEGRATION)
   async getAllIntegrations(
     @CurrentUser() user: User,
     @Param('workspaceId') workspaceId: string,
-    @Query('page') page: number = 1,
+    @Query('page') page: number = 0,
     @Query('limit') limit: number = 10,
     @Query('sort') sort: string = 'name',
     @Query('order') order: string = 'asc',

--- a/apps/api/src/integration/integration.e2e.spec.ts
+++ b/apps/api/src/integration/integration.e2e.spec.ts
@@ -599,6 +599,33 @@ describe('Integration Controller Tests', () => {
     expect(result.json().id).toEqual(integration1.id)
   })
 
+  it('should be able to fetch all integrations on first page', async () => {
+    const result = await app.inject({
+      method: 'GET',
+      url: `/integration/all/${workspace1.id}`,
+      headers: {
+        'x-e2e-user-email': user1.email
+      }
+    })
+
+    expect(result.statusCode).toEqual(200)
+    expect(result.json().items).toHaveLength(1)
+
+    //check metadata
+    const metadata = result.json().metadata
+    expect(metadata.links.self).toEqual(
+      `/integration/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/integration/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/integration/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+  })
+
   it('should not be able to fetch an integration that does not exist', async () => {
     const result = await app.inject({
       method: 'GET',

--- a/apps/api/src/integration/integration.e2e.spec.ts
+++ b/apps/api/src/integration/integration.e2e.spec.ts
@@ -26,6 +26,7 @@ import { MAIL_SERVICE } from '../mail/services/interface.service'
 import { MockMailService } from '../mail/services/mock.service'
 import { EnvironmentModule } from '../environment/environment.module'
 import { EnvironmentService } from '../environment/service/environment.service'
+import { QueryTransformPipe } from '../common/query.transform.pipe'
 
 describe('Integration Controller Tests', () => {
   let app: NestFastifyApplication
@@ -65,6 +66,8 @@ describe('Integration Controller Tests', () => {
     workspaceService = moduleRef.get(WorkspaceService)
     projectService = moduleRef.get(ProjectService)
     environmentService = moduleRef.get(EnvironmentService)
+
+    app.useGlobalPipes(new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()
@@ -602,7 +605,7 @@ describe('Integration Controller Tests', () => {
   it('should be able to fetch all integrations on first page', async () => {
     const result = await app.inject({
       method: 'GET',
-      url: `/integration/all/${workspace1.id}`,
+      url: `/integration/all/${workspace1.id}?page=0&limit=10`,
       headers: {
         'x-e2e-user-email': user1.email
       }
@@ -613,6 +616,7 @@ describe('Integration Controller Tests', () => {
 
     //check metadata
     const metadata = result.json().metadata
+    expect(metadata.totalCount).toEqual(1)
     expect(metadata.links.self).toEqual(
       `/integration/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
     )

--- a/apps/api/src/integration/service/integration.service.ts
+++ b/apps/api/src/integration/service/integration.service.ts
@@ -18,6 +18,7 @@ import { UpdateIntegration } from '../dto/update.integration/update.integration'
 import { AuthorityCheckerService } from '../../common/authority-checker.service'
 import createEvent from '../../common/create-event'
 import IntegrationFactory from '../plugins/factory/integration.factory'
+import { paginate } from '../../common/paginate'
 
 @Injectable()
 export class IntegrationService {
@@ -296,13 +297,40 @@ export class IntegrationService {
         ]
       },
       skip: page * limit,
-      take: limit,
+      take: Number(limit),
       orderBy: {
         [sort]: order
       }
     })
 
-    return integrations
+    //calculate metadata for pagination
+    const totalCount = await this.prisma.integration.count({
+      where: {
+        name: {
+          contains: search
+        },
+        workspaceId,
+        OR: [
+          {
+            projectId: null
+          },
+          {
+            projectId: {
+              in: projectIds
+            }
+          }
+        ]
+      }
+    })
+    const metadata = paginate(totalCount, `/integration/all/${workspaceId}`, {
+      page: Number(page),
+      limit: Number(limit),
+      sort,
+      order,
+      search
+    })
+
+    return { items: integrations, metadata }
   }
 
   async deleteIntegration(user: User, integrationId: Integration['id']) {

--- a/apps/api/src/integration/service/integration.service.ts
+++ b/apps/api/src/integration/service/integration.service.ts
@@ -297,7 +297,7 @@ export class IntegrationService {
         ]
       },
       skip: page * limit,
-      take: Number(limit),
+      take: limit,
       orderBy: {
         [sort]: order
       }
@@ -323,8 +323,8 @@ export class IntegrationService {
       }
     })
     const metadata = paginate(totalCount, `/integration/all/${workspaceId}`, {
-      page: Number(page),
-      limit: Number(limit),
+      page,
+      limit,
       sort,
       order,
       search


### PR DESCRIPTION
## Description

- Add paginated metadata response support for `getAllIntegrationsOfWorkspace()` of integration.service.ts under API
- Add extra test case
- Fix e2e test not working for `getAllIntegrations()` Controller.

Fixes #343 

## Future Improvements
N/A

## Screenshots
E2E tests failure due to default page set to 1:
![image](https://github.com/user-attachments/assets/cebbeb53-43d4-40d9-a271-ec0c0c713c59)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
