### PR TITLE
chore: Update controller invocation in environment commands

### DIFF
--- a/apps/cli/src/commands/environment/create.environment.ts
+++ b/apps/cli/src/commands/environment/create.environment.ts
@@ -5,7 +5,7 @@ import {
   type CommandArgument,
   type CommandOption
 } from 'src/types/command/command.types'
-import { EnvironmentController } from '@keyshade/api-client'
+import ControllerInstance from '../../util/controller-instance'
 import { Logger } from '@/util/logger'
 export class CreateEnvironment extends BaseCommand {
   getName(): string {
@@ -50,26 +50,18 @@ export class CreateEnvironment extends BaseCommand {
       return
     }
 
-    const apiKey = this.apiKey
-
-    const environmentData = {
-      name,
-      description,
-      projectSlug
-    }
-
-    const headers = {
-      'x-keyshade-token': apiKey
-    }
-
-    const environmentController = new EnvironmentController(this.baseUrl)
     Logger.info('Creating Environment...')
 
     const {
       data: environment,
       error,
       success
-    } = await environmentController.createEnvironment(environmentData, headers)
+    } = await ControllerInstance
+    .getInstance()
+    .environmentController.createEnvironment(
+      {name, description, projectSlug}, 
+      this.headers
+    )
 
     if (success) {
       Logger.info(

--- a/apps/cli/src/commands/environment/create.environment.ts
+++ b/apps/cli/src/commands/environment/create.environment.ts
@@ -5,7 +5,7 @@ import {
   type CommandArgument,
   type CommandOption
 } from 'src/types/command/command.types'
-import ControllerInstance from '../../util/controller-instance'
+import ControllerInstance from '@/util/controller-instance'
 import { Logger } from '@/util/logger'
 export class CreateEnvironment extends BaseCommand {
   getName(): string {

--- a/apps/cli/src/commands/environment/delete.environment.ts
+++ b/apps/cli/src/commands/environment/delete.environment.ts
@@ -1,5 +1,5 @@
 import BaseCommand from '../base.command'
-import ControllerInstance from '../../util/controller-instance'
+import ControllerInstance from '@/util/controller-instance'
 import {
   type CommandActionData,
   type CommandArgument

--- a/apps/cli/src/commands/environment/delete.environment.ts
+++ b/apps/cli/src/commands/environment/delete.environment.ts
@@ -1,5 +1,5 @@
 import BaseCommand from '../base.command'
-import { EnvironmentController } from '@keyshade/api-client'
+import ControllerInstance from '../../util/controller-instance'
 import {
   type CommandActionData,
   type CommandArgument
@@ -32,18 +32,13 @@ export class DeleteEnvironment extends BaseCommand {
       return
     }
 
-    const apiKey = this.apiKey
-
-    const headers = {
-      'x-keyshade-token': apiKey
-    }
-
-    const environmentController = new EnvironmentController(this.baseUrl)
     Logger.info('Deleting Environment...')
 
-    const { success, error } = await environmentController.deleteEnvironment(
+    const { success, error } = await ControllerInstance
+    .getInstance()
+    .environmentController.deleteEnvironment(
       { id: environmentId },
-      headers
+      this.headers
     )
 
     if (success) {

--- a/apps/cli/src/commands/environment/get.environment.ts
+++ b/apps/cli/src/commands/environment/get.environment.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@/util/logger'
 import BaseCommand from '../base.command'
-import ControllerInstance from '../../util/controller-instance'
+import ControllerInstance from '@/util/controller-instance'
 import {
   type CommandActionData,
   type CommandArgument

--- a/apps/cli/src/commands/environment/get.environment.ts
+++ b/apps/cli/src/commands/environment/get.environment.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@/util/logger'
 import BaseCommand from '../base.command'
-import { EnvironmentController } from '@keyshade/api-client'
+import ControllerInstance from '../../util/controller-instance'
 import {
   type CommandActionData,
   type CommandArgument
@@ -32,20 +32,17 @@ export class GetEnvironment extends BaseCommand {
       return
     }
 
-    const headers = {
-      'x-keyshade-token': this.apiKey
-    }
-
-    const environmentController = new EnvironmentController(this.baseUrl)
     Logger.info('Fetching Environment...')
 
     const {
       success,
       error,
       data: environment
-    } = await environmentController.getEnvironment(
+    } = await ControllerInstance
+    .getInstance()
+    .environmentController.getEnvironment(
       { slug: environmentSlug },
-      headers
+      this.headers
     )
 
     if (success) {

--- a/apps/cli/src/commands/environment/list.environment.ts
+++ b/apps/cli/src/commands/environment/list.environment.ts
@@ -1,5 +1,5 @@
 import BaseCommand from '../base.command'
-import { EnvironmentController } from '@keyshade/api-client'
+import ControllerInstance from '../../util/controller-instance'
 import {
   CommandOption,
   type CommandActionData,
@@ -38,21 +38,14 @@ export class ListEnvironment extends BaseCommand {
       return
     }
 
-    const headers = {
-      'x-keyshade-token': this.apiKey
-    }
-
-    const environmentController = new EnvironmentController(this.baseUrl)
     Logger.info('Fetching all environments...')
 
-    const {
-      success,
-      data: environments,
-      error
-    } = await environmentController.getAllEnvironmentsOfProject(
-      { projectSlug, ...options },
-      headers
-    )
+    const { data: environments, error, success } = await ControllerInstance
+      .getInstance()
+      .environmentController.getAllEnvironmentsOfProject(
+        { projectSlug, ...options },
+        this.headers
+      )
 
     if (success) {
       Logger.info('Fetched environments:')

--- a/apps/cli/src/commands/environment/list.environment.ts
+++ b/apps/cli/src/commands/environment/list.environment.ts
@@ -1,5 +1,5 @@
 import BaseCommand from '../base.command'
-import ControllerInstance from '../../util/controller-instance'
+import ControllerInstance from '@/util/controller-instance'
 import {
   CommandOption,
   type CommandActionData,

--- a/apps/cli/src/commands/environment/update.environment.ts
+++ b/apps/cli/src/commands/environment/update.environment.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@/util/logger'
 import BaseCommand from '../base.command'
-import { EnvironmentController } from '@keyshade/api-client'
+import ControllerInstance from '../../util/controller-instance'
 import {
   type CommandActionData,
   type CommandArgument,
@@ -49,24 +49,18 @@ export class UpdateEnvironment extends BaseCommand {
       return
     }
 
-    const headers = {
-      'x-keyshade-token': this.apiKey
-    }
-
-    const environmentData = {
-      name,
-      description,
-      slug: environmentSlug
-    }
-
-    const environmentController = new EnvironmentController(this.baseUrl)
     Logger.info('Updating Environment...')
 
     const {
       success,
       error,
       data: environment
-    } = await environmentController.updateEnvironment(environmentData, headers)
+    } = await ControllerInstance
+    .getInstance().
+    environmentController.updateEnvironment(
+      {name, description, slug: environmentSlug},
+      this.headers
+    )
 
     if (success) {
       Logger.info('Environment updated successfully')

--- a/apps/cli/src/commands/environment/update.environment.ts
+++ b/apps/cli/src/commands/environment/update.environment.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@/util/logger'
 import BaseCommand from '../base.command'
-import ControllerInstance from '../../util/controller-instance'
+import ControllerInstance from '@/util/controller-instance'
 import {
   type CommandActionData,
   type CommandArgument,


### PR DESCRIPTION
### **User description**
## Description

Updated controller invocation in environment commands in 
keyshade/apps/cli/src/commands/environment/list.environment.ts

Fixes #443 

## Mentions

@rajdip-b 

## Developer's checklist

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] There are no UI/UX issues


### Documentation Update
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
enhancement


___

### **Description**
- Refactored the environment fetching logic to use a centralized `ControllerInstance` instead of directly instantiating `EnvironmentController`.
- Simplified headers management by utilizing `this.headers` within the command.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list.environment.ts</strong><dd><code>Refactor environment fetching to use ControllerInstance</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/environment/list.environment.ts

<li>Replaced <code>EnvironmentController</code> import with <code>ControllerInstance</code>.<br> <li> Updated method to use <code>ControllerInstance</code> for fetching environments.<br> <li> Removed manual headers setup, using <code>this.headers</code> instead.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/477/files#diff-98e45816c7ac3ca77c1edecd3562146bfd4c9a30ab6f818de69daa6e0b6de5fe">+7/-14</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information