### PR TITLE
fix(api,api-client): Add environmentSlug in multiple places across the secret module

### DIFF
--- a/apps/api/src/secret/secret.e2e.spec.ts
+++ b/apps/api/src/secret/secret.e2e.spec.ts
@@ -209,6 +209,8 @@ describe('Secret Controller Tests', () => {
       expect(body.projectId).toBe(project1.id)
       expect(body.versions.length).toBe(1)
       expect(body.versions[0].value).not.toBe('Secret 2 value')
+      expect(body.versions[0].environment.id).toBe(environment1.id)
+      expect(body.versions[0].environment.slug).toBe(environment1.slug)
     })
 
     it('should have created a secret version', async () => {
@@ -341,10 +343,15 @@ describe('Secret Controller Tests', () => {
       const secretVersion = await prisma.secretVersion.findMany({
         where: {
           secretId: secret1.id
+        },
+        include: {
+          environment: true
         }
       })
 
       expect(secretVersion.length).toBe(1)
+      expect(secretVersion[0].environment.id).toBe(environment1.id)
+      expect(secretVersion[0].environment.slug).toBe(environment1.slug)
     })
 
     it('should create a new version if the value is updated', async () => {
@@ -371,6 +378,9 @@ describe('Secret Controller Tests', () => {
         where: {
           secretId: secret1.id,
           environmentId: environment1.id
+        },
+        include: {
+          environment: true
         }
       })
 

--- a/apps/api/src/secret/secret.types.ts
+++ b/apps/api/src/secret/secret.types.ts
@@ -1,4 +1,4 @@
-import { Project, Secret, SecretVersion } from '@prisma/client'
+import { Environment, Project, Secret, SecretVersion } from '@prisma/client'
 
 export interface SecretWithValue extends Secret {
   value: string

--- a/apps/api/src/secret/secret.types.ts
+++ b/apps/api/src/secret/secret.types.ts
@@ -1,4 +1,4 @@
-import { Environment, Project, Secret, SecretVersion } from '@prisma/client'
+import { Project, Secret, SecretVersion } from '@prisma/client'
 
 export interface SecretWithValue extends Secret {
   value: string

--- a/apps/api/src/secret/service/secret.service.ts
+++ b/apps/api/src/secret/service/secret.service.ts
@@ -126,7 +126,12 @@ export class SecretService {
         },
         versions: {
           select: {
-            environmentId: true,
+            environment: {
+              select: {
+                id: true,
+                slug: true
+              }
+            },
             value: true
           }
         }
@@ -252,7 +257,12 @@ export class SecretService {
             },
             select: {
               id: true,
-              environmentId: true,
+              environment: {
+                select: {
+                  id: true,
+                  slug: true
+                }
+              },
               value: true,
               version: true
             }
@@ -514,7 +524,15 @@ export class SecretService {
           orderBy: {
             version: 'desc'
           },
-          take: 1
+          take: 1,
+          include: {
+            environment: {
+              select: {
+                id: true,
+                slug: true
+              }
+            }
+          }
         }
       }
     })
@@ -648,6 +666,16 @@ export class SecretService {
             id: true,
             name: true
           }
+        },
+        versions: {
+          select: {
+            environment: {
+              select: {
+                id: true,
+                slug: true
+              }
+            }
+          }
         }
       },
       skip: page * limit,
@@ -699,6 +727,14 @@ export class SecretService {
           },
           orderBy: {
             version: 'desc'
+          },
+          include: {
+            environment: {
+              select: {
+                id: true,
+                slug: true
+              }
+            }
           }
         })
 

--- a/apps/api/src/secret/service/secret.service.ts
+++ b/apps/api/src/secret/service/secret.service.ts
@@ -671,6 +671,7 @@ export class SecretService {
           select: {
             environment: {
               select: {
+                name: true,
                 id: true,
                 slug: true
               }

--- a/packages/api-client/src/types/secret.types.d.ts
+++ b/packages/api-client/src/types/secret.types.d.ts
@@ -18,6 +18,10 @@ export interface Secret {
       id?: string
       environmentId: string
       value: string
+      environment: {
+        id: string
+        slug: string
+      }
     }
   ]
 }
@@ -48,6 +52,10 @@ export interface UpdateSecretResponse {
     {
       id?: string
       environmentId: string
+      environment: {
+        id: string
+        slug: string
+      }
       value: string
     }
   ]
@@ -83,6 +91,7 @@ export interface GetAllSecretsOfProjectResponse
       environment: {
         id: string
         name: string
+        slug: string
       }
       value: string
       version: number

--- a/packages/api-client/tests/secret.spec.ts
+++ b/packages/api-client/tests/secret.spec.ts
@@ -1,6 +1,5 @@
 import { APIClient } from '../src/core/client'
 import SecretController from '../src/controllers/secret'
-import { Environment } from '@api-client/types/environment.types'
 
 describe('Secret Controller Tests', () => {
   const backendUrl = process.env.BACKEND_URL
@@ -12,7 +11,7 @@ describe('Secret Controller Tests', () => {
   let projectSlug: string | null
   let workspaceSlug: string | null
   let secretSlug: string | null
-  let environment: Environment
+  let environmentSlug: string | null
 
   beforeAll(async () => {
     //Create the user's workspace
@@ -59,7 +58,7 @@ describe('Secret Controller Tests', () => {
       )
     ).json()) as any
 
-    environment = createEnvironmentResponse
+    environmentSlug = createEnvironmentResponse.slug
   })
 
   afterAll(async () => {
@@ -77,7 +76,7 @@ describe('Secret Controller Tests', () => {
         note: 'Secret 1 note',
         entries: [
           {
-            environmentSlug: environment.slug,
+            environmentSlug,
             value: 'Secret 1 value'
           }
         ],
@@ -104,7 +103,7 @@ describe('Secret Controller Tests', () => {
         note: 'Secret 2 note',
         entries: [
           {
-            environmentSlug: environment.slug,
+            environmentSlug,
             value: 'Secret 1 value'
           }
         ],
@@ -153,7 +152,7 @@ describe('Secret Controller Tests', () => {
         entries: [
           {
             value: 'Updated Secret 1 value',
-            environmentSlug: environment.slug
+            environmentSlug
           }
         ],
         secretSlug
@@ -171,7 +170,7 @@ describe('Secret Controller Tests', () => {
         entries: [
           {
             value: 'Secret 1 value',
-            environmentSlug: environment.slug
+            environmentSlug
           }
         ],
         secretSlug
@@ -184,7 +183,7 @@ describe('Secret Controller Tests', () => {
         entries: [
           {
             value: 'Updated Secret 1 value',
-            environmentSlug: environment.slug
+            environmentSlug
           }
         ],
         secretSlug
@@ -193,7 +192,7 @@ describe('Secret Controller Tests', () => {
     )
 
     const rollbackSecret = await secretController.rollbackSecret(
-      { secretSlug, environmentSlug: environment.slug, version: 1 },
+      { secretSlug, environmentSlug, version: 1 },
       { 'x-e2e-user-email': email }
     )
 
@@ -213,7 +212,7 @@ describe('Secret Controller Tests', () => {
   it('should get all secrets of an environment', async () => {
     const secrets: any = await secretController.getAllSecretsOfEnvironment(
       {
-        environmentSlug: environment.slug,
+        environmentSlug,
         projectSlug
       },
       { 'x-e2e-user-email': email }
@@ -246,7 +245,7 @@ describe('Secret Controller Tests', () => {
 
   it('should be able to fetch revisions of a secret', async () => {
     const revisions = await secretController.getRevisionsOfSecret(
-      { secretSlug, environmentSlug: environment.slug },
+      { secretSlug, environmentSlug},
       { 'x-e2e-user-email': email }
     )
     expect(revisions.data.items.length).toBe(1)

--- a/packages/api-client/tests/secret.spec.ts
+++ b/packages/api-client/tests/secret.spec.ts
@@ -12,6 +12,7 @@ describe('Secret Controller Tests', () => {
   let workspaceSlug: string | null
   let environmentSlug: string | null
   let secretSlug: string | null
+  let environment
 
   beforeAll(async () => {
     //Create the user's workspace
@@ -58,7 +59,8 @@ describe('Secret Controller Tests', () => {
       )
     ).json()) as any
 
-    environmentSlug = createEnvironmentResponse.slug
+    environment = createEnvironmentResponse
+    environmentSlug = environment.slug
   })
 
   afterAll(async () => {
@@ -115,6 +117,8 @@ describe('Secret Controller Tests', () => {
     expect(secret.data.name).toBe('Secret 2')
     expect(secret.data.slug).toBeDefined()
     expect(secret.data.versions.length).toBe(1)
+    expect(secret.data.versions[0].environment.id).toBe(environment.id)
+    expect(secret.data.versions[0].environment.slug).toBe(environmentSlug)
     expect(secret.error).toBe(null)
 
     // Delete the secret

--- a/packages/api-client/tests/secret.spec.ts
+++ b/packages/api-client/tests/secret.spec.ts
@@ -115,7 +115,7 @@ describe('Secret Controller Tests', () => {
     expect(secret.data.name).toBe('Secret 2')
     expect(secret.data.slug).toBeDefined()
     expect(secret.data.versions.length).toBe(1)
-    expect(secret.data.versions[0].environment.slug).toBe(environment.slug)
+    expect(secret.data.versions[0].environment.slug).toBe(environmentSlug)
     expect(secret.error).toBe(null)
 
     // Delete the secret

--- a/packages/api-client/tests/secret.spec.ts
+++ b/packages/api-client/tests/secret.spec.ts
@@ -1,5 +1,6 @@
 import { APIClient } from '../src/core/client'
 import SecretController from '../src/controllers/secret'
+import { Environment } from '@api-client/types/environment.types'
 
 describe('Secret Controller Tests', () => {
   const backendUrl = process.env.BACKEND_URL
@@ -10,9 +11,8 @@ describe('Secret Controller Tests', () => {
   const email = 'johndoe@example.com'
   let projectSlug: string | null
   let workspaceSlug: string | null
-  let environmentSlug: string | null
   let secretSlug: string | null
-  let environment
+  let environment: Environment
 
   beforeAll(async () => {
     //Create the user's workspace
@@ -60,7 +60,6 @@ describe('Secret Controller Tests', () => {
     ).json()) as any
 
     environment = createEnvironmentResponse
-    environmentSlug = environment.slug
   })
 
   afterAll(async () => {
@@ -78,7 +77,7 @@ describe('Secret Controller Tests', () => {
         note: 'Secret 1 note',
         entries: [
           {
-            environmentSlug,
+            environmentSlug: environment.slug,
             value: 'Secret 1 value'
           }
         ],
@@ -105,7 +104,7 @@ describe('Secret Controller Tests', () => {
         note: 'Secret 2 note',
         entries: [
           {
-            environmentSlug,
+            environmentSlug: environment.slug,
             value: 'Secret 1 value'
           }
         ],
@@ -117,8 +116,7 @@ describe('Secret Controller Tests', () => {
     expect(secret.data.name).toBe('Secret 2')
     expect(secret.data.slug).toBeDefined()
     expect(secret.data.versions.length).toBe(1)
-    expect(secret.data.versions[0].environment.id).toBe(environment.id)
-    expect(secret.data.versions[0].environment.slug).toBe(environmentSlug)
+    expect(secret.data.versions[0].environment.slug).toBe(environment.slug)
     expect(secret.error).toBe(null)
 
     // Delete the secret
@@ -155,7 +153,7 @@ describe('Secret Controller Tests', () => {
         entries: [
           {
             value: 'Updated Secret 1 value',
-            environmentSlug
+            environmentSlug: environment.slug
           }
         ],
         secretSlug
@@ -173,7 +171,7 @@ describe('Secret Controller Tests', () => {
         entries: [
           {
             value: 'Secret 1 value',
-            environmentSlug
+            environmentSlug: environment.slug
           }
         ],
         secretSlug
@@ -186,7 +184,7 @@ describe('Secret Controller Tests', () => {
         entries: [
           {
             value: 'Updated Secret 1 value',
-            environmentSlug
+            environmentSlug: environment.slug
           }
         ],
         secretSlug
@@ -195,7 +193,7 @@ describe('Secret Controller Tests', () => {
     )
 
     const rollbackSecret = await secretController.rollbackSecret(
-      { secretSlug, environmentSlug, version: 1 },
+      { secretSlug, environmentSlug: environment.slug, version: 1 },
       { 'x-e2e-user-email': email }
     )
 
@@ -215,7 +213,7 @@ describe('Secret Controller Tests', () => {
   it('should get all secrets of an environment', async () => {
     const secrets: any = await secretController.getAllSecretsOfEnvironment(
       {
-        environmentSlug,
+        environmentSlug: environment.slug,
         projectSlug
       },
       { 'x-e2e-user-email': email }
@@ -248,7 +246,7 @@ describe('Secret Controller Tests', () => {
 
   it('should be able to fetch revisions of a secret', async () => {
     const revisions = await secretController.getRevisionsOfSecret(
-      { secretSlug, environmentSlug },
+      { secretSlug, environmentSlug: environment.slug },
       { 'x-e2e-user-email': email }
     )
     expect(revisions.data.items.length).toBe(1)


### PR DESCRIPTION
### **User description**
## Description

Add environmentSlug in multiple places across the secret module <br />

Fixes #486 

## Developer's checklist

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-check on my work

**If changes are made in the code:**

- [X] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [X] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [X] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the secret module to include `environmentSlug` alongside `environmentId` in various places.
- Updated the secret service to select and return both `id` and `slug` for environments.
- Modified API client types to reflect the inclusion of `environment` details in secret versions.
- Added and updated tests in both the API and API client to verify the presence of `environment.id` and `environment.slug`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.e2e.spec.ts</strong><dd><code>Add tests for environment slug and id in secret versions</code>&nbsp; </dd></summary>
<hr>

apps/api/src/secret/secret.e2e.spec.ts

<li>Added tests to verify <code>environment.id</code> and <code>environment.slug</code> in secret <br>versions.<br> <li> Included <code>environment</code> in the Prisma query for secret versions.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/509/files#diff-598db59202ce7ecc8d2fb84528577afd14eac8275a30e174d704d6fc2b7f5c3b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secret.spec.ts</strong><dd><code>Add tests for environment slug and id in API client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/api-client/tests/secret.spec.ts

<li>Added tests to verify <code>environment.id</code> and <code>environment.slug</code> in API <br>client.<br> <li> Initialized <code>environment</code> variable for test setup.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/509/files#diff-4f38527eb4c63b4ddb03d7c6e668cc4bce26acafa0352464405521f47d7868f5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.service.ts</strong><dd><code>Include environment slug and id in secret service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/secret/service/secret.service.ts

<li>Updated secret service to include <code>environment.id</code> and <code>environment.slug</code>.<br> <li> Modified Prisma queries to select environment details.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/509/files#diff-dee38177617754972e3d3f727d7f1536566d7a784b7ffdda74aa97d6eec4cbc5">+39/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secret.types.d.ts</strong><dd><code>Update secret types to include environment slug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/api-client/src/types/secret.types.d.ts

<li>Updated <code>Secret</code> and <code>UpdateSecretResponse</code> interfaces to include <br><code>environment</code> object.<br> <li> Added <code>slug</code> to the <code>environment</code> object in types.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/509/files#diff-d0148d6535d1f0c29d4022e1be61df8ea298e755b37975b0238a0070510b6dc2">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information