### PR TITLE
modified package.json to add only pnpm package manager (GENERAL: Only allow PNPM #366)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "scripts": {
     "dev": "turbo run dev",
+    "preinstall": "if [[ \"$npm_config_user_agent\" != *pnpm* ]]; then echo 'This project uses pnpm. Please run using pnpm.'; exit 1; fi",
     "dev:api": "turbo run dev --filter=api",
     "dev:web": "turbo run dev --filter=web",
     "dev:platform": "turbo run dev --filter=platform",


### PR DESCRIPTION
GENERAL: Only allow PNPM #366

#description
Restriction on Package Manager Usage
To ensure consistency in our project, I've added a preinstall script in package.json.
"preinstall": "if [[ \"$npm_config_user_agent\" != *pnpm* ]]; then echo 'This project uses pnpm. Please run using pnpm.'; exit 1; fi",

This script checks the package manager before installation and displays an error if anything other than PNPM is used, promoting uniformity among contributors.

Fixes #366
GENERAL: Only allow PNPM #366 


## Dependencies
No additional packages or dependencies are required for the preinstall script


## Developer's checklist

- [Y] My PR follows the style guidelines of this project
- [Y] I have performed a self-check on my work

**If changes are made in the code:**

- [Y] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [Y] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [Y] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.
