### PR TITLE
feat(API): Included default workspace details in getSelf function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ tmp
 
 # dependencies
 node_modules
-
+package-lock.json
 # IDEs and editors
 /.idea
 .project

--- a/apps/api/src/user/service/user.service.ts
+++ b/apps/api/src/user/service/user.service.ts
@@ -30,7 +30,26 @@ export class UserService {
   }
 
   async getSelf(user: User) {
-    return user
+    let defaultWorkspace = null
+    if (!user.isAdmin) {
+      defaultWorkspace = await this.prisma.workspace.findFirst({
+        where: {
+          ownerId: user.id,
+          isDefault: true
+        },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          isFreeTier: true,
+          createdAt: true,
+          updatedAt: true,
+          lastUpdatedById: true
+        }
+      })
+    }
+
+    return { ...user, defaultWorkspace }
   }
 
   async updateSelf(user: User, dto: UpdateUserDto) {

--- a/apps/api/src/user/service/user.service.ts
+++ b/apps/api/src/user/service/user.service.ts
@@ -37,12 +37,7 @@ export class UserService {
       },
       select: {
         id: true,
-        name: true,
-        description: true,
-        isFreeTier: true,
-        createdAt: true,
-        updatedAt: true,
-        lastUpdatedById: true
+        name: true
       }
     })
 

--- a/apps/api/src/user/service/user.service.ts
+++ b/apps/api/src/user/service/user.service.ts
@@ -6,7 +6,7 @@ import {
   UnauthorizedException
 } from '@nestjs/common'
 import { UpdateUserDto } from '../dto/update.user/update.user'
-import { AuthProvider, User } from '@prisma/client'
+import { AuthProvider, User, Workspace } from '@prisma/client'
 import { PrismaService } from '@/prisma/prisma.service'
 import { CreateUserDto } from '../dto/create.user/create.user'
 import { IMailService, MAIL_SERVICE } from '@/mail/services/interface.service'
@@ -30,16 +30,13 @@ export class UserService {
   }
 
   async getSelf(user: User) {
-    const defaultWorkspace = await this.prisma.workspace.findFirst({
-      where: {
-        ownerId: user.id,
-        isDefault: true
-      },
-      select: {
-        id: true,
-        name: true
-      }
-    })
+    const defaultWorkspace: Workspace | null =
+      await this.prisma.workspace.findFirst({
+        where: {
+          ownerId: user.id,
+          isDefault: true
+        }
+      })
 
     return { ...user, defaultWorkspace }
   }

--- a/apps/api/src/user/service/user.service.ts
+++ b/apps/api/src/user/service/user.service.ts
@@ -30,24 +30,21 @@ export class UserService {
   }
 
   async getSelf(user: User) {
-    let defaultWorkspace = null
-    if (!user.isAdmin) {
-      defaultWorkspace = await this.prisma.workspace.findFirst({
-        where: {
-          ownerId: user.id,
-          isDefault: true
-        },
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          isFreeTier: true,
-          createdAt: true,
-          updatedAt: true,
-          lastUpdatedById: true
-        }
-      })
-    }
+    const defaultWorkspace = await this.prisma.workspace.findFirst({
+      where: {
+        ownerId: user.id,
+        isDefault: true
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        isFreeTier: true,
+        createdAt: true,
+        updatedAt: true,
+        lastUpdatedById: true
+      }
+    })
 
     return { ...user, defaultWorkspace }
   }

--- a/apps/api/src/user/user.e2e.spec.ts
+++ b/apps/api/src/user/user.e2e.spec.ts
@@ -111,12 +111,7 @@ describe('User Controller Tests', () => {
 
     expect(result.json().defaultWorkspace).toMatchObject({
       id: workspace.id,
-      name: workspace.name,
-      description: workspace.description,
-      isFreeTier: workspace.isFreeTier,
-      createdAt: workspace.createdAt.toISOString(),
-      updatedAt: workspace.updatedAt.toISOString(),
-      lastUpdatedById: workspace.lastUpdatedById
+      name: workspace.name
     })
   })
 

--- a/apps/api/src/user/user.e2e.spec.ts
+++ b/apps/api/src/user/user.e2e.spec.ts
@@ -82,7 +82,8 @@ describe('User Controller Tests', () => {
     })
     expect(result.statusCode).toEqual(200)
     expect(JSON.parse(result.body)).toEqual({
-      ...adminUser
+      ...adminUser,
+      defaultWorkspace: null
     })
   })
 
@@ -94,10 +95,37 @@ describe('User Controller Tests', () => {
         'x-e2e-user-email': regularUser.email
       }
     })
+
+    const workspace = await prisma.workspace.findFirst({
+      where: {
+        ownerId: regularUser.id,
+        isDefault: true
+      }
+    })
+
     expect(result.statusCode).toEqual(200)
     expect(JSON.parse(result.body)).toEqual({
-      ...regularUser
+      ...regularUser,
+      defaultWorkspace: expect.any(Object)
     })
+
+    expect(result.json().defaultWorkspace.id).toEqual(workspace.id)
+    expect(result.json().defaultWorkspace.name).toEqual(workspace.name)
+    expect(result.json().defaultWorkspace.description).toEqual(
+      workspace.description
+    )
+    expect(result.json().defaultWorkspace.isFreeTier).toEqual(
+      workspace.isFreeTier
+    )
+    expect(result.json().defaultWorkspace.createdAt).toEqual(
+      workspace.createdAt.toISOString()
+    )
+    expect(result.json().defaultWorkspace.updatedAt).toEqual(
+      workspace.updatedAt.toISOString()
+    )
+    expect(result.json().defaultWorkspace.lastUpdatedById).toEqual(
+      workspace.lastUpdatedById
+    )
   })
 
   it('should have created a default workspace', async () => {

--- a/apps/api/src/user/user.e2e.spec.ts
+++ b/apps/api/src/user/user.e2e.spec.ts
@@ -109,23 +109,15 @@ describe('User Controller Tests', () => {
       defaultWorkspace: expect.any(Object)
     })
 
-    expect(result.json().defaultWorkspace.id).toEqual(workspace.id)
-    expect(result.json().defaultWorkspace.name).toEqual(workspace.name)
-    expect(result.json().defaultWorkspace.description).toEqual(
-      workspace.description
-    )
-    expect(result.json().defaultWorkspace.isFreeTier).toEqual(
-      workspace.isFreeTier
-    )
-    expect(result.json().defaultWorkspace.createdAt).toEqual(
-      workspace.createdAt.toISOString()
-    )
-    expect(result.json().defaultWorkspace.updatedAt).toEqual(
-      workspace.updatedAt.toISOString()
-    )
-    expect(result.json().defaultWorkspace.lastUpdatedById).toEqual(
-      workspace.lastUpdatedById
-    )
+    expect(result.json().defaultWorkspace).toMatchObject({
+      id: workspace.id,
+      name: workspace.name,
+      description: workspace.description,
+      isFreeTier: workspace.isFreeTier,
+      createdAt: workspace.createdAt.toISOString(),
+      updatedAt: workspace.updatedAt.toISOString(),
+      lastUpdatedById: workspace.lastUpdatedById
+    })
   })
 
   it('should have created a default workspace', async () => {

--- a/packages/eslint-config-custom/package-lock.json
+++ b/packages/eslint-config-custom/package-lock.json
@@ -1,0 +1,174 @@
+{
+	"name": "eslint-config-custom",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "eslint-config-custom",
+			"version": "0.0.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@vercel/style-guide": "^5.0.0",
+				"eslint-config-turbo": "^1.10.12",
+				"typescript": "^4.5.3"
+			}
+		},
+		"../../node_modules/.pnpm/@vercel+style-guide@5.2.0_@next+eslint-plugin-next@13.5.6_eslint@8.57.0_jest@29.7.0_@types+no_sdq2icpzhfmze3wlrhq5gaoyxi/node_modules/@vercel/style-guide": {
+			"version": "5.2.0",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"@babel/core": "^7.22.11",
+				"@babel/eslint-parser": "^7.22.11",
+				"@rushstack/eslint-patch": "^1.3.3",
+				"@typescript-eslint/eslint-plugin": "^6.5.0",
+				"@typescript-eslint/parser": "^6.5.0",
+				"eslint-config-prettier": "^9.0.0",
+				"eslint-import-resolver-alias": "^1.1.2",
+				"eslint-import-resolver-typescript": "^3.6.0",
+				"eslint-plugin-eslint-comments": "^3.2.0",
+				"eslint-plugin-import": "^2.28.1",
+				"eslint-plugin-jest": "^27.2.3",
+				"eslint-plugin-jsx-a11y": "^6.7.1",
+				"eslint-plugin-playwright": "^0.16.0",
+				"eslint-plugin-react": "^7.33.2",
+				"eslint-plugin-react-hooks": "^4.6.0",
+				"eslint-plugin-testing-library": "^6.0.1",
+				"eslint-plugin-tsdoc": "^0.2.17",
+				"eslint-plugin-unicorn": "^48.0.1",
+				"prettier-plugin-packagejson": "^2.4.5"
+			},
+			"devDependencies": {
+				"@commitlint/cli": "^17.7.1",
+				"@commitlint/config-conventional": "^17.7.0",
+				"@semantic-release/git": "^10.0.1",
+				"eslint": "^8.48.0",
+				"husky": "^8.0.3",
+				"lint-staged": "^14.0.1",
+				"prettier": "^3.0.2",
+				"semantic-release": "^21.1.1",
+				"typescript": "^5.2.2"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"@next/eslint-plugin-next": ">=12.3.0 <15",
+				"eslint": ">=8.48.0 <9",
+				"prettier": ">=3.0.0 <4",
+				"typescript": ">=4.8.0 <6"
+			},
+			"peerDependenciesMeta": {
+				"@next/eslint-plugin-next": {
+					"optional": true
+				},
+				"eslint": {
+					"optional": true
+				},
+				"prettier": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"../../node_modules/.pnpm/eslint-config-turbo@1.13.4_eslint@8.57.0/node_modules/eslint-config-turbo": {
+			"version": "1.13.4",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"eslint-plugin-turbo": "1.13.4"
+			},
+			"devDependencies": {
+				"@turbo/eslint-config": "0.0.0",
+				"@types/eslint": "^8.44.2"
+			},
+			"peerDependencies": {
+				"eslint": ">6.6.0"
+			}
+		},
+		"../../node_modules/.pnpm/typescript@4.9.5/node_modules/typescript": {
+			"version": "4.9.5",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"devDependencies": {
+				"@octokit/rest": "latest",
+				"@types/chai": "latest",
+				"@types/fancy-log": "^2.0.0",
+				"@types/fs-extra": "^9.0.13",
+				"@types/glob": "latest",
+				"@types/gulp": "^4.0.9",
+				"@types/gulp-concat": "latest",
+				"@types/gulp-newer": "latest",
+				"@types/gulp-rename": "latest",
+				"@types/gulp-sourcemaps": "latest",
+				"@types/merge2": "latest",
+				"@types/microsoft__typescript-etw": "latest",
+				"@types/minimist": "latest",
+				"@types/mkdirp": "latest",
+				"@types/mocha": "latest",
+				"@types/ms": "latest",
+				"@types/node": "latest",
+				"@types/source-map-support": "latest",
+				"@types/which": "^2.0.1",
+				"@types/xml2js": "^0.4.11",
+				"@typescript-eslint/eslint-plugin": "^5.33.1",
+				"@typescript-eslint/parser": "^5.33.1",
+				"@typescript-eslint/utils": "^5.33.1",
+				"azure-devops-node-api": "^11.2.0",
+				"chai": "latest",
+				"chalk": "^4.1.2",
+				"del": "^6.1.1",
+				"diff": "^5.1.0",
+				"eslint": "^8.22.0",
+				"eslint-formatter-autolinkable-stylish": "^1.2.0",
+				"eslint-plugin-import": "^2.26.0",
+				"eslint-plugin-jsdoc": "^39.3.6",
+				"eslint-plugin-local": "^1.0.0",
+				"eslint-plugin-no-null": "^1.0.2",
+				"fancy-log": "latest",
+				"fs-extra": "^9.1.0",
+				"glob": "latest",
+				"gulp": "^4.0.2",
+				"gulp-concat": "latest",
+				"gulp-insert": "latest",
+				"gulp-newer": "latest",
+				"gulp-rename": "latest",
+				"gulp-sourcemaps": "latest",
+				"merge2": "latest",
+				"minimist": "latest",
+				"mkdirp": "latest",
+				"mocha": "latest",
+				"mocha-fivemat-progress-reporter": "latest",
+				"ms": "^2.1.3",
+				"node-fetch": "^3.2.10",
+				"source-map-support": "latest",
+				"typescript": "^4.8.4",
+				"vinyl": "latest",
+				"which": "^2.0.2",
+				"xml2js": "^0.4.23"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/@vercel/style-guide": {
+			"resolved": "../../node_modules/.pnpm/@vercel+style-guide@5.2.0_@next+eslint-plugin-next@13.5.6_eslint@8.57.0_jest@29.7.0_@types+no_sdq2icpzhfmze3wlrhq5gaoyxi/node_modules/@vercel/style-guide",
+			"link": true
+		},
+		"node_modules/eslint-config-turbo": {
+			"resolved": "../../node_modules/.pnpm/eslint-config-turbo@1.13.4_eslint@8.57.0/node_modules/eslint-config-turbo",
+			"link": true
+		},
+		"node_modules/typescript": {
+			"resolved": "../../node_modules/.pnpm/typescript@4.9.5/node_modules/typescript",
+			"link": true
+		}
+	}
+}

--- a/packages/tsconfig/package-lock.json
+++ b/packages/tsconfig/package-lock.json
@@ -1,0 +1,13 @@
+{
+	"name": "tsconfig",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "tsconfig",
+			"version": "0.0.0",
+			"license": "MIT"
+		}
+	}
+}


### PR DESCRIPTION
### **User description**
## Description

Added default workspace details in `getSelf` function for a user
Fixes #365 


### Further change

- [ ] Need to update Postman example for [this](https://www.postman.com/keyshade/keyshade/api/a31bdb66-69e3-469b-afb4-f2051385e634/example/32733901-ea33b8a7-7e26-46df-b6cb-a19a2c659094?action=share&source=copy-link&creator=38154269&version=498519d9-7d01-4cfb-996c-32fd22917742&collection=32733901-e9ebcd71-c27e-483f-bf69-6cadcb11a3f4) API and include defaultWorkspace details

Sample response after updating should be like this

```{
    "id": "cm0s8xc1y000013zv8gextk2n",
    "email": "regularuser@gmail.com",
    "name": null,
    "profilePictureUrl": null,
    "isActive": true,
    "isOnboardingFinished": false,
    "isAdmin": false,
    "authProvider": "EMAIL_OTP",
    "defaultWorkspace": {
        "id": "713d0227-eb11-4228-961a-ff7d5d707471",
        "name": "My Workspace",
        "description": null,
        "isFreeTier": true,
        "createdAt": "2024-09-07T14:34:15.256Z",
        "updatedAt": "2024-09-07T14:34:15.256Z",
        "lastUpdatedById": null
    }
}
```

___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `getSelf` function to include default workspace details for non-admin users.
- Updated end-to-end tests to verify the inclusion of `defaultWorkspace` in the user response.
- Added assertions to ensure the correct properties of the default workspace are returned.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.service.ts</strong><dd><code>Include default workspace details in getSelf function</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/user/service/user.service.ts

<li>Added logic to fetch default workspace details for non-admin users.<br> <li> Modified <code>getSelf</code> function to include <code>defaultWorkspace</code> in the response.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/414/files#diff-6ca55e419496e622d41d22930ddd6d7e7d9f907148c36afcae40ef6320dab922">+20/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.e2e.spec.ts</strong><dd><code>Update tests for getSelf function with workspace details</code>&nbsp; </dd></summary>
<hr>

apps/api/src/user/user.e2e.spec.ts

<li>Updated test to check for <code>defaultWorkspace</code> in user response.<br> <li> Added assertions for default workspace properties for regular users.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/414/files#diff-e033f59a1c8df8834aa27fc532b74514ecc01b9a1c0eef7c56bdff989f127094">+30/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

