### PR TITLE
fix(api): Replace the id with slug in the global-search service

### DIFF
--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -442,7 +442,7 @@ export class WorkspaceService {
           { description: { contains: searchTerm, mode: 'insensitive' } }
         ]
       },
-      select: { id: true, name: true, description: true }
+      select: { slug: true, name: true, description: true }
     })
   }
 
@@ -467,7 +467,7 @@ export class WorkspaceService {
           { description: { contains: searchTerm, mode: 'insensitive' } }
         ]
       },
-      select: { id: true, name: true, description: true }
+      select: { slug: true, name: true, description: true }
     })
   }
 
@@ -493,7 +493,7 @@ export class WorkspaceService {
           { note: { contains: searchTerm, mode: 'insensitive' } }
         ]
       },
-      select: { id: true, name: true, note: true }
+      select: { slug: true, name: true, note: true }
     })
   }
 
@@ -518,7 +518,7 @@ export class WorkspaceService {
           { note: { contains: searchTerm, mode: 'insensitive' } }
         ]
       },
-      select: { id: true, name: true, note: true }
+      select: { slug: true, name: true, note: true }
     })
   }
 

--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -20,7 +20,6 @@ import {
   Environment,
   EventSource,
   EventType,
-  Prisma,
   Project,
   ProjectAccessLevel,
   Secret,
@@ -435,10 +434,16 @@ export class WorkspaceService {
     searchTerm: string
   ): Promise<Partial<Project>[]> {
     // Fetch projects where user has READ_PROJECT authority and match search term
-    return this.createSearchQuery('Project', projectIds, searchTerm, [
-      'name',
-      'description'
-    ])
+    return this.prisma.project.findMany({
+      where: {
+        id: { in: projectIds },
+        OR: [
+          { name: { contains: searchTerm, mode: 'insensitive' } },
+          { description: { contains: searchTerm, mode: 'insensitive' } }
+        ]
+      },
+      select: { slug: true, name: true, description: true }
+    })
   }
 
   /**
@@ -452,10 +457,18 @@ export class WorkspaceService {
     projectIds: string[],
     searchTerm: string
   ): Promise<Partial<Environment>[]> {
-    return this.createSearchQuery('Environment', projectIds, searchTerm, [
-      'name',
-      'description'
-    ])
+    return this.prisma.environment.findMany({
+      where: {
+        project: {
+          id: { in: projectIds }
+        },
+        OR: [
+          { name: { contains: searchTerm, mode: 'insensitive' } },
+          { description: { contains: searchTerm, mode: 'insensitive' } }
+        ]
+      },
+      select: { slug: true, name: true, description: true }
+    })
   }
 
   /**
@@ -470,10 +483,18 @@ export class WorkspaceService {
     searchTerm: string
   ): Promise<Partial<Secret>[]> {
     // Fetch secrets associated with projects user has READ_SECRET authority on
-    return this.createSearchQuery('Secret', projectIds, searchTerm, [
-      'name',
-      'note'
-    ])
+    return await this.prisma.secret.findMany({
+      where: {
+        project: {
+          id: { in: projectIds }
+        },
+        OR: [
+          { name: { contains: searchTerm, mode: 'insensitive' } },
+          { note: { contains: searchTerm, mode: 'insensitive' } }
+        ]
+      },
+      select: { slug: true, name: true, note: true }
+    })
   }
 
   /**
@@ -487,10 +508,18 @@ export class WorkspaceService {
     projectIds: string[],
     searchTerm: string
   ): Promise<Partial<Variable>[]> {
-    return this.createSearchQuery('Variable', projectIds, searchTerm, [
-      'name',
-      'note'
-    ])
+    return this.prisma.variable.findMany({
+      where: {
+        project: {
+          id: { in: projectIds }
+        },
+        OR: [
+          { name: { contains: searchTerm, mode: 'insensitive' } },
+          { note: { contains: searchTerm, mode: 'insensitive' } }
+        ]
+      },
+      select: { slug: true, name: true, note: true }
+    })
   }
 
   /**
@@ -512,43 +541,5 @@ export class WorkspaceService {
         }
       })) > 0
     )
-  }
-
-  /**
-   * Creates a search query object based on provided project IDs and search term.
-   * @param model The Prisma model name (e.g., 'Project', 'Environment')
-   * @param projectIds The IDs of projects to query
-   * @param searchTerm The search term to query by
-   * @param fields The fields to apply the search term in the query
-   * @returns The prisma query object
-   * @private
-   */
-  private createSearchQuery<T>(
-    model: Prisma.ModelName,
-    projectIds: string[],
-    searchTerm: string,
-    fields: Array<Exclude<keyof T, 'slug'>>
-  ): Promise<Partial<T>[]> {
-    const idQueryFilter =
-      model === 'Project'
-        ? { id: { in: projectIds } }
-        : { projectId: { in: projectIds } }
-
-    const searchConditions = fields.map((field) => ({
-      [field]: { contains: searchTerm, mode: 'insensitive' }
-    }))
-
-    const selectFields = Object.fromEntries([
-      ['slug', true],
-      ...fields.map((field) => [field, true])
-    ])
-
-    return this.prisma[model].findMany({
-      where: {
-        ...idQueryFilter,
-        OR: searchConditions
-      },
-      select: selectFields
-    })
   }
 }

--- a/packages/api-client/src/types/workspace.types.d.ts
+++ b/packages/api-client/src/types/workspace.types.d.ts
@@ -96,22 +96,22 @@ export interface GlobalSearchRequest {
 
 export interface GlobalSearchResponse {
   projects: {
-    id: string
+    slug: string
     name: string
     description: string
   }[]
   environments: {
-    id: string
+    slug: string
     name: string
     description: string
   }[]
   secrets: {
-    id: string
+    slug: string
     name: string
     note: string
   }[]
   variables: {
-    id: string
+    slug: string
     name: string
     note: string
   }[]


### PR DESCRIPTION
### **User description**
## Description

Updated the response of the global search API with slug instead of id.

Fixes #426 

## Dependencies

_Mention any dependencies/packages used_

## Future Improvements

_Mention any improvements to be done in future related to any file/feature_

## Mentions

_Mention and tag the people_

## Screenshots of relevant screens

_Add screenshots of relevant screens_


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the global search API to return `slug` instead of `id` in the response.
- Modified multiple query methods in `WorkspaceService` to select `slug` instead of `id`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Replace `id` with `slug` in global search queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts

<li>Replaced <code>id</code> with <code>slug</code> in the selection fields of multiple query <br>methods.<br> <li> Updated the global search service to use <code>slug</code> instead of <code>id</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/455/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

