### PR TITLE
feat: Remove project IDs from workspace role export data and update tests

### DIFF
--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -277,12 +277,7 @@ export class WorkspaceService {
         description: true,
         colorCode: true,
         hasAdminAuthority: true,
-        authorities: true,
-        projects: {
-          select: {
-            id: true
-          }
-        }
+        authorities: true
       }
     })
 

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -529,6 +529,13 @@ describe('Workspace Controller Tests', () => {
       expect(body.icon).toEqual(workspace1.icon)
       expect(body.workspaceRoles).toBeInstanceOf(Array)
       expect(body.projects).toBeInstanceOf(Array)
+
+      const exampleWorkspaceRole = body.workspaceRoles[0]
+      expect(exampleWorkspaceRole).toHaveProperty('name')
+      expect(exampleWorkspaceRole).toHaveProperty('description')
+      expect(exampleWorkspaceRole).toHaveProperty('hasAdminAuthority')
+      expect(exampleWorkspaceRole).toHaveProperty('authorities')
+      expect(exampleWorkspaceRole).toHaveProperty('colorCode')
     })
   })
 


### PR DESCRIPTION
### **User description**
## Description

_Give a summary of the change that you have made_ <br />
Changed the exportData function in the workspace controller to no longer return project IDs. I updated the e2e test to now check for the important fields that are supposed to be returned by exportData.

Fixes #425

## Dependencies

_Mention any dependencies/packages used_
None

## Future Improvements

_Mention any improvements to be done in future related to any file/feature_
The test currently doesn't test if there is extra fields that is not needed/not supposed to be there, only that the important fields are there. If necessary, I will change the test to be more precise.

## Mentions

_Mention and tag the people_

## Screenshots of relevant screens

_Add screenshots of relevant screens_
![Screenshot from 2024-09-18 19-29-22](https://github.com/user-attachments/assets/c96c5167-fe6a-4116-b896-69c7c62063eb)
![Screenshot from 2024-09-18 19-30-07](https://github.com/user-attachments/assets/a8c004fb-1f01-4642-afff-494818aeabfb)

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Removed project IDs from the `exportData` function in the workspace service to streamline the data returned.
- Updated end-to-end tests to verify that `workspaceRoles` contain the expected fields such as `name`, `description`, `hasAdminAuthority`, `authorities`, and `colorCode`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Remove project ID selection from exportData function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts

<li>Removed the selection of project IDs from the <code>exportData</code> function.<br> <li> Kept other fields like <code>name</code>, <code>description</code>, and <code>authorities</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/448/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Update e2e test to verify workspaceRole fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts

<li>Updated test to check for specific fields in <code>workspaceRoles</code>.<br> <li> Ensured <code>workspaceRoles</code> contains expected properties.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/448/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

