### PR TITLE
docs: Fix Documentation Hyperlink and update expired Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We love documentation contributions! Whether it's more complete descriptions, ne
 
 ## Community
 
-You can chat with the core team on [our discord](https://discord.gg/m6TcpWBSdt). Please be respectful to each other and follow our code of conduct.
+You can chat with the core team on [our discord](https://discord.gg/xJFggHUPAf). Please be respectful to each other and follow our code of conduct.
 
 Thank you again for your interest in our project, your contribution, and your support!
 

--- a/docs/contributing-to-keyshade/running-things-locally/README.md
+++ b/docs/contributing-to-keyshade/running-things-locally/README.md
@@ -13,4 +13,5 @@ You can pick up any of these topics from the following and start with it.
 - [Running the API](running-the-api.md)
 - [Running the Web](running-the-web-app.md)
 - [Running the CLI](running-the-cli.md)
+- [Running the Platform](running-the-platform.md)
 - [API Testing](api-testing.md)


### PR DESCRIPTION
## Description

This pull request addresses two issues: (1) The missing hyperlink for "Running the Platform" on the "Running Things Locally" documentation page, which has now been corrected by adding a direct link to the relevant section for easier navigation, and (2) the expired Discord invite link in the CONTRIBUTING.md file, which has been replaced with a valid invite to ensure users can join the Discord server without issues. <br />

Fixes #[493] & #[494]

## Mentions

@career-yashaswee

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
