### PR TITLE
feat(api): Add pagination metadata to Project module

### DIFF
--- a/apps/api/src/project/project.e2e.spec.ts
+++ b/apps/api/src/project/project.e2e.spec.ts
@@ -463,14 +463,29 @@ describe('Project Controller Tests', () => {
   it('should be able to fetch all projects of a workspace', async () => {
     const response = await app.inject({
       method: 'GET',
-      url: `/project/all/${workspace1.id}?page=0`,
+      url: `/project/all/${workspace1.id}?page=0&limit=10`,
       headers: {
         'x-e2e-user-email': user1.email
       }
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json().length).toEqual(2)
+    expect(response.json().items.length).toEqual(2)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(2)
+    expect(metadata.links.self).toBe(
+      `/project/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.first).toBe(
+      `/project/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
+    expect(metadata.links.previous).toEqual(null)
+    expect(metadata.links.next).toEqual(null)
+    expect(metadata.links.last).toBe(
+      `/project/all/${workspace1.id}?page=0&limit=10&sort=name&order=asc&search=`
+    )
   })
 
   it('should not be able to fetch all projects of a non existing workspace', async () => {
@@ -1722,9 +1737,22 @@ describe('Project Controller Tests', () => {
           'x-e2e-user-email': user2.email
         }
       })
-
       expect(response.statusCode).toBe(200)
-      expect(response.json()).toHaveLength(1)
+      expect(response.json().items).toHaveLength(1)
+
+      //check metadata
+      const metadata = response.json().metadata
+      expect(metadata.links.self).toBe(
+        `/project/${project3.id}/forks?page=0&limit=10`
+      )
+      expect(metadata.links.first).toBe(
+        `/project/${project3.id}/forks?page=0&limit=10`
+      )
+      expect(metadata.links.previous).toEqual(null)
+      expect(metadata.links.next).toEqual(null)
+      expect(metadata.links.last).toBe(
+        `/project/${project3.id}/forks?page=0&limit=10`
+      )
     })
 
     it('should not contain a forked project that has access level other than GLOBAL', async () => {
@@ -1754,7 +1782,7 @@ describe('Project Controller Tests', () => {
       })
 
       expect(response.statusCode).toBe(200)
-      expect(response.json()).toHaveLength(1)
+      expect(response.json().items).toHaveLength(1)
     })
   })
 })

--- a/apps/api/src/project/project.e2e.spec.ts
+++ b/apps/api/src/project/project.e2e.spec.ts
@@ -38,6 +38,7 @@ import { VariableService } from '../variable/service/variable.service'
 import { VariableModule } from '../variable/variable.module'
 import { SecretModule } from '../secret/secret.module'
 import { EnvironmentModule } from '../environment/environment.module'
+import { QueryTransformPipe } from '../common/query.transform.pipe'
 
 describe('Project Controller Tests', () => {
   let app: NestFastifyApplication
@@ -85,6 +86,8 @@ describe('Project Controller Tests', () => {
     environmentService = moduleRef.get(EnvironmentService)
     secretService = moduleRef.get(SecretService)
     variableService = moduleRef.get(VariableService)
+
+    app.useGlobalPipes(new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()

--- a/apps/api/src/project/service/project.service.ts
+++ b/apps/api/src/project/service/project.service.ts
@@ -612,8 +612,8 @@ export class ProjectService {
       forksAllowed.length,
       `/project/${projectId}/forks`,
       {
-        page: Number(page),
-        limit: Number(limit)
+        page,
+        limit
       }
     )
 
@@ -654,7 +654,7 @@ export class ProjectService {
     const items = (
       await this.prisma.project.findMany({
         skip: page * limit,
-        take: Number(limit),
+        take: limit,
         orderBy: {
           [sort]: order
         },
@@ -710,8 +710,8 @@ export class ProjectService {
     })
 
     const metadata = paginate(totalCount, `/project/all/${workspaceId}`, {
-      page: Number(page),
-      limit: Number(limit),
+      page,
+      limit,
       sort,
       order,
       search


### PR DESCRIPTION
## Description

- Add support for paginated response in `getProjectsOfWorkspace()` and `getAllProjectForks()` of project.service.ts under API.
- Add and improve required tests.
- Hard-coded page and limit, to be more strict in tests.

Fixes #338
Fixes #369 , since pagination is dependant on totalCount, therefore checking authority for all project might be a good option.

## Future Improvements
- Explicit number conversion in prisma query as well as in paginate's arguments could be ignored.

## Screenshots of relevant screens
Some tests:
![image](https://github.com/user-attachments/assets/90b42927-a727-40ba-b768-c22c8281b18f)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
