### PR TITLE
feat(API):  Added icon and removed description field from workspace

### DIFF
--- a/apps/api/src/common/workspace.ts
+++ b/apps/api/src/common/workspace.ts
@@ -34,7 +34,7 @@ export const createWorkspace = async (
       id: workspaceId,
       slug: await generateEntitySlug(dto.name, 'WORKSPACE', prisma),
       name: dto.name,
-      description: dto.description,
+      icon: dto.icon,
       isFreeTier: true,
       ownerId: user.id,
       isDefault,

--- a/apps/api/src/event/event.e2e.spec.ts
+++ b/apps/api/src/event/event.e2e.spec.ts
@@ -99,7 +99,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a workspace event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      icon: "🤓"
+      icon: '🤓'
     })
 
     expect(workspace).toBeDefined()
@@ -144,7 +144,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a project event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-        icon: "🤓"
+      icon: '🤓'
     })
 
     const project = (await projectService.createProject(user, workspace.slug, {
@@ -198,7 +198,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch an environment event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      icon: "🤓"
+      icon: '🤓'
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -261,7 +261,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a secret event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-       icon: "🤓"
+      icon: '🤓'
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -340,7 +340,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a variable event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-       icon: "🤓"
+      icon: '🤓'
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -419,7 +419,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a workspace role event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-        icon: "🤓"
+      icon: '🤓'
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -485,7 +485,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch all events', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-        icon: "🤓"
+      icon: '🤓'
     })
 
     const response = await app.inject({
@@ -518,7 +518,7 @@ describe('Event Controller Tests', () => {
   it('should throw an error with wrong severity value', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      icon: "🤓"
+      icon: '🤓'
     })
 
     const response = await app.inject({
@@ -535,7 +535,7 @@ describe('Event Controller Tests', () => {
   it('should throw an error with wrong source value', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-        icon: "🤓"
+      icon: '🤓'
     })
 
     const response = await app.inject({
@@ -552,7 +552,7 @@ describe('Event Controller Tests', () => {
   it('should throw an error if user is not provided in event creation for user-triggered event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-        icon: "🤓"
+      icon: '🤓'
     })
 
     try {
@@ -577,7 +577,7 @@ describe('Event Controller Tests', () => {
   it('should throw an exception for invalid event source', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-       icon: "🤓"
+      icon: '🤓'
     })
 
     try {
@@ -602,7 +602,7 @@ describe('Event Controller Tests', () => {
   it('should throw an exception for invalid event type', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-        icon: "🤓"
+      icon: '🤓'
     })
 
     try {

--- a/apps/api/src/event/event.e2e.spec.ts
+++ b/apps/api/src/event/event.e2e.spec.ts
@@ -99,7 +99,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a workspace event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+      icon: "🤓"
     })
 
     expect(workspace).toBeDefined()
@@ -144,7 +144,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a project event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+        icon: "🤓"
     })
 
     const project = (await projectService.createProject(user, workspace.slug, {
@@ -198,7 +198,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch an environment event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+      icon: "🤓"
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -261,7 +261,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a secret event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+       icon: "🤓"
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -340,7 +340,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a variable event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+       icon: "🤓"
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -419,7 +419,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch a workspace role event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+        icon: "🤓"
     })
 
     const project = await projectService.createProject(user, workspace.slug, {
@@ -485,7 +485,7 @@ describe('Event Controller Tests', () => {
   it('should be able to fetch all events', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+        icon: "🤓"
     })
 
     const response = await app.inject({
@@ -518,7 +518,7 @@ describe('Event Controller Tests', () => {
   it('should throw an error with wrong severity value', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+      icon: "🤓"
     })
 
     const response = await app.inject({
@@ -535,7 +535,7 @@ describe('Event Controller Tests', () => {
   it('should throw an error with wrong source value', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+        icon: "🤓"
     })
 
     const response = await app.inject({
@@ -552,7 +552,7 @@ describe('Event Controller Tests', () => {
   it('should throw an error if user is not provided in event creation for user-triggered event', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+        icon: "🤓"
     })
 
     try {
@@ -577,7 +577,7 @@ describe('Event Controller Tests', () => {
   it('should throw an exception for invalid event source', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+       icon: "🤓"
     })
 
     try {
@@ -602,7 +602,7 @@ describe('Event Controller Tests', () => {
   it('should throw an exception for invalid event type', async () => {
     const workspace = await workspaceService.createWorkspace(user, {
       name: 'My workspace',
-      description: 'Some description'
+        icon: "🤓"
     })
 
     try {

--- a/apps/api/src/prisma/migrations/20240915122629_add_icon_remove_description_from_workspace/migration.sql
+++ b/apps/api/src/prisma/migrations/20240915122629_add_icon_remove_description_from_workspace/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `description` on the `Workspace` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Workspace" DROP COLUMN "description",
+ADD COLUMN     "icon" TEXT;

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -449,12 +449,12 @@ model Workspace {
   id          String   @id @default(cuid())
   name        String
   slug        String   @unique
-  description String?
   isFreeTier  Boolean  @default(true)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   ownerId     String
   isDefault   Boolean  @default(false)
+  icon        String?
 
   lastUpdatedBy   User?   @relation(fields: [lastUpdatedById], references: [id], onUpdate: Cascade, onDelete: SetNull)
   lastUpdatedById String?

--- a/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
+++ b/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
@@ -220,7 +220,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should not be able to transfer ownership to a non member', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-        description: 'Workspace 2 description'
+         icon: "🤓"
       })
 
       const response = await app.inject({
@@ -241,7 +241,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should not be able to transfer ownership to a member who did not accept the invitation', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-        description: 'Workspace 2 description'
+          icon: "🤓"
       })
 
       // Create membership
@@ -265,7 +265,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should be able to transfer the ownership of the workspace', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-        description: 'Workspace 2 description'
+         icon: "🤓"
       })
 
       // Create membership
@@ -306,7 +306,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should not be able to transfer ownership if is not admin', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-        description: 'Workspace 2 description'
+         icon: "🤓"
       })
 
       // Create membership

--- a/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
+++ b/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
@@ -220,7 +220,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should not be able to transfer ownership to a non member', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-         icon: "🤓"
+        icon: '🤓'
       })
 
       const response = await app.inject({
@@ -241,7 +241,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should not be able to transfer ownership to a member who did not accept the invitation', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-          icon: "🤓"
+        icon: '🤓'
       })
 
       // Create membership
@@ -265,7 +265,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should be able to transfer the ownership of the workspace', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-         icon: "🤓"
+        icon: '🤓'
       })
 
       // Create membership
@@ -306,7 +306,7 @@ describe('Workspace Membership Controller Tests', () => {
     it('should not be able to transfer ownership if is not admin', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-         icon: "🤓"
+        icon: '🤓'
       })
 
       // Create membership

--- a/apps/api/src/workspace/dto/create.workspace/create.workspace.ts
+++ b/apps/api/src/workspace/dto/create.workspace/create.workspace.ts
@@ -7,5 +7,5 @@ export class CreateWorkspace {
 
   @IsString()
   @IsOptional()
-  description?: string
+  icon?: string
 }

--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -96,7 +96,7 @@ export class WorkspaceService {
         slug: dto.name
           ? await generateEntitySlug(dto.name, 'WORKSPACE', this.prisma)
           : undefined,
-        description: dto.description,
+        icon: dto.icon,
         lastUpdatedBy: {
           connect: {
             id: user.id
@@ -210,18 +210,10 @@ export class WorkspaceService {
             userId: user.id
           }
         },
-        OR: [
-          {
-            name: {
-              contains: search
-            }
-          },
-          {
-            description: {
-              contains: search
-            }
-          }
-        ]
+
+        name: {
+          contains: search
+        }
       }
     })
 
@@ -233,18 +225,11 @@ export class WorkspaceService {
             userId: user.id
           }
         },
-        OR: [
-          {
+       
             name: {
               contains: search
             }
-          },
-          {
-            description: {
-              contains: search
-            }
-          }
-        ]
+         
       }
     })
 
@@ -281,7 +266,7 @@ export class WorkspaceService {
     const data: any = {}
 
     data.name = workspace.name
-    data.description = workspace.description
+    data.icon = workspace.icon
 
     // Get all the roles of the workspace
     data.workspaceRoles = await this.prisma.workspaceRole.findMany({

--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -225,11 +225,10 @@ export class WorkspaceService {
             userId: user.id
           }
         },
-       
-            name: {
-              contains: search
-            }
-         
+
+        name: {
+          contains: search
+        }
       }
     })
 

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -192,7 +192,7 @@ describe('Workspace Controller Tests', () => {
         url: '/workspace',
         payload: {
           name: 'Workspace 1',
-            icon: "🤓"
+          icon: '🤓'
         }
       })
 
@@ -201,7 +201,7 @@ describe('Workspace Controller Tests', () => {
 
       expect(body.name).toBe('Workspace 1')
       expect(body.slug).toBeDefined()
-      expect(body.icon).toBe("🤓")
+      expect(body.icon).toBe('🤓')
       expect(body.ownerId).toBe(user1.id)
       expect(body.isFreeTier).toBe(true)
       expect(body.isDefault).toBe(false)
@@ -216,7 +216,7 @@ describe('Workspace Controller Tests', () => {
         url: '/workspace',
         payload: {
           name: 'My Workspace',
-            icon: "🤓"
+          icon: '🤓'
         }
       })
 
@@ -231,7 +231,7 @@ describe('Workspace Controller Tests', () => {
     it('should let other user to create workspace with same name', async () => {
       await workspaceService.createWorkspace(user1, {
         name: 'Workspace 1',
-         icon: "🤓"
+        icon: '🤓'
       })
 
       const response = await app.inject({
@@ -242,7 +242,7 @@ describe('Workspace Controller Tests', () => {
         url: '/workspace',
         payload: {
           name: 'Workspace 1',
-            icon: "🤓"
+          icon: '🤓'
         }
       })
 
@@ -250,7 +250,7 @@ describe('Workspace Controller Tests', () => {
       workspace2 = response.json()
 
       expect(workspace2.name).toBe('Workspace 1')
-      expect(workspace2.icon).toBe("🤓")
+      expect(workspace2.icon).toBe('🤓')
       expect(workspace2.ownerId).toBe(user2.id)
       expect(workspace2.isFreeTier).toBe(true)
       expect(workspace2.isDefault).toBe(false)
@@ -321,7 +321,7 @@ describe('Workspace Controller Tests', () => {
         url: `/workspace/${workspace1.slug}`,
         payload: {
           name: 'Workspace 1 Updated',
-            icon: "🔥"
+          icon: '🔥'
         }
       })
 
@@ -330,7 +330,7 @@ describe('Workspace Controller Tests', () => {
 
       expect(body.name).toBe('Workspace 1 Updated')
       expect(body.slug).not.toBe(workspace1.slug)
-      expect(body.icon).toBe("🔥")
+      expect(body.icon).toBe('🔥')
     })
 
     it('should not be able to change the name to an existing workspace or same name', async () => {
@@ -362,7 +362,7 @@ describe('Workspace Controller Tests', () => {
         url: `/workspace/${workspace1.slug}`,
         payload: {
           name: 'Workspace 1 Updated',
-            icon: "🤓"
+          icon: '🤓'
         }
       })
 
@@ -371,7 +371,7 @@ describe('Workspace Controller Tests', () => {
 
     it('should have created a WORKSPACE_UPDATED event', async () => {
       await workspaceService.updateWorkspace(user1, workspace1.slug, {
-          icon: "🤓"
+        icon: '🤓'
       })
 
       const response = await fetchEvents(
@@ -536,7 +536,7 @@ describe('Workspace Controller Tests', () => {
     it('should be able to delete the workspace', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-          icon: "🤓"
+        icon: '🤓'
       })
 
       const response = await app.inject({

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -192,7 +192,7 @@ describe('Workspace Controller Tests', () => {
         url: '/workspace',
         payload: {
           name: 'Workspace 1',
-          description: 'Workspace 1 description'
+            icon: "🤓"
         }
       })
 
@@ -201,7 +201,7 @@ describe('Workspace Controller Tests', () => {
 
       expect(body.name).toBe('Workspace 1')
       expect(body.slug).toBeDefined()
-      expect(body.description).toBe('Workspace 1 description')
+      expect(body.icon).toBe("🤓")
       expect(body.ownerId).toBe(user1.id)
       expect(body.isFreeTier).toBe(true)
       expect(body.isDefault).toBe(false)
@@ -216,7 +216,7 @@ describe('Workspace Controller Tests', () => {
         url: '/workspace',
         payload: {
           name: 'My Workspace',
-          description: 'My Workspace description'
+            icon: "🤓"
         }
       })
 
@@ -231,7 +231,7 @@ describe('Workspace Controller Tests', () => {
     it('should let other user to create workspace with same name', async () => {
       await workspaceService.createWorkspace(user1, {
         name: 'Workspace 1',
-        description: 'Workspace 1 description'
+         icon: "🤓"
       })
 
       const response = await app.inject({
@@ -242,7 +242,7 @@ describe('Workspace Controller Tests', () => {
         url: '/workspace',
         payload: {
           name: 'Workspace 1',
-          description: 'Workspace 1 description'
+            icon: "🤓"
         }
       })
 
@@ -250,7 +250,7 @@ describe('Workspace Controller Tests', () => {
       workspace2 = response.json()
 
       expect(workspace2.name).toBe('Workspace 1')
-      expect(workspace2.description).toBe('Workspace 1 description')
+      expect(workspace2.icon).toBe("🤓")
       expect(workspace2.ownerId).toBe(user2.id)
       expect(workspace2.isFreeTier).toBe(true)
       expect(workspace2.isDefault).toBe(false)
@@ -321,7 +321,7 @@ describe('Workspace Controller Tests', () => {
         url: `/workspace/${workspace1.slug}`,
         payload: {
           name: 'Workspace 1 Updated',
-          description: 'Workspace 1 updated description'
+            icon: "🔥"
         }
       })
 
@@ -330,7 +330,7 @@ describe('Workspace Controller Tests', () => {
 
       expect(body.name).toBe('Workspace 1 Updated')
       expect(body.slug).not.toBe(workspace1.slug)
-      expect(body.description).toBe('Workspace 1 updated description')
+      expect(body.icon).toBe("🔥")
     })
 
     it('should not be able to change the name to an existing workspace or same name', async () => {
@@ -362,7 +362,7 @@ describe('Workspace Controller Tests', () => {
         url: `/workspace/${workspace1.slug}`,
         payload: {
           name: 'Workspace 1 Updated',
-          description: 'Workspace 1 updated description'
+            icon: "🤓"
         }
       })
 
@@ -371,7 +371,7 @@ describe('Workspace Controller Tests', () => {
 
     it('should have created a WORKSPACE_UPDATED event', async () => {
       await workspaceService.updateWorkspace(user1, workspace1.slug, {
-        description: 'Workspace 1 Description'
+          icon: "🤓"
       })
 
       const response = await fetchEvents(
@@ -526,7 +526,7 @@ describe('Workspace Controller Tests', () => {
       const body = response.json()
 
       expect(body.name).toEqual(workspace1.name)
-      expect(body.description).toEqual(workspace1.description)
+      expect(body.icon).toEqual(workspace1.icon)
       expect(body.workspaceRoles).toBeInstanceOf(Array)
       expect(body.projects).toBeInstanceOf(Array)
     })
@@ -536,7 +536,7 @@ describe('Workspace Controller Tests', () => {
     it('should be able to delete the workspace', async () => {
       const newWorkspace = await workspaceService.createWorkspace(user1, {
         name: 'Workspace 2',
-        description: 'Workspace 2 description'
+          icon: "🤓"
       })
 
       const response = await app.inject({

--- a/packages/api-client/src/types/workspace.types.d.ts
+++ b/packages/api-client/src/types/workspace.types.d.ts
@@ -4,7 +4,7 @@ interface Workspace {
   id: string
   name: string
   slug: string
-  description: string
+  icon: string
   isFreeTier: boolean
   createdAt: string
   updatedAt: string
@@ -15,7 +15,7 @@ interface Workspace {
 
 export interface CreateWorkspaceRequest {
   name: string
-  description?: string
+  icon?: string
 }
 
 export interface CreateWorkspaceResponse extends Workspace {}
@@ -50,7 +50,7 @@ export interface ExportDataRequest {
 
 export interface ExportDataResponse {
   name: string
-  description: string
+  icon: string
   workspaceRoles: {
     name: string
     description: string

--- a/packages/api-client/tests/workspace.spec.ts
+++ b/packages/api-client/tests/workspace.spec.ts
@@ -78,7 +78,7 @@ describe('Workspaces Controller Tests', () => {
       await workspaceController.createWorkspace(
         {
           name: 'New Workspace',
-          description: 'This is a new workspace'
+          icon: '🤓'
         },
         {
           'x-e2e-user-email': email

--- a/packages/schema/src/workspace.ts
+++ b/packages/schema/src/workspace.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const CreateWorkspaceSchema = z.object({
   name: z.string(),
-  description: z.string().optional(),
+  icon: z.string().optional(),
   isDefault: z.boolean().optional()
 })
 


### PR DESCRIPTION
### **User description**
## Description

 Added icon and removed description field from workspace

Fixes #229 

## Screenshots of relevant screens
<img width="997" alt="Screenshot 2024-09-15 at 7 37 27 PM" src="https://github.com/user-attachments/assets/888c4391-4418-4a78-8ea7-d666062e3341">

<img width="997" alt="Screenshot 2024-09-15 at 7 39 34 PM" src="https://github.com/user-attachments/assets/11039e29-484e-4457-bf81-ef30aaeb572c">


## Additional changes Required

- [] Postman updation

Sample response for fetching all workspace of a user
``` {
            "id": "006bd5bf-43ac-41ad-b7a9-b1317d08f8ee",
            "name": "My first workspace 2",
            "slug": "my-first-workspace-2-0",
            "isFreeTier": true,
            "createdAt": "2024-09-15T13:32:58.131Z",
            "updatedAt": "2024-09-15T13:32:58.131Z",
            "ownerId": "cm0v65bm00000130sigtvry7y",
            "isDefault": false,
            "icon": "🤓",
            "lastUpdatedById": null
        },
 ```
 
 Request Body for creating a new Workspace 
 ```{
    "name": "My first workspace 2",
    "icon":"🤓"
}
```


___

### **PR Type**
enhancement, tests


___

### **Description**
- Replaced the `description` field with an `icon` field in the workspace model, affecting creation and update operations.
- Updated database schema and migration scripts to reflect the removal of `description` and addition of `icon`.
- Modified all relevant tests to accommodate the change from `description` to `icon`.
- Adjusted DTOs and service logic to handle the new `icon` field.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.ts</strong><dd><code>Replace description with icon in workspace creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/workspace.ts

- Replaced `description` field with `icon` in workspace creation.



</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-e1de4e05ccfed469f0914045b02f50393adc5d62e90c88db403a562ae99c2075">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create.workspace.ts</strong><dd><code>Update DTO to include icon instead of description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/dto/create.workspace/create.workspace.ts

- Changed optional field from `description` to `icon` in DTO.



</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-c760c1ab4fbc21b71e76046a55e199b8bff73f6924dcab6615a505afc644f924">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Update workspace service to use icon instead of description</code></dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts

<li>Replaced <code>description</code> with <code>icon</code> in workspace service logic.<br> <li> Removed search functionality for <code>description</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+8/-23</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Database migration to replace description with icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/migrations/20240915122629_add_icon_remove_description_from_workspace/migration.sql

<li>Dropped <code>description</code> column and added <code>icon</code> column in <code>Workspace</code> table.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-2a594d7e7d2a2a9d670d1ee5d06d97d76f08f8862f8781955a08fc883aff020e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma schema for workspace icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/schema.prisma

<li>Removed <code>description</code> field and added <code>icon</code> field in <code>Workspace</code> model.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-24191263d57c55d02e0cdf394de15225b628d1da20bd826b1541b59b6b02adb4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event.e2e.spec.ts</strong><dd><code>Update tests to reflect workspace icon change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/event/event.e2e.spec.ts

<li>Updated tests to use <code>icon</code> instead of <code>description</code> for workspace.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-e3b2a34abdd21ac689f251a13fc249d534413e3c14ed8a6ae7374021b1663fe2">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace-membership.e2e.spec.ts</strong><dd><code>Modify tests for workspace icon update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts

<li>Modified tests to use <code>icon</code> instead of <code>description</code> for workspace.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-3d2af810cbc31b6ae710d387ba6e8d72d9aaf5e8021ce6266fe5b438c6115c1a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Update workspace tests for icon field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts

- Updated workspace tests to use `icon` instead of `description`.



</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/435/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+12/-12</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

