### PR TITLE
feat(api): Add pagination metadata to Event module

### DIFF
--- a/apps/api/src/environment/environment.e2e.spec.ts
+++ b/apps/api/src/environment/environment.e2e.spec.ts
@@ -235,7 +235,7 @@ describe('Environment Controller Tests', () => {
       EventSource.ENVIRONMENT
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.ENVIRONMENT)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -344,7 +344,7 @@ describe('Environment Controller Tests', () => {
       EventSource.ENVIRONMENT
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.ENVIRONMENT)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -459,7 +459,7 @@ describe('Environment Controller Tests', () => {
       EventSource.ENVIRONMENT
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.ENVIRONMENT)
     expect(event.triggerer).toBe(EventTriggerer.USER)

--- a/apps/api/src/event/event.e2e.spec.ts
+++ b/apps/api/src/event/event.e2e.spec.ts
@@ -35,6 +35,7 @@ import { EnvironmentModule } from '../environment/environment.module'
 import createEvent from '../common/create-event'
 import { VariableService } from '../variable/service/variable.service'
 import { VariableModule } from '../variable/variable.module'
+import { QueryTransformPipe } from '../common/query.transform.pipe'
 
 describe('Event Controller Tests', () => {
   let app: NestFastifyApplication
@@ -79,6 +80,8 @@ describe('Event Controller Tests', () => {
     projectService = moduleRef.get(ProjectService)
     secretService = moduleRef.get(SecretService)
     variableService = moduleRef.get(VariableService)
+
+    app.useGlobalPipes(new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()

--- a/apps/api/src/event/event.e2e.spec.ts
+++ b/apps/api/src/event/event.e2e.spec.ts
@@ -115,9 +115,8 @@ describe('Event Controller Tests', () => {
         'x-e2e-user-email': user.email
       }
     })
-
     expect(response.statusCode).toBe(200)
-    const event = response.json()[0]
+    const event = response.json().items[0]
 
     expect(event.id).toBeDefined()
     expect(event.title).toBeDefined()
@@ -129,6 +128,21 @@ describe('Event Controller Tests', () => {
     expect(event.itemId).toBe(newWorkspace.id)
     expect(event.userId).toBe(user.id)
     expect(event.workspaceId).toBe(newWorkspace.id)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/event/${newWorkspace.id}?source=WORKSPACE&page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${newWorkspace.id}?source=WORKSPACE&page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${newWorkspace.id}?source=WORKSPACE&page=0&limit=10&search=`
+    )
   })
 
   it('should be able to fetch a project event', async () => {
@@ -152,7 +166,7 @@ describe('Event Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    const event = response.json()[0]
+    const event = response.json().items[0]
 
     expect(event.id).toBeDefined()
     expect(event.title).toBeDefined()
@@ -164,6 +178,21 @@ describe('Event Controller Tests', () => {
     expect(event.itemId).toBe(newProject.id)
     expect(event.userId).toBe(user.id)
     expect(event.workspaceId).toBe(workspace.id)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?source=PROJECT&page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?source=PROJECT&page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?source=PROJECT&page=0&limit=10&search=`
+    )
   })
 
   it('should be able to fetch an environment event', async () => {
@@ -188,7 +217,7 @@ describe('Event Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    const event = response.json()[0]
+    const event = response.json().items[0]
 
     expect(event.id).toBeDefined()
     expect(event.title).toBeDefined()
@@ -200,6 +229,21 @@ describe('Event Controller Tests', () => {
     expect(event.itemId).toBe(newEnvironment.id)
     expect(event.userId).toBe(user.id)
     expect(event.workspaceId).toBe(workspace.id)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?source=ENVIRONMENT&page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?source=ENVIRONMENT&page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?source=ENVIRONMENT&page=0&limit=10&search=`
+    )
   })
 
   it('should be able to fetch a secret event', async () => {
@@ -230,7 +274,7 @@ describe('Event Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    const event = response.json()[0]
+    const event = response.json().items[0]
 
     expect(event.id).toBeDefined()
     expect(event.title).toBeDefined()
@@ -242,6 +286,21 @@ describe('Event Controller Tests', () => {
     expect(event.itemId).toBe(newSecret.id)
     expect(event.userId).toBe(user.id)
     expect(event.workspaceId).toBe(workspace.id)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?source=SECRET&page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?source=SECRET&page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?source=SECRET&page=0&limit=10&search=`
+    )
   })
 
   it('should be able to fetch a variable event', async () => {
@@ -272,7 +331,7 @@ describe('Event Controller Tests', () => {
 
     expect(response.statusCode).toBe(200)
     // expect(response.json()).toBe({})
-    const event = response.json()[0]
+    const event = response.json().items[0]
 
     expect(event.id).toBeDefined()
     expect(event.title).toBeDefined()
@@ -284,6 +343,21 @@ describe('Event Controller Tests', () => {
     expect(event.itemId).toBe(newVariable.id)
     expect(event.userId).toBe(user.id)
     expect(event.workspaceId).toBe(workspace.id)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?source=VARIABLE&page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?source=VARIABLE&page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?source=VARIABLE&page=0&limit=10&search=`
+    )
   })
 
   it('should be able to fetch a workspace role event', async () => {
@@ -310,7 +384,7 @@ describe('Event Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    const event = response.json()[0]
+    const event = response.json().items[0]
 
     expect(event.id).toBeDefined()
     expect(event.title).toBeDefined()
@@ -322,6 +396,21 @@ describe('Event Controller Tests', () => {
     expect(event.itemId).toBe(newWorkspaceRole.id)
     expect(event.userId).toBe(user.id)
     expect(event.workspaceId).toBe(workspace.id)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(1)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?source=WORKSPACE_ROLE&page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?source=WORKSPACE_ROLE&page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?source=WORKSPACE_ROLE&page=0&limit=10&search=`
+    )
   })
 
   it('should be able to fetch all events', async () => {
@@ -334,7 +423,52 @@ describe('Event Controller Tests', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toHaveLength(6)
+    expect(response.json().items).toHaveLength(6)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(6)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?page=0&limit=10&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?page=0&limit=10&search=`
+    )
+    expect(metadata.links.previous).toBeNull()
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?page=0&limit=10&search=`
+    )
+  })
+
+  it('should be able to fetch 2nd page of all events', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/event/${workspace.id}?page=1&limit=3&`,
+      headers: {
+        'x-e2e-user-email': user.email
+      }
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json().items).toHaveLength(3)
+
+    //check metadata
+    const metadata = response.json().metadata
+    expect(metadata.totalCount).toEqual(6)
+    expect(metadata.links.self).toEqual(
+      `/event/${workspace.id}?page=1&limit=3&search=`
+    )
+    expect(metadata.links.first).toEqual(
+      `/event/${workspace.id}?page=0&limit=3&search=`
+    )
+    expect(metadata.links.previous).toEqual(
+      `/event/${workspace.id}?page=0&limit=3&search=`
+    )
+    expect(metadata.links.next).toBeNull()
+    expect(metadata.links.last).toEqual(
+      `/event/${workspace.id}?page=1&limit=3&search=`
+    )
   })
 
   it('should throw an error with wrong severity value', async () => {

--- a/apps/api/src/event/service/event.service.ts
+++ b/apps/api/src/event/service/event.service.ts
@@ -44,7 +44,7 @@ export class EventService {
         }
       },
       skip: page * limit,
-      take: Number(limit),
+      take: limit,
       orderBy: {
         timestamp: 'desc'
       }
@@ -66,8 +66,8 @@ export class EventService {
       totalCount,
       `/event/${workspaceId}`,
       {
-        page: Number(page),
-        limit: Number(limit),
+        page,
+        limit,
         search
       },
       { source }

--- a/apps/api/src/project/project.e2e.spec.ts
+++ b/apps/api/src/project/project.e2e.spec.ts
@@ -225,7 +225,7 @@ describe('Project Controller Tests', () => {
       EventSource.PROJECT
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.PROJECT)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -401,7 +401,7 @@ describe('Project Controller Tests', () => {
       EventSource.PROJECT
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.PROJECT)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -650,7 +650,7 @@ describe('Project Controller Tests', () => {
       EventSource.PROJECT
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.PROJECT)
     expect(event.triggerer).toBe(EventTriggerer.USER)

--- a/apps/api/src/secret/secret.e2e.spec.ts
+++ b/apps/api/src/secret/secret.e2e.spec.ts
@@ -291,7 +291,7 @@ describe('Secret Controller Tests', () => {
       EventSource.SECRET
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.SECRET)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -410,7 +410,7 @@ describe('Secret Controller Tests', () => {
       EventSource.SECRET
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.SECRET)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -911,7 +911,7 @@ describe('Secret Controller Tests', () => {
       EventSource.SECRET
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.SECRET)
     expect(event.triggerer).toBe(EventTriggerer.USER)

--- a/apps/api/src/variable/variable.e2e.spec.ts
+++ b/apps/api/src/variable/variable.e2e.spec.ts
@@ -292,7 +292,7 @@ describe('Variable Controller Tests', () => {
       EventSource.VARIABLE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.VARIABLE)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -430,7 +430,7 @@ describe('Variable Controller Tests', () => {
       EventSource.VARIABLE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.VARIABLE)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -755,7 +755,7 @@ describe('Variable Controller Tests', () => {
       EventSource.VARIABLE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.VARIABLE)
     expect(event.triggerer).toBe(EventTriggerer.USER)

--- a/apps/api/src/workspace-role/workspace-role.e2e.spec.ts
+++ b/apps/api/src/workspace-role/workspace-role.e2e.spec.ts
@@ -253,7 +253,7 @@ describe('Workspace Role Controller Tests', () => {
       EventSource.WORKSPACE_ROLE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.WORKSPACE_ROLE)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -407,7 +407,7 @@ describe('Workspace Role Controller Tests', () => {
       EventSource.WORKSPACE_ROLE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.WORKSPACE_ROLE)
     expect(event.triggerer).toBe(EventTriggerer.USER)
@@ -628,7 +628,7 @@ describe('Workspace Role Controller Tests', () => {
       EventSource.WORKSPACE_ROLE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event.source).toBe(EventSource.WORKSPACE_ROLE)
     expect(event.triggerer).toBe(EventTriggerer.USER)

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -225,7 +225,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -343,7 +343,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -488,7 +488,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -566,7 +566,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -644,7 +644,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -722,7 +722,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -834,7 +834,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -898,7 +898,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)
@@ -967,7 +967,7 @@ describe('Workspace Controller Tests', () => {
       EventSource.WORKSPACE
     )
 
-    const event = response[0]
+    const event = response.items[0]
 
     expect(event).toBeDefined()
     expect(event.source).toBe(EventSource.WORKSPACE)


### PR DESCRIPTION
## Description

- Add support for paginated response for `getEvents()` of event.service.ts under API.
- Add and improve relevant test cases.
- Modify event variable's value in affected modules' e2e, where state of events are queried.

Fixes #344

Also, Fixes #336 after merging this and #382 #387 #388 #389 #390 #391 #393.

## Dependencies
N/A

## Future Improvements
N/A

## Screenshots of relevant screens
Extra test:
![image](https://github.com/user-attachments/assets/83676a3a-5054-4663-baf6-2fca76b26742)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
