### PR TITLE
feat(cli): Store `metrics_enabled` key in profile config

### DIFF
--- a/apps/cli/src/commands/base.command.ts
+++ b/apps/cli/src/commands/base.command.ts
@@ -17,6 +17,7 @@ export default abstract class BaseCommand {
   // Use these fields from the subclasses to make API requests if needed
   protected apiKey: string | null = null
   protected baseUrl: string | null = null
+  protected metricsEnabled: boolean | null = null
 
   // Headers to be used by the API requests
   protected headers: Record<string, string> | null = null
@@ -150,6 +151,7 @@ export default abstract class BaseCommand {
 
         this.apiKey = profile.apiKey
         this.baseUrl = profile.baseUrl
+        this.metricsEnabled = profile.metrics_enabled
       } else {
         throw new Error('Profile not found')
       }
@@ -167,6 +169,7 @@ export default abstract class BaseCommand {
       if (defaultProfile) {
         this.apiKey = defaultProfile.apiKey
         this.baseUrl = defaultProfile.baseUrl
+        this.metricsEnabled = defaultProfile.metrics_enabled
       }
     }
 

--- a/apps/cli/src/commands/profile/create.profile.ts
+++ b/apps/cli/src/commands/profile/create.profile.ts
@@ -47,7 +47,8 @@ export default class CreateProfile extends BaseCommand {
       {
         short: '-m',
         long: '--enable-metrics',
-        description: 'Enable anonymous metrics collection',
+        description:
+          'Should keyshade collect anonymous metrics for development?',
         defaultValue: false
       }
     ]

--- a/apps/cli/src/commands/profile/create.profile.ts
+++ b/apps/cli/src/commands/profile/create.profile.ts
@@ -43,6 +43,12 @@ export default class CreateProfile extends BaseCommand {
         long: '--set-default',
         description: 'Set the profile as the default profile',
         defaultValue: false
+      },
+      {
+        short: '-m',
+        long: '--enable-metrics',
+        description: 'Enable anonymous metrics collection',
+        defaultValue: false
       }
     ]
   }
@@ -50,7 +56,8 @@ export default class CreateProfile extends BaseCommand {
   async action({ options }: CommandActionData): Promise<void> {
     intro('Creating a new profile')
 
-    const { name, apiKey, baseUrl, setDefault } = await this.parseInput(options)
+    const { name, apiKey, baseUrl, setDefault, enableMetrics } =
+      await this.parseInput(options)
 
     this.profiles = await fetchProfileConfig()
     await this.checkOverwriteExistingProfile(name)
@@ -58,7 +65,7 @@ export default class CreateProfile extends BaseCommand {
     const s = spinner()
     s.start('Saving changes...')
 
-    this.setProfileConfigData(name, apiKey, baseUrl, setDefault)
+    this.setProfileConfigData(name, apiKey, baseUrl, setDefault, enableMetrics)
     await writeProfileConfig(this.profiles)
 
     s.stop()
@@ -70,8 +77,9 @@ export default class CreateProfile extends BaseCommand {
     apiKey?: string
     baseUrl?: string
     setDefault?: boolean
+    enableMetrics?: boolean
   }> {
-    let { name, apiKey, baseUrl, setDefault } = options
+    let { name, apiKey, baseUrl, setDefault, enableMetrics } = options
 
     if (!name) {
       name = await text({
@@ -84,6 +92,12 @@ export default class CreateProfile extends BaseCommand {
       apiKey = await text({
         message: 'Enter the API key for the profile',
         placeholder: 'ks_************'
+      })
+    }
+
+    if (!enableMetrics === undefined) {
+      enableMetrics = await confirm({
+        message: 'Should keyshade collect anonymous metrics for development?'
       })
     }
 
@@ -101,11 +115,18 @@ export default class CreateProfile extends BaseCommand {
           'API key must start with "ks_" and contain only letters and numbers.'
         ),
       baseUrl: z.string().url().or(z.string().length(0)).optional(),
-      setDefault: z.boolean().optional()
+      setDefault: z.boolean().optional(),
+      enableMetrics: z.boolean().optional()
     })
 
     // Validate the collected data
-    const parsedData = inputSchema.parse({ name, apiKey, baseUrl, setDefault })
+    const parsedData = inputSchema.parse({
+      name,
+      apiKey,
+      baseUrl,
+      setDefault,
+      enableMetrics
+    })
 
     return parsedData
   }
@@ -126,7 +147,8 @@ export default class CreateProfile extends BaseCommand {
     name: string,
     apiKey: string,
     baseUrl: string,
-    setDefault: boolean
+    setDefault: boolean,
+    enableMetrics: boolean
   ): void {
     if (setDefault) {
       this.profiles.default = name
@@ -134,7 +156,8 @@ export default class CreateProfile extends BaseCommand {
 
     this.profiles[name] = {
       apiKey,
-      baseUrl
+      baseUrl,
+      metrics_enabled: enableMetrics
     }
   }
 }

--- a/apps/cli/src/commands/profile/list.profile.ts
+++ b/apps/cli/src/commands/profile/list.profile.ts
@@ -78,11 +78,12 @@ export default class ListProfile extends BaseCommand {
         profileList.push([
           `${defaultProfile === profile ? `${profile} (default)` : profile}`,
           `${profiles[profile].apiKey}`,
-          `${profiles[profile].baseUrl}`
+          `${profiles[profile].baseUrl}`,
+          `${profiles[profile].metrics_enabled ? 'Yes' : 'No'}`
         ])
       })
       table.push(
-        ['Profile', 'API Key', 'Base URL'],
+        ['Profile', 'API Key', 'Base URL', 'Metrics Enabled'],
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         ...profileList
       )

--- a/apps/cli/src/commands/profile/update.profile.ts
+++ b/apps/cli/src/commands/profile/update.profile.ts
@@ -44,7 +44,8 @@ export default class UpdateProfile extends BaseCommand {
       {
         short: '-m',
         long: '--enable-metrics <boolean>',
-        description: 'Enable or disable anonymous metrics collection'
+        description:
+          'Should keyshade collect anonymous metrics for development?'
       }
     ]
   }

--- a/apps/cli/src/commands/profile/update.profile.ts
+++ b/apps/cli/src/commands/profile/update.profile.ts
@@ -40,6 +40,11 @@ export default class UpdateProfile extends BaseCommand {
         short: '-b',
         long: '--base-url <string>',
         description: 'New base URL for the keyshade server'
+      },
+      {
+        short: '-m',
+        long: '--enable-metrics <boolean>',
+        description: 'Enable or disable anonymous metrics collection'
       }
     ]
   }
@@ -48,7 +53,7 @@ export default class UpdateProfile extends BaseCommand {
     this.profiles = await fetchProfileConfig()
 
     const profile = args[0]
-    const { name, apiKey, baseUrl } = options
+    const { name, apiKey, baseUrl, enableMetrics } = options
 
     const s = spinner()
     s.start('Updating the profile')
@@ -58,7 +63,8 @@ export default class UpdateProfile extends BaseCommand {
       profile,
       name as string,
       apiKey as string,
-      baseUrl as string
+      baseUrl as string,
+      enableMetrics as boolean
     )
     await writeProfileConfig(this.profiles)
 
@@ -69,7 +75,8 @@ export default class UpdateProfile extends BaseCommand {
     profile: string,
     name: string,
     apiKey: string,
-    baseUrl: string
+    baseUrl: string,
+    enableMetrics: boolean
   ): void {
     const isDefaultProfile = checkIsDefaultProfile(this.profiles, profile)
 
@@ -79,6 +86,10 @@ export default class UpdateProfile extends BaseCommand {
 
     if (baseUrl) {
       this.profiles[profile].baseUrl = baseUrl
+    }
+
+    if (enableMetrics !== undefined) {
+      this.profiles[profile].metrics_enabled = enableMetrics
     }
 
     if (name) {

--- a/apps/cli/src/types/index.types.d.ts
+++ b/apps/cli/src/types/index.types.d.ts
@@ -10,6 +10,7 @@ export interface ProfileConfig {
   [name: string]: {
     apiKey: string
     baseUrl: string
+    metrics_enabled: boolean
   }
 }
 


### PR DESCRIPTION
### **User description**
## Description

- `index.types.d.ts`: Added `metrics_enabled` boolean to the ProfileConfig.
- `create.profile.ts`: Introduced `-m, --enable-metrics` for enabling/disabling metrics collection.
- `update.profile.ts`: Added the flag to update the metrics collection status.
- `list.profile.ts`: Displayed `Metrics Enabled` column in the profile table
- `base.command.ts`: Added `metricsEnabled` to store and manage the metrics setting.

Fixes #528 

## Developer's checklist

- [✅] My PR follows the style guidelines of this project

- [❌] I have performed a self-check on my work


___

### **PR Type**
Enhancement


___

### **Description**
- Added a `metrics_enabled` key to the `ProfileConfig` interface to support metrics collection.
- Introduced `--enable-metrics` flag in `create.profile.ts` for enabling/disabling metrics during profile creation.
- Updated `update.profile.ts` to allow modification of the metrics setting for existing profiles.
- Enhanced `list.profile.ts` to display the metrics enabled status in the profile list.
- Modified `base.command.ts` to store and manage the metrics setting within the command base class.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.command.ts</strong><dd><code>Add metricsEnabled property to BaseCommand class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/base.command.ts

<li>Added <code>metricsEnabled</code> property to the <code>BaseCommand</code> class.<br> <li> Updated logic to initialize <code>metricsEnabled</code> from profile configuration.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/536/files#diff-980d8a71431fbbd62a18657e807607090029c54ea39d825e1535ceb4ce289b36">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create.profile.ts</strong><dd><code>Add enable-metrics flag to profile creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/profile/create.profile.ts

<li>Introduced <code>--enable-metrics</code> flag for profile creation.<br> <li> Updated input parsing to include metrics option.<br> <li> Modified profile configuration to store metrics setting.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/536/files#diff-71f3f4ea9fcc92ffe9e871082369710fad3f7e2120141ffa595a07d0add4c329">+30/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list.profile.ts</strong><dd><code>Display metrics enabled status in profile list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/profile/list.profile.ts

- Added `Metrics Enabled` column to profile listing.



</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/536/files#diff-4d80b74d95d3f96b1b5343ce7ba0f0aec77ca5f627917b38d1626f9eefb00e9a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update.profile.ts</strong><dd><code>Add enable-metrics flag to profile update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/profile/update.profile.ts

<li>Added <code>--enable-metrics</code> flag for updating profiles.<br> <li> Updated profile data to handle metrics setting.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/536/files#diff-1022d0c11dea57a922404e0431dd9410310900120338d22d8a4ebaffb0889f88">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.types.d.ts</strong><dd><code>Update ProfileConfig interface with metrics_enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/types/index.types.d.ts

- Added `metrics_enabled` boolean to `ProfileConfig` interface.



</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/536/files#diff-e98c0a3c91ecf88e57bf648844ce8e40d14cfbc93779cdbc61d279c8f609b880">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information