### PR TITLE
refactor(schema): add describe blocks in tests for each kind of schema

### DIFF
--- a/packages/schema/src/secret/index.ts
+++ b/packages/schema/src/secret/index.ts
@@ -84,7 +84,7 @@ export const RollBackSecretRequestSchema = z.object({
 })
 
 export const RollBackSecretResponseSchema = z.object({
-  count: z.string()
+  count: z.number()
 })
 
 export const GetAllSecretsOfProjectRequestSchema = PageRequestSchema.extend({

--- a/packages/schema/src/variable/index.ts
+++ b/packages/schema/src/variable/index.ts
@@ -84,7 +84,7 @@ export const RollBackVariableRequestSchema = z.object({
 })
 
 export const RollBackVariableResponseSchema = z.object({
-  count: z.string()
+  count: z.number()
 })
 
 export const DeleteVariableRequestSchema = z.object({

--- a/packages/schema/tests/api-key.spec.ts
+++ b/packages/schema/tests/api-key.spec.ts
@@ -14,340 +14,354 @@ import {
   CanAccessLiveUpdatesApiKeyResponseSchema
 } from '@/api-key'
 
-describe('API Key Schema Tests', () => {
-  // Tests for ApiKeySchema
-  it('should validate a valid ApiKeySchema', () => {
-    const result = ApiKeySchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      value: 'api-key-value',
-      expiresAt: '2024-10-10T10:00:00Z',
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['READ_SECRET', 'READ_VARIABLE'],
-      userId: 'user123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid ApiKeySchema', () => {
-    const result = ApiKeySchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      value: 'api-key-value',
-      expiresAt: 'invalid-date', // Should be a valid date string
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'] // Invalid authority
-      // no userId
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for CreateApiKeyRequestSchema
-  it('should validate if proper input is specified for CreateApiKeyRequestSchema', () => {
-    const result = CreateApiKeyRequestSchema.safeParse({
-      name: 'test',
-      expiresAfter: '720',
-      authorities: ['UPDATE_PROJECT']
+describe('API Key Schemas Tests', () => {
+  describe('ApiKeySchema Tests', () => {
+    it('should validate a valid ApiKeySchema', () => {
+      const result = ApiKeySchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        value: 'api-key-value',
+        expiresAt: '2024-10-10T10:00:00Z',
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['READ_SECRET', 'READ_VARIABLE'],
+        userId: 'user123'
+      })
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
+    it('should not validate an invalid ApiKeySchema', () => {
+      const result = ApiKeySchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        value: 'api-key-value',
+        expiresAt: 'invalid-date', // Should be a valid date string
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'] // Invalid authority
+        // no userId
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  it('should validate if optional fields are specified for CreateApiKeyRequestSchema', () => {
-    const result = CreateApiKeyRequestSchema.safeParse({
-      name: 'test',
-      expiresAfter: '720',
-      authorities: ['UPDATE_PROJECT'],
-      slug: 'test-slug'
+  describe('CreateApiKeyRequestSchema Tests', () => {
+    it('should validate if proper input is specified for CreateApiKeyRequestSchema', () => {
+      const result = CreateApiKeyRequestSchema.safeParse({
+        name: 'test',
+        expiresAfter: '720',
+        authorities: ['UPDATE_PROJECT']
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should validate if optional fields are specified for CreateApiKeyRequestSchema', () => {
+      const result = CreateApiKeyRequestSchema.safeParse({
+        name: 'test',
+        expiresAfter: '720',
+        authorities: ['UPDATE_PROJECT'],
+        slug: 'test-slug'
+      })
 
-  it('should not validate if invalid values are specified for CreateApiKeyRequestSchema', () => {
-    const result = CreateApiKeyRequestSchema.safeParse({
-      name: 123,
-      expiresAfter: 123
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
+    it('should not validate if invalid values are specified for CreateApiKeyRequestSchema', () => {
+      const result = CreateApiKeyRequestSchema.safeParse({
+        name: 123,
+        expiresAfter: 123
+      })
 
-  it('should not validate if required values are not specified for CreateApiKeyRequestSchema', () => {
-    const result = CreateApiKeyRequestSchema.safeParse({})
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for CreateApiKeyResponseSchema
-  it('should validate a valid CreateApiKeyResponseSchema', () => {
-    const result = CreateApiKeyResponseSchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      value: 'api-key-value',
-      expiresAt: '2024-10-10T10:00:00Z',
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['READ_SECRET', 'READ_VARIABLE'],
-      userId: 'user123'
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid CreateApiKeyResponseSchema', () => {
-    const result = CreateApiKeyResponseSchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      value: 'api-key-value',
-      expiresAt: 'invalid-date', // Should be a valid date string
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'], // Invalid authority
-      expiresAfter: 'INVALID_EXPIRES_AFTER' // Invalid expiresAfter
-      // no userId
+    it('should not validate if required values are not specified for CreateApiKeyRequestSchema', () => {
+      const result = CreateApiKeyRequestSchema.safeParse({})
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
   })
 
-  // Tests for UpdateApiKeyRequestSchema
-  it('should validate a valid UpdateApiKeyRequestSchema', () => {
-    const result = UpdateApiKeyRequestSchema.safeParse({
-      apiKeySlug: 'api-key-slug',
-      name: 'Updated API Key Name',
-      authorities: ['READ_SECRET', 'READ_VARIABLE'],
-      expiresAfter: '24'
+  describe('CreateApiKeyResponseSchema Tests', () => {
+    it('should validate a valid CreateApiKeyResponseSchema', () => {
+      const result = CreateApiKeyResponseSchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        value: 'api-key-value',
+        expiresAt: '2024-10-10T10:00:00Z',
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['READ_SECRET', 'READ_VARIABLE'],
+        userId: 'user123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid UpdateApiKeyRequestSchema', () => {
-    const result = UpdateApiKeyRequestSchema.safeParse({
-      // apiKeySlug is missing
-      name: 'Updated API Key Name',
-      authorities: ['INVALID_AUTHORITY'], // Invalid authority
-      expiresAfter: 'INVALID_EXPIRES_AFTER' // Invalid expiresAfter
+    it('should not validate an invalid CreateApiKeyResponseSchema', () => {
+      const result = CreateApiKeyResponseSchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        value: 'api-key-value',
+        expiresAt: 'invalid-date', // Should be a valid date string
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'], // Invalid authority
+        expiresAfter: 'INVALID_EXPIRES_AFTER' // Invalid expiresAfter
+        // no userId
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
   })
 
-  // Tests for UpdateApiKeyResponseSchema
-  it('should validate a valid UpdateApiKeyResponseSchema', () => {
-    const result = UpdateApiKeyResponseSchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      expiresAt: '2024-10-10T10:00:00Z',
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['READ_SECRET', 'READ_VARIABLE']
+  describe('UpdateApiKeyRequestSchema Tests', () => {
+    it('should validate a valid UpdateApiKeyRequestSchema', () => {
+      const result = UpdateApiKeyRequestSchema.safeParse({
+        apiKeySlug: 'api-key-slug',
+        name: 'Updated API Key Name',
+        authorities: ['READ_SECRET', 'READ_VARIABLE'],
+        expiresAfter: '24'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid UpdateApiKeyResponseSchema', () => {
-    const result = UpdateApiKeyResponseSchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      expiresAt: 'invalid-date', // Should be a valid date string
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'] // Invalid authority
+    it('should not validate an invalid UpdateApiKeyRequestSchema', () => {
+      const result = UpdateApiKeyRequestSchema.safeParse({
+        // apiKeySlug is missing
+        name: 'Updated API Key Name',
+        authorities: ['INVALID_AUTHORITY'], // Invalid authority
+        expiresAfter: 'INVALID_EXPIRES_AFTER' // Invalid expiresAfter
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
   })
 
-  // Tests for DeleteApiKeyRequestSchema
-  it('should validate a valid DeleteApiKeyRequestSchema', () => {
-    const result = DeleteApiKeyRequestSchema.safeParse({
-      apiKeySlug: 'api-key-slug'
+  describe('UpdateApiKeyResponseSchema Tests', () => {
+    it('should validate a valid UpdateApiKeyResponseSchema', () => {
+      const result = UpdateApiKeyResponseSchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        expiresAt: '2024-10-10T10:00:00Z',
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['READ_SECRET', 'READ_VARIABLE']
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid DeleteApiKeyRequestSchema', () => {
-    const result = DeleteApiKeyRequestSchema.safeParse({
-      apiKeySlug: 123 // Should be a string
+    it('should not validate an invalid UpdateApiKeyResponseSchema', () => {
+      const result = UpdateApiKeyResponseSchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        expiresAt: 'invalid-date', // Should be a valid date string
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'] // Invalid authority
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1) // Adjust the number based on invalid fields
   })
 
-  // Tests for DeleteApiKeyResponseSchema
-  it('should validate a valid DeleteApiKeyResponseSchema', () => {
-    const result = DeleteApiKeyResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteApiKeyResponseSchema', () => {
-    const result = DeleteApiKeyResponseSchema.safeParse({
-      unexpectedField: 'value'
+  describe('DeleteApiKeyRequestSchema Tests', () => {
+    it('should validate a valid DeleteApiKeyRequestSchema', () => {
+      const result = DeleteApiKeyRequestSchema.safeParse({
+        apiKeySlug: 'api-key-slug'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-  })
 
-  // Tests for GetApiKeysOfUserRequestSchema
-  it('should validate a valid GetApiKeysOfUserRequestSchema', () => {
-    const result = GetApiKeysOfUserRequestSchema.safeParse({
-      page: 1,
-      limit: 10
+    it('should not validate an invalid DeleteApiKeyRequestSchema', () => {
+      const result = DeleteApiKeyRequestSchema.safeParse({
+        apiKeySlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1) // Adjust the number based on invalid fields
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid GetApiKeysOfUserRequestSchema', () => {
-    const result = GetApiKeysOfUserRequestSchema.safeParse({
-      page: 'one', // Should be a number
-      limit: 10
+  describe('DeleteApiKeyResponseSchema Tests', () => {
+    it('should validate a valid DeleteApiKeyResponseSchema', () => {
+      const result = DeleteApiKeyResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid DeleteApiKeyResponseSchema', () => {
+      const result = DeleteApiKeyResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
   })
 
-  // Tests for GetApiKeysOfUserResponseSchema
-  it('should validate a valid GetApiKeysOfUserResponseSchema', () => {
-    const result = GetApiKeysOfUserResponseSchema.safeParse({
-      items: [
-        {
-          id: 'apikey123',
-          name: 'API Key Name',
-          slug: 'api-key-slug',
-          expiresAt: '2024-10-10T10:00:00Z',
-          createdAt: '2024-10-09T10:00:00Z',
-          updatedAt: '2024-10-09T10:00:00Z',
-          authorities: ['READ_SECRET', 'READ_VARIABLE']
-        }
-      ],
-      metadata: {
+  describe('GetApiKeysOfUserRequestSchema Tests', () => {
+    it('should validate a valid GetApiKeysOfUserRequestSchema', () => {
+      const result = GetApiKeysOfUserRequestSchema.safeParse({
         page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+        limit: 10
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetApiKeysOfUserRequestSchema', () => {
+      const result = GetApiKeysOfUserRequestSchema.safeParse({
+        page: 'one', // Should be a number
+        limit: 10
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('GetApiKeysOfUserResponseSchema Tests', () => {
+    it('should validate a valid GetApiKeysOfUserResponseSchema', () => {
+      const result = GetApiKeysOfUserResponseSchema.safeParse({
+        items: [
+          {
+            id: 'apikey123',
+            name: 'API Key Name',
+            slug: 'api-key-slug',
+            expiresAt: '2024-10-10T10:00:00Z',
+            createdAt: '2024-10-09T10:00:00Z',
+            updatedAt: '2024-10-09T10:00:00Z',
+            authorities: ['READ_SECRET', 'READ_VARIABLE']
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid GetApiKeysOfUserResponseSchema', () => {
-    const result = GetApiKeysOfUserResponseSchema.safeParse({
-      items: [
-        {
-          id: 'apikey123',
-          name: 'API Key Name',
-          slug: 'api-key-slug',
-          expiresAt: 'invalid-date', // Should be a valid date string
-          createdAt: '2024-10-09T10:00:00Z',
-          updatedAt: '2024-10-09T10:00:00Z',
-          authorities: ['INVALID_AUTHORITY'] // Invalid authority
+    it('should not validate an invalid GetApiKeysOfUserResponseSchema', () => {
+      const result = GetApiKeysOfUserResponseSchema.safeParse({
+        items: [
+          {
+            id: 'apikey123',
+            name: 'API Key Name',
+            slug: 'api-key-slug',
+            expiresAt: 'invalid-date', // Should be a valid date string
+            createdAt: '2024-10-09T10:00:00Z',
+            updatedAt: '2024-10-09T10:00:00Z',
+            authorities: ['INVALID_AUTHORITY'] // Invalid authority
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
   })
 
-  // Tests for GetApiKeyRequestSchema
-  it('should validate a valid GetApiKeyRequestSchema', () => {
-    const result = GetApiKeyRequestSchema.safeParse({
-      apiKeySlug: 'api-key-slug'
+  describe('GetApiKeyRequestSchema Tests', () => {
+    it('should validate a valid GetApiKeyRequestSchema', () => {
+      const result = GetApiKeyRequestSchema.safeParse({
+        apiKeySlug: 'api-key-slug'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid GetApiKeyRequestSchema', () => {
+      const result = GetApiKeyRequestSchema.safeParse({
+        apiKeySlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should not validate an invalid GetApiKeyRequestSchema', () => {
-    const result = GetApiKeyRequestSchema.safeParse({
-      apiKeySlug: 123 // Should be a string
+  describe('GetApiKeyResponseSchema Tests', () => {
+    it('should validate a valid GetApiKeyResponseSchema', () => {
+      const result = GetApiKeyResponseSchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        expiresAt: '2024-10-10T10:00:00Z',
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['READ_SECRET', 'READ_VARIABLE']
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid GetApiKeyResponseSchema', () => {
+      const result = GetApiKeyResponseSchema.safeParse({
+        id: 'apikey123',
+        name: 'API Key Name',
+        slug: 'api-key-slug',
+        expiresAt: 'invalid-date', // Should be a valid date string
+        createdAt: '2024-10-09T10:00:00Z',
+        updatedAt: '2024-10-09T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'] // Invalid authority
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  // Tests for GetApiKeyResponseSchema
-  it('should validate a valid GetApiKeyResponseSchema', () => {
-    const result = GetApiKeyResponseSchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      expiresAt: '2024-10-10T10:00:00Z',
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['READ_SECRET', 'READ_VARIABLE']
+  describe('CanAccessLiveUpdatesApiKeyRequestSchema Tests', () => {
+    it('should validate a valid CanAccessLiveUpdatesApiKeyRequestSchema', () => {
+      const result =
+        CanAccessLiveUpdatesApiKeyRequestSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid CanAccessLiveUpdatesApiKeyRequestSchema', () => {
+      const result = CanAccessLiveUpdatesApiKeyRequestSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
   })
 
-  it('should not validate an invalid GetApiKeyResponseSchema', () => {
-    const result = GetApiKeyResponseSchema.safeParse({
-      id: 'apikey123',
-      name: 'API Key Name',
-      slug: 'api-key-slug',
-      expiresAt: 'invalid-date', // Should be a valid date string
-      createdAt: '2024-10-09T10:00:00Z',
-      updatedAt: '2024-10-09T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'] // Invalid authority
+  describe('CanAccessLiveUpdatesApiKeyResponseSchema Tests', () => {
+    it('should validate a valid CanAccessLiveUpdatesApiKeyResponseSchema', () => {
+      const result = CanAccessLiveUpdatesApiKeyResponseSchema.safeParse({
+        canAccessLiveUpdates: true
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
 
-  // Tests for CanAccessLiveUpdatesApiKeyRequestSchema
-  it('should validate a valid CanAccessLiveUpdatesApiKeyRequestSchema', () => {
-    const result = CanAccessLiveUpdatesApiKeyRequestSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CanAccessLiveUpdatesApiKeyRequestSchema', () => {
-    const result = CanAccessLiveUpdatesApiKeyRequestSchema.safeParse({
-      unexpectedField: 'value'
+    it('should not validate an invalid CanAccessLiveUpdatesApiKeyResponseSchema', () => {
+      const result = CanAccessLiveUpdatesApiKeyResponseSchema.safeParse({
+        canAccessLiveUpdates: 'true' // Should be a boolean
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1) // Adjust the number based on invalid fields
     })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for CanAccessLiveUpdatesApiKeyResponseSchema
-  it('should validate a valid CanAccessLiveUpdatesApiKeyResponseSchema', () => {
-    const result = CanAccessLiveUpdatesApiKeyResponseSchema.safeParse({
-      canAccessLiveUpdates: true
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CanAccessLiveUpdatesApiKeyResponseSchema', () => {
-    const result = CanAccessLiveUpdatesApiKeyResponseSchema.safeParse({
-      canAccessLiveUpdates: 'true' // Should be a boolean
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1) // Adjust the number based on invalid fields
   })
 })

--- a/packages/schema/tests/auth.spec.ts
+++ b/packages/schema/tests/auth.spec.ts
@@ -1,52 +1,54 @@
 import { ResendOTPRequestSchema, ResendOTPResponseSchema } from '../src/auth'
 
 describe('Auth Schema Tests', () => {
-  // Tests for ResendOTPRequestSchema
-  it('should validate a valid ResendOTPRequestSchema', () => {
-    const result = ResendOTPRequestSchema.safeParse({
-      userEmail: 'test@example.com'
+  describe('ResendOTPRequestSchema Tests', () => {
+    it('should validate a valid ResendOTPRequestSchema', () => {
+      const result = ResendOTPRequestSchema.safeParse({
+        userEmail: 'test@example.com'
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should not validate an invalid ResendOTPRequestSchema with a non email string', () => {
+      const result = ResendOTPRequestSchema.safeParse({
+        userEmail: 'invalid-email'
+      })
 
-  it('should not validate an invalid ResendOTPRequestSchema with a non email string', () => {
-    const result = ResendOTPRequestSchema.safeParse({
-      userEmail: 'invalid-email'
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0]?.path).toEqual(['userEmail'])
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0]?.path).toEqual(['userEmail'])
-  })
+    it('should not validate an invalid ResendOTPRequestSchema with userEmail of different type', () => {
+      const result = ResendOTPRequestSchema.safeParse({
+        userEmail: 456
+      })
 
-  it('should not validate an invalid ResendOTPRequestSchema with userEmail of different type', () => {
-    const result = ResendOTPRequestSchema.safeParse({
-      userEmail: 456
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0]?.path).toEqual(['userEmail'])
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0]?.path).toEqual(['userEmail'])
+    it('should not validate an invalid ResendOTPRequestSchema with missing userEmail', () => {
+      const result = ResendOTPRequestSchema.safeParse({})
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0]?.path).toEqual(['userEmail'])
+    })
   })
 
-  it('should not validate an invalid ResendOTPRequestSchema with missing userEmail', () => {
-    const result = ResendOTPRequestSchema.safeParse({})
+  describe('ResendOTPResponseSchema Tests', () => {
+    it('should validate an empty response for ResendOTPResponseSchema', () => {
+      const result = ResendOTPResponseSchema.safeParse(undefined)
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0]?.path).toEqual(['userEmail'])
-  })
-
-  // Tests for ResendOTPResponseSchema
-  it('should validate an empty response for ResendOTPResponseSchema', () => {
-    const result = ResendOTPResponseSchema.safeParse(undefined)
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate when unexpected fields are provided for ResendOTPResponseSchema', () => {
-    const result = ResendOTPResponseSchema.safeParse({
-      unexpectedField: 'value'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
+    it('should not validate when unexpected fields are provided for ResendOTPResponseSchema', () => {
+      const result = ResendOTPResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+
+      expect(result.success).toBe(false)
+    })
   })
 })

--- a/packages/schema/tests/enums.test.ts
+++ b/packages/schema/tests/enums.test.ts
@@ -10,139 +10,157 @@ import {
   projectAccessLevelEnum
 } from '@//enums'
 
-describe('Enums Tests', () => {
-  it('integrationTypeEnum should have correct values', () => {
-    expect(integrationTypeEnum.options).toEqual([
-      'DISCORD',
-      'SLACK',
-      'GITHUB',
-      'GITLAB'
-    ])
+describe('Enums Schema Tests', () => {
+  describe('integrationTypeEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(integrationTypeEnum.options).toEqual([
+        'DISCORD',
+        'SLACK',
+        'GITHUB',
+        'GITLAB'
+      ])
+    })
   })
 
-  it('expiresAfterEnum should have correct values', () => {
-    expect(expiresAfterEnum.options).toEqual([
-      'never',
-      '24',
-      '168',
-      '720',
-      '8760'
-    ])
+  describe('expiresAfterEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(expiresAfterEnum.options).toEqual([
+        'never',
+        '24',
+        '168',
+        '720',
+        '8760'
+      ])
+    })
   })
 
-  it('rotateAfterEnum should have correct values', () => {
-    expect(rotateAfterEnum.options).toEqual([
-      'never',
-      '24',
-      '168',
-      '720',
-      '8760'
-    ])
+  describe('rotateAfterEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(rotateAfterEnum.options).toEqual([
+        'never',
+        '24',
+        '168',
+        '720',
+        '8760'
+      ])
+    })
   })
 
-  it('eventSourceEnum should have correct values', () => {
-    expect(eventSourceEnum.options).toEqual([
-      'SECRET',
-      'VARIABLE',
-      'ENVIRONMENT',
-      'PROJECT',
-      'WORKSPACE',
-      'WORKSPACE_ROLE',
-      'INTEGRATION'
-    ])
+  describe('eventSourceEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(eventSourceEnum.options).toEqual([
+        'SECRET',
+        'VARIABLE',
+        'ENVIRONMENT',
+        'PROJECT',
+        'WORKSPACE',
+        'WORKSPACE_ROLE',
+        'INTEGRATION'
+      ])
+    })
   })
 
-  it('eventTriggererEnum should have correct values', () => {
-    expect(eventTriggererEnum.options).toEqual(['USER', 'SYSTEM'])
+  describe('eventTriggererEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(eventTriggererEnum.options).toEqual(['USER', 'SYSTEM'])
+    })
   })
 
-  it('eventSeverityEnum should have correct values', () => {
-    expect(eventSeverityEnum.options).toEqual(['INFO', 'WARN', 'ERROR'])
+  describe('eventSeverityEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(eventSeverityEnum.options).toEqual(['INFO', 'WARN', 'ERROR'])
+    })
   })
 
-  it('eventTypeEnum should have correct values', () => {
-    expect(eventTypeEnum.options).toEqual([
-      'INVITED_TO_WORKSPACE',
-      'REMOVED_FROM_WORKSPACE',
-      'ACCEPTED_INVITATION',
-      'DECLINED_INVITATION',
-      'CANCELLED_INVITATION',
-      'LEFT_WORKSPACE',
-      'WORKSPACE_MEMBERSHIP_UPDATED',
-      'WORKSPACE_UPDATED',
-      'WORKSPACE_CREATED',
-      'WORKSPACE_ROLE_CREATED',
-      'WORKSPACE_ROLE_UPDATED',
-      'WORKSPACE_ROLE_DELETED',
-      'PROJECT_CREATED',
-      'PROJECT_UPDATED',
-      'PROJECT_DELETED',
-      'SECRET_UPDATED',
-      'SECRET_DELETED',
-      'SECRET_ADDED',
-      'VARIABLE_UPDATED',
-      'VARIABLE_DELETED',
-      'VARIABLE_ADDED',
-      'ENVIRONMENT_UPDATED',
-      'ENVIRONMENT_DELETED',
-      'ENVIRONMENT_ADDED',
-      'INTEGRATION_ADDED',
-      'INTEGRATION_UPDATED',
-      'INTEGRATION_DELETED'
-    ])
+  describe('eventTypeEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(eventTypeEnum.options).toEqual([
+        'INVITED_TO_WORKSPACE',
+        'REMOVED_FROM_WORKSPACE',
+        'ACCEPTED_INVITATION',
+        'DECLINED_INVITATION',
+        'CANCELLED_INVITATION',
+        'LEFT_WORKSPACE',
+        'WORKSPACE_MEMBERSHIP_UPDATED',
+        'WORKSPACE_UPDATED',
+        'WORKSPACE_CREATED',
+        'WORKSPACE_ROLE_CREATED',
+        'WORKSPACE_ROLE_UPDATED',
+        'WORKSPACE_ROLE_DELETED',
+        'PROJECT_CREATED',
+        'PROJECT_UPDATED',
+        'PROJECT_DELETED',
+        'SECRET_UPDATED',
+        'SECRET_DELETED',
+        'SECRET_ADDED',
+        'VARIABLE_UPDATED',
+        'VARIABLE_DELETED',
+        'VARIABLE_ADDED',
+        'ENVIRONMENT_UPDATED',
+        'ENVIRONMENT_DELETED',
+        'ENVIRONMENT_ADDED',
+        'INTEGRATION_ADDED',
+        'INTEGRATION_UPDATED',
+        'INTEGRATION_DELETED'
+      ])
+    })
   })
 
-  it('authorityEnum should have correct values', () => {
-    expect(authorityEnum.options).toEqual([
-      'CREATE_PROJECT',
-      'READ_USERS',
-      'ADD_USER',
-      'REMOVE_USER',
-      'UPDATE_USER_ROLE',
-      'READ_WORKSPACE',
-      'UPDATE_WORKSPACE',
-      'DELETE_WORKSPACE',
-      'CREATE_WORKSPACE_ROLE',
-      'READ_WORKSPACE_ROLE',
-      'UPDATE_WORKSPACE_ROLE',
-      'DELETE_WORKSPACE_ROLE',
-      'WORKSPACE_ADMIN',
-      'READ_PROJECT',
-      'UPDATE_PROJECT',
-      'DELETE_PROJECT',
-      'CREATE_SECRET',
-      'READ_SECRET',
-      'UPDATE_SECRET',
-      'DELETE_SECRET',
-      'CREATE_ENVIRONMENT',
-      'READ_ENVIRONMENT',
-      'UPDATE_ENVIRONMENT',
-      'DELETE_ENVIRONMENT',
-      'CREATE_VARIABLE',
-      'READ_VARIABLE',
-      'UPDATE_VARIABLE',
-      'DELETE_VARIABLE',
-      'CREATE_INTEGRATION',
-      'READ_INTEGRATION',
-      'UPDATE_INTEGRATION',
-      'DELETE_INTEGRATION',
-      'CREATE_WORKSPACE',
-      'CREATE_API_KEY',
-      'READ_API_KEY',
-      'UPDATE_API_KEY',
-      'DELETE_API_KEY',
-      'UPDATE_PROFILE',
-      'READ_SELF',
-      'UPDATE_SELF',
-      'READ_EVENT'
-    ])
+  describe('authorityEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(authorityEnum.options).toEqual([
+        'CREATE_PROJECT',
+        'READ_USERS',
+        'ADD_USER',
+        'REMOVE_USER',
+        'UPDATE_USER_ROLE',
+        'READ_WORKSPACE',
+        'UPDATE_WORKSPACE',
+        'DELETE_WORKSPACE',
+        'CREATE_WORKSPACE_ROLE',
+        'READ_WORKSPACE_ROLE',
+        'UPDATE_WORKSPACE_ROLE',
+        'DELETE_WORKSPACE_ROLE',
+        'WORKSPACE_ADMIN',
+        'READ_PROJECT',
+        'UPDATE_PROJECT',
+        'DELETE_PROJECT',
+        'CREATE_SECRET',
+        'READ_SECRET',
+        'UPDATE_SECRET',
+        'DELETE_SECRET',
+        'CREATE_ENVIRONMENT',
+        'READ_ENVIRONMENT',
+        'UPDATE_ENVIRONMENT',
+        'DELETE_ENVIRONMENT',
+        'CREATE_VARIABLE',
+        'READ_VARIABLE',
+        'UPDATE_VARIABLE',
+        'DELETE_VARIABLE',
+        'CREATE_INTEGRATION',
+        'READ_INTEGRATION',
+        'UPDATE_INTEGRATION',
+        'DELETE_INTEGRATION',
+        'CREATE_WORKSPACE',
+        'CREATE_API_KEY',
+        'READ_API_KEY',
+        'UPDATE_API_KEY',
+        'DELETE_API_KEY',
+        'UPDATE_PROFILE',
+        'READ_SELF',
+        'UPDATE_SELF',
+        'READ_EVENT'
+      ])
+    })
   })
 
-  it('projectAccessLevelEnum should have correct values', () => {
-    expect(projectAccessLevelEnum.options).toEqual([
-      'GLOBAL',
-      'INTERNAL',
-      'PRIVATE'
-    ])
+  describe('projectAccessLevelEnum Tests', () => {
+    it('should have correct values', () => {
+      expect(projectAccessLevelEnum.options).toEqual([
+        'GLOBAL',
+        'INTERNAL',
+        'PRIVATE'
+      ])
+    })
   })
 })

--- a/packages/schema/tests/environment.spec.ts
+++ b/packages/schema/tests/environment.spec.ts
@@ -13,319 +13,330 @@ import {
 } from '@/environment'
 
 describe('Environment Schema Tests', () => {
-  // Tests for EnvironmentSchema
-  it('should validate a valid EnvironmentSchema', () => {
-    const result = EnvironmentSchema.safeParse({
-      id: 'env123',
-      name: 'Development',
-      slug: 'development',
-      description: null,
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: 'project123'
+  describe('EnvironmentSchema Tests', () => {
+    it('should validate a valid EnvironmentSchema', () => {
+      const result = EnvironmentSchema.safeParse({
+        id: 'env123',
+        name: 'Development',
+        slug: 'development',
+        description: null,
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: 'project123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid EnvironmentSchema with missing fields', () => {
+      const result = EnvironmentSchema.safeParse({
+        id: 'env123',
+        name: 'Development'
+        // Missing required fields
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(6)
+    })
+
+    it('should not validate an invalid EnvironmentSchema with incorrect types', () => {
+      const result = EnvironmentSchema.safeParse({
+        id: 'env123',
+        name: 'Development',
+        slug: 'development',
+        description: 'Development environment',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should not validate an invalid EnvironmentSchema with missing fields', () => {
-    const result = EnvironmentSchema.safeParse({
-      id: 'env123',
-      name: 'Development'
-      // Missing required fields
+  describe('CreateEnvironmentRequestSchema Tests', () => {
+    it('should validate if proper input is specified for CreateEnvironmentRequestSchema', () => {
+      const result = CreateEnvironmentRequestSchema.safeParse({
+        name: 'test',
+        description: 'test description',
+        projectSlug: 'project123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(6)
+
+    it('should not validate if invalid values are specified for CreateEnvironmentRequestSchema', () => {
+      const result = CreateEnvironmentRequestSchema.safeParse({
+        name: 123,
+        projectSlug: 'project123'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+
+    it('should not validate if required values are not specified for CreateEnvironmentRequestSchema', () => {
+      const result = CreateEnvironmentRequestSchema.safeParse({
+        name: 'test'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should not validate an invalid EnvironmentSchema with incorrect types', () => {
-    const result = EnvironmentSchema.safeParse({
-      id: 'env123',
-      name: 'Development',
-      slug: 'development',
-      description: 'Development environment',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: 123 // Should be a string
+  describe('CreateEnvironmentResponseSchema Tests', () => {
+    it('should validate a valid CreateEnvironmentResponseSchema', () => {
+      const result = CreateEnvironmentResponseSchema.safeParse({
+        id: 'env123',
+        name: 'Development',
+        slug: 'development',
+        description: 'Development environment',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: 'project123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid CreateEnvironmentResponseSchema with multiple incorrect types', () => {
+      const result = CreateEnvironmentResponseSchema.safeParse({
+        id: 123, // Should be a string
+        name: 'Development',
+        slug: 'development',
+        description: 456, // Should be a string or null
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: true // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  // Tests for CreateEnvironmentRequestSchema
-  it('should validate if proper input is specified for CreateEnvironmentRequestSchema', () => {
-    const result = CreateEnvironmentRequestSchema.safeParse({
-      name: 'test',
-      description: 'test description',
-      projectSlug: 'project123'
+  describe('UpdateEnvironmentRequestSchema Tests', () => {
+    it('should validate if proper input is specified for UpdateEnvironmentRequestSchema', () => {
+      const result = UpdateEnvironmentRequestSchema.safeParse({
+        name: 'updatedTest',
+        slug: 'updated-slug'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate if invalid values are specified for UpdateEnvironmentRequestSchema', () => {
+      const result = UpdateEnvironmentRequestSchema.safeParse({
+        name: 123,
+        slug: 'updated-slug'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should not validate if invalid values are specified for CreateEnvironmentRequestSchema', () => {
-    const result = CreateEnvironmentRequestSchema.safeParse({
-      name: 123,
-      projectSlug: 'project123'
+  describe('UpdateEnvironmentResponseSchema Tests', () => {
+    it('should validate a valid UpdateEnvironmentResponseSchema', () => {
+      const result = UpdateEnvironmentResponseSchema.safeParse({
+        id: 'env123',
+        name: 'Development',
+        slug: 'development',
+        description: 'Development environment',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: 'project123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid UpdateEnvironmentResponseSchema with multiple incorrect types', () => {
+      const result = UpdateEnvironmentResponseSchema.safeParse({
+        id: 123, // Should be a string
+        name: 'Development',
+        slug: 'development',
+        description: 456, // Should be a string or null
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: true // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  it('should not validate if required values are not specified for CreateEnvironmentRequestSchema', () => {
-    const result = CreateEnvironmentRequestSchema.safeParse({
-      name: 'test'
+  describe('GetEnvironmentRequestSchema Tests', () => {
+    it('should validate if proper input is specified for GetEnvironmentRequestSchema', () => {
+      const result = GetEnvironmentRequestSchema.safeParse({
+        slug: 'test-slug'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate if invalid values are specified for GetEnvironmentRequestSchema', () => {
+      const result = GetEnvironmentRequestSchema.safeParse({
+        slug: 123
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  // Tests for CreateEnvironmentResponseSchema
-  it('should validate a valid CreateEnvironmentResponseSchema', () => {
-    const result = CreateEnvironmentResponseSchema.safeParse({
-      id: 'env123',
-      name: 'Development',
-      slug: 'development',
-      description: 'Development environment',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: 'project123'
+  describe('GetEnvironmentResponseSchema Tests', () => {
+    it('should validate a valid GetEnvironmentResponseSchema', () => {
+      const result = GetEnvironmentResponseSchema.safeParse({
+        id: 'env123',
+        name: 'Development',
+        slug: 'development',
+        description: 'Development environment',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: 'project123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid GetEnvironmentResponseSchema with multiple incorrect types', () => {
+      const result = GetEnvironmentResponseSchema.safeParse({
+        id: 123, // Should be a string
+        name: 'Development',
+        slug: 'development',
+        description: 456, // Should be a string or null
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        lastUpdatedById: 'user123',
+        projectId: true // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  it('should not validate an invalid CreateEnvironmentResponseSchema with multiple incorrect types', () => {
-    const result = CreateEnvironmentResponseSchema.safeParse({
-      id: 123, // Should be a string
-      name: 'Development',
-      slug: 'development',
-      description: 456, // Should be a string or null
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: true // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for UpdateEnvironmentRequestSchema
-  it('should validate if proper input is specified for UpdateEnvironmentRequestSchema', () => {
-    const result = UpdateEnvironmentRequestSchema.safeParse({
-      name: 'updatedTest',
-      slug: 'updated-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if invalid values are specified for UpdateEnvironmentRequestSchema', () => {
-    const result = UpdateEnvironmentRequestSchema.safeParse({
-      name: 123,
-      slug: 'updated-slug'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for UpdateEnvironmentResponseSchema
-  it('should validate a valid UpdateEnvironmentResponseSchema', () => {
-    const result = UpdateEnvironmentResponseSchema.safeParse({
-      id: 'env123',
-      name: 'Development',
-      slug: 'development',
-      description: 'Development environment',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: 'project123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateEnvironmentResponseSchema with multiple incorrect types', () => {
-    const result = UpdateEnvironmentResponseSchema.safeParse({
-      id: 123, // Should be a string
-      name: 'Development',
-      slug: 'development',
-      description: 456, // Should be a string or null
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: true // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for GetEnvironmentRequestSchema
-  it('should validate if proper input is specified for GetEnvironmentRequestSchema', () => {
-    const result = GetEnvironmentRequestSchema.safeParse({
-      slug: 'test-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if invalid values are specified for GetEnvironmentRequestSchema', () => {
-    const result = GetEnvironmentRequestSchema.safeParse({
-      slug: 123
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for GetEnvironmentResponseSchema
-  it('should validate a valid GetEnvironmentResponseSchema', () => {
-    const result = GetEnvironmentResponseSchema.safeParse({
-      id: 'env123',
-      name: 'Development',
-      slug: 'development',
-      description: 'Development environment',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: 'project123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetEnvironmentResponseSchema with multiple incorrect types', () => {
-    const result = GetEnvironmentResponseSchema.safeParse({
-      id: 123, // Should be a string
-      name: 'Development',
-      slug: 'development',
-      description: 456, // Should be a string or null
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      lastUpdatedById: 'user123',
-      projectId: true // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for GetAllEnvironmentsOfProjectRequestSchema
-  it('should validate if proper input is specified for GetAllEnvironmentsOfProjectRequestSchema', () => {
-    const result = GetAllEnvironmentsOfProjectRequestSchema.safeParse({
-      projectSlug: 'project-slug',
-      page: 1,
-      limit: 10
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if invalid values are specified for GetAllEnvironmentsOfProjectRequestSchema', () => {
-    const result = GetAllEnvironmentsOfProjectRequestSchema.safeParse({
-      projectSlug: 123,
-      page: 'one',
-      limit: 'ten'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for GetAllEnvironmentsOfProjectResponseSchema
-  it('should validate a valid GetAllEnvironmentsOfProjectResponseSchema', () => {
-    const result = GetAllEnvironmentsOfProjectResponseSchema.safeParse({
-      items: [
-        {
-          id: 'env123',
-          name: 'Development',
-          slug: 'development',
-          description: 'Development environment',
-          createdAt: '2024-10-01T00:00:00Z',
-          updatedAt: '2024-10-01T00:00:00Z',
-          lastUpdatedById: 'user123',
-          projectId: 'project123',
-          lastUpdatedBy: {
-            id: 'user123',
-            name: 'John Doe',
-            email: 'john.doe@example.com',
-            profilePictureUrl: 'http://example.com/profile.jpg'
-          }
-        }
-      ],
-      metadata: {
+  describe('GetAllEnvironmentsOfProjectRequestSchema Tests', () => {
+    it('should validate if proper input is specified for GetAllEnvironmentsOfProjectRequestSchema', () => {
+      const result = GetAllEnvironmentsOfProjectRequestSchema.safeParse({
+        projectSlug: 'project-slug',
         page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+        limit: 10
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate if invalid values are specified for GetAllEnvironmentsOfProjectRequestSchema', () => {
+      const result = GetAllEnvironmentsOfProjectRequestSchema.safeParse({
+        projectSlug: 123,
+        page: 'one',
+        limit: 'ten'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  it('should not validate an invalid GetAllEnvironmentsOfProjectResponseSchema with incorrect types', () => {
-    const result = GetAllEnvironmentsOfProjectResponseSchema.safeParse({
-      items: [
-        {
-          id: 'env123',
-          name: 'Development',
-          slug: 'development',
-          description: 'Development environment',
-          createdAt: '2024-10-01T00:00:00Z',
-          updatedAt: '2024-10-01T00:00:00Z',
-          lastUpdatedById: 'user123',
-          projectId: 'project123',
-          lastUpdatedBy: {
-            id: 'user123',
-            name: 'John Doe',
-            email: 'john.doe@example.com',
-            profilePictureUrl: null
+  describe('GetAllEnvironmentsOfProjectResponseSchema Tests', () => {
+    it('should validate a valid GetAllEnvironmentsOfProjectResponseSchema', () => {
+      const result = GetAllEnvironmentsOfProjectResponseSchema.safeParse({
+        items: [
+          {
+            id: 'env123',
+            name: 'Development',
+            slug: 'development',
+            description: 'Development environment',
+            createdAt: '2024-10-01T00:00:00Z',
+            updatedAt: '2024-10-01T00:00:00Z',
+            lastUpdatedById: 'user123',
+            projectId: 'project123',
+            lastUpdatedBy: {
+              id: 'user123',
+              name: 'John Doe',
+              email: 'john.doe@example.com',
+              profilePictureUrl: 'http://example.com/profile.jpg'
+            }
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
           }
         }
-      ],
-      metadata: {
-        page: 'one', // Should be a number
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetAllEnvironmentsOfProjectResponseSchema with incorrect types', () => {
+      const result = GetAllEnvironmentsOfProjectResponseSchema.safeParse({
+        items: [
+          {
+            id: 'env123',
+            name: 'Development',
+            slug: 'development',
+            description: 'Development environment',
+            createdAt: '2024-10-01T00:00:00Z',
+            updatedAt: '2024-10-01T00:00:00Z',
+            lastUpdatedById: 'user123',
+            projectId: 'project123',
+            lastUpdatedBy: {
+              id: 'user123',
+              name: 'John Doe',
+              email: 'john.doe@example.com',
+              profilePictureUrl: null
+            }
+          }
+        ],
+        metadata: {
+          page: 'one', // Should be a number
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
   })
 
-  // Tests for DeleteEnvironmentRequestSchema
-  it('should validate if proper input is specified for DeleteEnvironmentRequestSchema', () => {
-    const result = DeleteEnvironmentRequestSchema.safeParse({
-      slug: 'test-slug'
+  describe('DeleteEnvironmentRequestSchema Tests', () => {
+    it('should validate if proper input is specified for DeleteEnvironmentRequestSchema', () => {
+      const result = DeleteEnvironmentRequestSchema.safeParse({
+        slug: 'test-slug'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate if invalid values are specified for DeleteEnvironmentRequestSchema', () => {
+      const result = DeleteEnvironmentRequestSchema.safeParse({
+        slug: 123
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should not validate if invalid values are specified for DeleteEnvironmentRequestSchema', () => {
-    const result = DeleteEnvironmentRequestSchema.safeParse({
-      slug: 123
+  describe('DeleteEnvironmentResponseSchema Tests', () => {
+    it('should validate a valid DeleteEnvironmentResponseSchema', () => {
+      const result = DeleteEnvironmentResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for DeleteEnvironmentResponseSchema
-  it('should validate a valid DeleteEnvironmentResponseSchema', () => {
-    const result = DeleteEnvironmentResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteEnvironmentResponseSchema', () => {
-    const result = DeleteEnvironmentResponseSchema.safeParse({
-      unexpectedField: 'value'
+    it('should not validate an invalid DeleteEnvironmentResponseSchema', () => {
+      const result = DeleteEnvironmentResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
     })
-    expect(result.success).toBe(false)
   })
 })

--- a/packages/schema/tests/event.spec.ts
+++ b/packages/schema/tests/event.spec.ts
@@ -2,127 +2,129 @@
 import { GetEventsRequestSchema, GetEventsResponseSchema } from '@/event'
 
 describe('Event Schema Tests', () => {
-  // Tests for GetEventsRequestSchema
-  it('should validate a valid GetEventsRequestSchema', () => {
-    const result = GetEventsRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      source: 'WORKSPACE'
+  describe('GetEventsRequestSchema Tests', () => {
+    it('should validate a valid GetEventsRequestSchema', () => {
+      const result = GetEventsRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        source: 'WORKSPACE'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should validate GetEventsRequestSchema when only workspaceSlug is provided', () => {
+      const result = GetEventsRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate GetEventsRequestSchema when severity is also provided', () => {
+      const result = GetEventsRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        source: 'INTEGRATION',
+        severity: 'WARN'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetEventsRequestSchema', () => {
+      const result = GetEventsRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        source: 'PROJECT_CREATED' // Invalid source
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should validate GetEventsRequestSchema when only workspaceSlug is provided', () => {
-    const result = GetEventsRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate GetEventsRequestSchema when severity is also provided', () => {
-    const result = GetEventsRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      source: 'INTEGRATION',
-      severity: 'WARN'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetEventsRequestSchema', () => {
-    const result = GetEventsRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      source: 'PROJECT_CREATED' // Invalid source
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for GetEventsResponseSchema
-  it('should validate a valid GetEventsResponseSchema', () => {
-    const result = GetEventsResponseSchema.safeParse({
-      items: [
-        {
-          id: 'event123',
-          source: 'SECRET',
-          triggerer: 'USER',
-          severity: 'INFO',
-          type: 'SECRET_UPDATED',
-          timestamp: '2024-10-01T00:00:00Z',
-          metadata: {
-            name: 'Event Name',
-            projectName: 'Project Name',
-            projectId: 'project123',
-            variableId: 'variable123',
-            environmentId: 'env123',
-            secretId: 'secret123',
-            workspaceId: 'workspace123',
-            workspaceName: 'Workspace Name'
-          },
-          title: 'Event Title',
-          description: 'Event Description',
-          itemId: 'item123',
-          userId: 'user123',
-          workspaceId: 'workspace123'
+  describe('GetEventsResponseSchema Tests', () => {
+    it('should validate a valid GetEventsResponseSchema', () => {
+      const result = GetEventsResponseSchema.safeParse({
+        items: [
+          {
+            id: 'event123',
+            source: 'SECRET',
+            triggerer: 'USER',
+            severity: 'INFO',
+            type: 'SECRET_UPDATED',
+            timestamp: '2024-10-01T00:00:00Z',
+            metadata: {
+              name: 'Event Name',
+              projectName: 'Project Name',
+              projectId: 'project123',
+              variableId: 'variable123',
+              environmentId: 'env123',
+              secretId: 'secret123',
+              workspaceId: 'workspace123',
+              workspaceName: 'Workspace Name'
+            },
+            title: 'Event Title',
+            description: 'Event Description',
+            itemId: 'item123',
+            userId: 'user123',
+            workspaceId: 'workspace123'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid GetEventsResponseSchema', () => {
-    const result = GetEventsResponseSchema.safeParse({
-      items: [
-        {
-          id: 'event123',
-          source: 'PROJECT_CREATED',
-          triggerer: 'user123',
-          severity: 'high',
-          type: 'update',
-          timestamp: '2024-10-01T00:00:00Z',
-          metadata: {
-            name: 'Event Name',
-            projectName: 'Project Name',
-            projectId: 'project123',
-            variableId: 'variable123',
-            environmentId: 'env123',
-            secretId: 'secret123',
-            workspaceId: 'workspace123',
-            workspaceName: 'Workspace Name'
-          },
-          title: 'Event Title',
-          description: 'Event Description',
-          itemId: 'item123',
-          userId: 123, // Should be a string
-          workspaceId: 'workspace123'
+    it('should not validate an invalid GetEventsResponseSchema', () => {
+      const result = GetEventsResponseSchema.safeParse({
+        items: [
+          {
+            id: 'event123',
+            source: 'PROJECT_CREATED',
+            triggerer: 'user123',
+            severity: 'high',
+            type: 'update',
+            timestamp: '2024-10-01T00:00:00Z',
+            metadata: {
+              name: 'Event Name',
+              projectName: 'Project Name',
+              projectId: 'project123',
+              variableId: 'variable123',
+              environmentId: 'env123',
+              secretId: 'secret123',
+              workspaceId: 'workspace123',
+              workspaceName: 'Workspace Name'
+            },
+            title: 'Event Title',
+            description: 'Event Description',
+            itemId: 'item123',
+            userId: 123, // Should be a string
+            workspaceId: 'workspace123'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(5)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(5)
   })
 })

--- a/packages/schema/tests/integration.spec.ts
+++ b/packages/schema/tests/integration.spec.ts
@@ -14,390 +14,401 @@ import {
 import { eventTypeEnum, integrationTypeEnum } from '@/enums'
 
 describe('Integration Schema Tests', () => {
-  // Tests for IntegrationSchema
-  it('should validate a valid IntegrationSchema', () => {
-    const result = IntegrationSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: integrationTypeEnum.Enum.DISCORD,
-      notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate if empty notifyOn array is provided for IntegrationSchema', () => {
-    const result = IntegrationSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: integrationTypeEnum.Enum.DISCORD,
-      notifyOn: [],
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid IntegrationSchema', () => {
-    const result = IntegrationSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: 'INVALID_TYPE', // Invalid type
-      notifyOn: ['INVALID_EVENT'], // Invalid event
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for CreateIntegrationRequestSchema
-  it('should validate if proper input is specified', () => {
-    const result = CreateIntegrationRequestSchema.safeParse({
-      workspaceSlug: 'workspace123',
-      name: 'Integration Test',
-      type: integrationTypeEnum.Enum.DISCORD,
-      metadata: { key: 'value' },
-      notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
-      projectSlug: 'project123',
-      environmentSlug: 'environment123'
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate if only required fields are specified', () => {
-    const result = CreateIntegrationRequestSchema.safeParse({
-      workspaceSlug: 'workspace123',
-      name: 'Integration Test',
-      type: integrationTypeEnum.Enum.DISCORD,
-      metadata: { key: 'value' }
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if invalid values are specified', () => {
-    const result = CreateIntegrationRequestSchema.safeParse({
-      workspaceSlug: 'workspace123',
-      name: 123,
-      type: integrationTypeEnum.Enum.DISCORD,
-      metadata: 'invalid metadata'
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  it('should not validate if required values are not specified', () => {
-    const result = CreateIntegrationRequestSchema.safeParse({
-      metadata: { key: 'value' }
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  it('should validate with optional fields omitted', () => {
-    const result = CreateIntegrationRequestSchema.safeParse({
-      workspaceSlug: 'workspace123',
-      name: 'Integration Test',
-      type: integrationTypeEnum.Enum.DISCORD,
-      metadata: { key: 'value' }
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if empty notifyOn array is provided', () => {
-    const result = CreateIntegrationRequestSchema.safeParse({
-      workspaceSlug: 'workspace123',
-      name: 'Integration Test',
-      type: integrationTypeEnum.Enum.DISCORD,
-      metadata: { key: 'value' },
-      notifyOn: []
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for CreateIntegrationResponseSchema
-  it('should validate a valid CreateIntegrationResponseSchema', () => {
-    const result = CreateIntegrationResponseSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: integrationTypeEnum.Enum.DISCORD,
-      notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CreateIntegrationResponseSchema', () => {
-    const result = CreateIntegrationResponseSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: 'INVALID_TYPE', // Invalid type
-      notifyOn: ['INVALID_EVENT'], // Invalid event
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for UpdateIntegrationRequestSchema
-  it('should validate a valid UpdateIntegrationRequestSchema', () => {
-    const result = UpdateIntegrationRequestSchema.safeParse({
-      integrationSlug: 'integration-slug',
-      name: 'Updated Integration Name',
-      notifyOn: [eventTypeEnum.Enum.PROJECT_DELETED],
-      metadata: { key: 'new-value' }
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateIntegrationRequestSchema', () => {
-    const result = UpdateIntegrationRequestSchema.safeParse({
-      integrationSlug: 123, // Should be a string
-      name: 'Updated Integration Name',
-      notifyOn: ['EVENT_A'], // Invalid event
-      metadata: { key: 'new-value' }
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for UpdateIntegrationResponseSchema
-  it('should validate a valid UpdateIntegrationResponseSchema', () => {
-    const result = UpdateIntegrationResponseSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: integrationTypeEnum.Enum.DISCORD,
-      notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateIntegrationResponseSchema', () => {
-    const result = UpdateIntegrationResponseSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: 'INVALID_TYPE', // Invalid type
-      notifyOn: ['INVALID_EVENT'], // Invalid event
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for DeleteIntegrationRequestSchema
-  it('should validate a valid DeleteIntegrationRequestSchema', () => {
-    const result = DeleteIntegrationRequestSchema.safeParse({
-      integrationSlug: 'integration-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteIntegrationRequestSchema', () => {
-    const result = DeleteIntegrationRequestSchema.safeParse({
-      integrationSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for DeleteIntegrationResponseSchema
-  it('should validate a valid DeleteIntegrationResponseSchema', () => {
-    const result = DeleteIntegrationResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteIntegrationResponseSchema', () => {
-    const result = DeleteIntegrationResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for GetIntegrationRequestSchema
-  it('should validate a valid GetIntegrationRequestSchema', () => {
-    const result = GetIntegrationRequestSchema.safeParse({
-      integrationSlug: 'integration-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetIntegrationRequestSchema', () => {
-    const result = GetIntegrationRequestSchema.safeParse({
-      integrationSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for GetIntegrationResponseSchema
-  it('should validate a valid GetIntegrationResponseSchema', () => {
-    const result = GetIntegrationResponseSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: integrationTypeEnum.Enum.GITHUB,
-      notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123',
-      workspace: {
-        id: 'workspace123',
-        name: 'Workspace Name',
-        slug: 'workspace-slug',
-        icon: 'workspace-icon',
-        isFreeTier: true,
+  describe('IntegrationSchema Tests', () => {
+    it('should validate a valid IntegrationSchema', () => {
+      const result = IntegrationSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
         createdAt: '2024-10-01T00:00:00Z',
         updatedAt: '2024-10-01T00:00:00Z',
-        ownerId: 'owner123',
-        isDefault: false,
-        lastUpdatedById: 'user123'
-      }
+        type: integrationTypeEnum.Enum.DISCORD,
+        notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should validate if empty notifyOn array is provided for IntegrationSchema', () => {
+      const result = IntegrationSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: integrationTypeEnum.Enum.DISCORD,
+        notifyOn: [],
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid IntegrationSchema', () => {
+      const result = IntegrationSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: 'INVALID_TYPE', // Invalid type
+        notifyOn: ['INVALID_EVENT'], // Invalid event
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate an invalid GetIntegrationResponseSchema', () => {
-    const result = GetIntegrationResponseSchema.safeParse({
-      id: 'integration123',
-      name: 'Integration Name',
-      slug: 'integration-slug',
-      metadata: { key: 'value' },
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      type: 'INVALID_TYPE', // Invalid type
-      notifyOn: ['INVALID_EVENT'], // Invalid event
-      workspaceId: 'workspace123',
-      projectId: 'project123',
-      environmentId: 'environment123'
-      // Missing workspace field
+  describe('CreateIntegrationRequestSchema Tests', () => {
+    it('should validate if proper input is specified', () => {
+      const result = CreateIntegrationRequestSchema.safeParse({
+        workspaceSlug: 'workspace123',
+        name: 'Integration Test',
+        type: integrationTypeEnum.Enum.DISCORD,
+        metadata: { key: 'value' },
+        notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
+        projectSlug: 'project123',
+        environmentSlug: 'environment123'
+      })
+
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
+
+    it('should validate if only required fields are specified', () => {
+      const result = CreateIntegrationRequestSchema.safeParse({
+        workspaceSlug: 'workspace123',
+        name: 'Integration Test',
+        type: integrationTypeEnum.Enum.DISCORD,
+        metadata: { key: 'value' }
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate if invalid values are specified', () => {
+      const result = CreateIntegrationRequestSchema.safeParse({
+        workspaceSlug: 'workspace123',
+        name: 123,
+        type: integrationTypeEnum.Enum.DISCORD,
+        metadata: 'invalid metadata'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+
+    it('should not validate if required values are not specified', () => {
+      const result = CreateIntegrationRequestSchema.safeParse({
+        metadata: { key: 'value' }
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
+
+    it('should validate with optional fields omitted', () => {
+      const result = CreateIntegrationRequestSchema.safeParse({
+        workspaceSlug: 'workspace123',
+        name: 'Integration Test',
+        type: integrationTypeEnum.Enum.DISCORD,
+        metadata: { key: 'value' }
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate if empty notifyOn array is provided', () => {
+      const result = CreateIntegrationRequestSchema.safeParse({
+        workspaceSlug: 'workspace123',
+        name: 'Integration Test',
+        type: integrationTypeEnum.Enum.DISCORD,
+        metadata: { key: 'value' },
+        notifyOn: []
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  // Tests for GetAllIntegrationRequestSchema
-  it('should validate a valid GetAllIntegrationRequestSchema', () => {
-    const result = GetAllIntegrationRequestSchema.safeParse({
-      workspaceSlug: 'workspace123',
-      page: 1,
-      limit: 10
+  describe('CreateIntegrationResponseSchema Tests', () => {
+    it('should validate a valid CreateIntegrationResponseSchema', () => {
+      const result = CreateIntegrationResponseSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: integrationTypeEnum.Enum.DISCORD,
+        notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid CreateIntegrationResponseSchema', () => {
+      const result = CreateIntegrationResponseSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: 'INVALID_TYPE', // Invalid type
+        notifyOn: ['INVALID_EVENT'], // Invalid event
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate an invalid GetAllIntegrationRequestSchema', () => {
-    const result = GetAllIntegrationRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      page: 1
+  describe('UpdateIntegrationRequestSchema Tests', () => {
+    it('should validate a valid UpdateIntegrationRequestSchema', () => {
+      const result = UpdateIntegrationRequestSchema.safeParse({
+        integrationSlug: 'integration-slug',
+        name: 'Updated Integration Name',
+        notifyOn: [eventTypeEnum.Enum.PROJECT_DELETED],
+        metadata: { key: 'new-value' }
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid UpdateIntegrationRequestSchema', () => {
+      const result = UpdateIntegrationRequestSchema.safeParse({
+        integrationSlug: 123, // Should be a string
+        name: 'Updated Integration Name',
+        notifyOn: ['EVENT_A'], // Invalid event
+        metadata: { key: 'new-value' }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  // Tests for GetAllIntegrationResponseSchema
-  it('should validate a valid GetAllIntegrationResponseSchema', () => {
-    const result = GetAllIntegrationResponseSchema.safeParse({
-      items: [
-        {
-          id: 'integration123',
-          name: 'Integration Name',
-          slug: 'integration-slug',
-          metadata: { key: 'value' },
+  describe('UpdateIntegrationResponseSchema Tests', () => {
+    it('should validate a valid UpdateIntegrationResponseSchema', () => {
+      const result = UpdateIntegrationResponseSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: integrationTypeEnum.Enum.DISCORD,
+        notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid UpdateIntegrationResponseSchema', () => {
+      const result = UpdateIntegrationResponseSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: 'INVALID_TYPE', // Invalid type
+        notifyOn: ['INVALID_EVENT'], // Invalid event
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('DeleteIntegrationRequestSchema Tests', () => {
+    it('should validate a valid DeleteIntegrationRequestSchema', () => {
+      const result = DeleteIntegrationRequestSchema.safeParse({
+        integrationSlug: 'integration-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeleteIntegrationRequestSchema', () => {
+      const result = DeleteIntegrationRequestSchema.safeParse({
+        integrationSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('DeleteIntegrationResponseSchema Tests', () => {
+    it('should validate a valid DeleteIntegrationResponseSchema', () => {
+      const result = DeleteIntegrationResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeleteIntegrationResponseSchema', () => {
+      const result = DeleteIntegrationResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('GetIntegrationRequestSchema Tests', () => {
+    it('should validate a valid GetIntegrationRequestSchema', () => {
+      const result = GetIntegrationRequestSchema.safeParse({
+        integrationSlug: 'integration-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetIntegrationRequestSchema', () => {
+      const result = GetIntegrationRequestSchema.safeParse({
+        integrationSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('GetIntegrationResponseSchema Tests', () => {
+    it('should validate a valid GetIntegrationResponseSchema', () => {
+      const result = GetIntegrationResponseSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: integrationTypeEnum.Enum.GITHUB,
+        notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123',
+        workspace: {
+          id: 'workspace123',
+          name: 'Workspace Name',
+          slug: 'workspace-slug',
+          icon: 'workspace-icon',
+          isFreeTier: true,
           createdAt: '2024-10-01T00:00:00Z',
           updatedAt: '2024-10-01T00:00:00Z',
-          type: integrationTypeEnum.Enum.DISCORD,
-          notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
-          workspaceId: 'workspace123',
-          projectId: 'project123',
-          environmentId: 'environment123'
+          ownerId: 'owner123',
+          isDefault: false,
+          lastUpdatedById: 'user123'
         }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid GetIntegrationResponseSchema', () => {
+      const result = GetIntegrationResponseSchema.safeParse({
+        id: 'integration123',
+        name: 'Integration Name',
+        slug: 'integration-slug',
+        metadata: { key: 'value' },
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        type: 'INVALID_TYPE', // Invalid type
+        notifyOn: ['INVALID_EVENT'], // Invalid event
+        workspaceId: 'workspace123',
+        projectId: 'project123',
+        environmentId: 'environment123'
+        // Missing workspace field
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  it('should not validate an invalid GetAllIntegrationResponseSchema', () => {
-    const result = GetAllIntegrationResponseSchema.safeParse({
-      items: 'not-an-array', // Should be an array
-      metadata: {
+  describe('GetAllIntegrationRequestSchema Tests', () => {
+    it('should validate a valid GetAllIntegrationRequestSchema', () => {
+      const result = GetAllIntegrationRequestSchema.safeParse({
+        workspaceSlug: 'workspace123',
         page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+        limit: 10
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid GetAllIntegrationRequestSchema', () => {
+      const result = GetAllIntegrationRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        page: 1
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('GetAllIntegrationResponseSchema Tests', () => {
+    it('should validate a valid GetAllIntegrationResponseSchema', () => {
+      const result = GetAllIntegrationResponseSchema.safeParse({
+        items: [
+          {
+            id: 'integration123',
+            name: 'Integration Name',
+            slug: 'integration-slug',
+            metadata: { key: 'value' },
+            createdAt: '2024-10-01T00:00:00Z',
+            updatedAt: '2024-10-01T00:00:00Z',
+            type: integrationTypeEnum.Enum.DISCORD,
+            notifyOn: [eventTypeEnum.Enum.ACCEPTED_INVITATION],
+            workspaceId: 'workspace123',
+            projectId: 'project123',
+            environmentId: 'environment123'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetAllIntegrationResponseSchema', () => {
+      const result = GetAllIntegrationResponseSchema.safeParse({
+        items: 'not-an-array', // Should be an array
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 })

--- a/packages/schema/tests/pagination.spec.ts
+++ b/packages/schema/tests/pagination.spec.ts
@@ -7,189 +7,193 @@ import {
 } from '@/pagination'
 
 describe('Pagination Schema Tests', () => {
-  // Tests for PageRequestSchema
-  it('should validate a valid PageRequestSchema', () => {
-    const result = PageRequestSchema.safeParse({
-      page: 1,
-      limit: 10
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid PageRequestSchema with incorrect types', () => {
-    const result = PageRequestSchema.safeParse({
-      page: 'one' // should be a number
-    })
-
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for PageResponseSchema
-  const itemSchema = z.object({
-    id: z.string(),
-    name: z.string()
-  })
-
-  it('should validate a valid PageResponseSchema', () => {
-    const result = PageResponseSchema(itemSchema).safeParse({
-      items: [{ id: '123', name: 'Test' }],
-      metadata: {
+  describe('PageRequestSchema Tests', () => {
+    it('should validate a valid PageRequestSchema', () => {
+      const result = PageRequestSchema.safeParse({
         page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+        limit: 10
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid PageRequestSchema with incorrect types', () => {
+      const result = PageRequestSchema.safeParse({
+        page: 'one' // should be a number
+      })
+
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('PageResponseSchema Tests', () => {
+    const itemSchema = z.object({
+      id: z.string(),
+      name: z.string()
+    })
+
+    it('should validate a valid PageResponseSchema', () => {
+      const result = PageResponseSchema(itemSchema).safeParse({
+        items: [{ id: '123', name: 'Test' }],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid PageResponseSchema with incorrect items type', () => {
-    const result = PageResponseSchema(itemSchema).safeParse({
-      items: 'not-an-array', // should be an array
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'not-an-url', // should be a URL
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+    it('should not validate an invalid PageResponseSchema with incorrect items type', () => {
+      const result = PageResponseSchema(itemSchema).safeParse({
+        items: 'not-an-array', // should be an array
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'not-an-url', // should be a URL
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  it('should not validate an invalid PageResponseSchema with missing metadata fields', () => {
-    const result = PageResponseSchema(itemSchema).safeParse({
-      items: [{ id: '123', name: 'Test' }],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        // totalCount is missing
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+    it('should not validate an invalid PageResponseSchema with missing metadata fields', () => {
+      const result = PageResponseSchema(itemSchema).safeParse({
+        items: [{ id: '123', name: 'Test' }],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          // totalCount is missing
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+
+      expect(result.success).toBe(false)
     })
-
-    expect(result.success).toBe(false)
   })
 
-  // Tests for ResponseErrorSchema
-  it('should validate a valid ResponseErrorSchema', () => {
-    const result = ResponseErrorSchema.safeParse({
-      message: 'An error occurred',
-      error: 'ERROR_CODE',
-      statusCode: 400
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid ResponseErrorSchema with missing fields', () => {
-    const result = ResponseErrorSchema.safeParse({
-      message: 'An error occurred',
-      error: 'ERROR_CODE'
-    })
-
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for ClientResponseSchema
-  const dataSchema = z.object({
-    id: z.string(),
-    name: z.string()
-  })
-
-  it('should validate when success is true and data is present', () => {
-    const result = ClientResponseSchema(dataSchema).safeParse({
-      success: true,
-      error: null,
-      data: { id: '123', name: 'Test' }
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate when success is false and error is present', () => {
-    const result = ClientResponseSchema(dataSchema).safeParse({
-      success: false,
-      error: {
+  describe('ResponseErrorSchema Tests', () => {
+    it('should validate a valid ResponseErrorSchema', () => {
+      const result = ResponseErrorSchema.safeParse({
         message: 'An error occurred',
         error: 'ERROR_CODE',
         statusCode: 400
-      },
-      data: null
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate when success is true and data is null', () => {
-    const result = ClientResponseSchema(dataSchema).safeParse({
-      success: true,
-      error: null,
-      data: null
-    })
-
-    expect(result.success).toBe(false)
-  })
-
-  it('should not validate when success is false and error is null', () => {
-    const result = ClientResponseSchema(dataSchema).safeParse({
-      success: false,
-      error: null,
-      data: null
-    })
-
-    expect(result.success).toBe(false)
-  })
-
-  it('should not validate when success is true and error is present', () => {
-    const result = ClientResponseSchema(dataSchema).safeParse({
-      success: true,
-      error: {
+    it('should not validate an invalid ResponseErrorSchema with missing fields', () => {
+      const result = ResponseErrorSchema.safeParse({
         message: 'An error occurred',
-        error: 'ERROR_CODE',
-        statusCode: 400
-      },
-      data: { id: '123', name: 'Test' }
-    })
+        error: 'ERROR_CODE'
+      })
 
-    expect(result.success).toBe(false)
+      expect(result.success).toBe(false)
+    })
   })
 
-  it('should not validate when success is false and data is present', () => {
-    const result = ClientResponseSchema(dataSchema).safeParse({
-      success: false,
-      error: {
-        message: 'An error occurred',
-        error: 'ERROR_CODE',
-        statusCode: 400
-      },
-      data: { id: '123', name: 'Test' }
+  describe('ClientResponseSchema Tests', () => {
+    const dataSchema = z.object({
+      id: z.string(),
+      name: z.string()
     })
 
-    expect(result.success).toBe(false)
+    it('should validate when success is true and data is present', () => {
+      const result = ClientResponseSchema(dataSchema).safeParse({
+        success: true,
+        error: null,
+        data: { id: '123', name: 'Test' }
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate when success is false and error is present', () => {
+      const result = ClientResponseSchema(dataSchema).safeParse({
+        success: false,
+        error: {
+          message: 'An error occurred',
+          error: 'ERROR_CODE',
+          statusCode: 400
+        },
+        data: null
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate when success is true and data is null', () => {
+      const result = ClientResponseSchema(dataSchema).safeParse({
+        success: true,
+        error: null,
+        data: null
+      })
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should not validate when success is false and error is null', () => {
+      const result = ClientResponseSchema(dataSchema).safeParse({
+        success: false,
+        error: null,
+        data: null
+      })
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should not validate when success is true and error is present', () => {
+      const result = ClientResponseSchema(dataSchema).safeParse({
+        success: true,
+        error: {
+          message: 'An error occurred',
+          error: 'ERROR_CODE',
+          statusCode: 400
+        },
+        data: { id: '123', name: 'Test' }
+      })
+
+      expect(result.success).toBe(false)
+    })
+
+    it('should not validate when success is false and data is present', () => {
+      const result = ClientResponseSchema(dataSchema).safeParse({
+        success: false,
+        error: {
+          message: 'An error occurred',
+          error: 'ERROR_CODE',
+          statusCode: 400
+        },
+        data: { id: '123', name: 'Test' }
+      })
+
+      expect(result.success).toBe(false)
+    })
   })
 })

--- a/packages/schema/tests/secret.spec.ts
+++ b/packages/schema/tests/secret.spec.ts
@@ -18,498 +18,513 @@ import {
 import { rotateAfterEnum } from '@/enums'
 
 describe('Secret Schema Tests', () => {
-  // Tests for SecretSchema
-  it('should validate a valid SecretSchema', () => {
-    const result = SecretSchema.safeParse({
-      id: 'secret123',
-      name: 'Secret Name',
-      slug: 'secret-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      rotateAt: null,
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'secret-value',
-          environment: {
-            id: 'env123',
-            slug: 'development'
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid SecretSchema', () => {
-    const result = SecretSchema.safeParse({
-      id: 'secret123',
-      name: 'Secret Name',
-      slug: 'secret-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      rotateAt: null,
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'secret-value',
-          environment: {
-            id: 'env123'
-            // Missing slug
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for CreateSecretRequestSchema
-  it('should validate a valid CreateSecretRequestSchema', () => {
-    const result = CreateSecretRequestSchema.safeParse({
-      projectSlug: 'project-slug',
-      name: 'Secret Name',
-      note: 'This is a note',
-      rotateAfter: rotateAfterEnum.enum['24'],
-      entries: [
-        {
-          value: 'secret-value',
-          environmentSlug: 'development'
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CreateSecretRequestSchema', () => {
-    const result = CreateSecretRequestSchema.safeParse({
-      projectSlug: 'project-slug',
-      name: 'Secret Name',
-      note: 'This is a note',
-      rotateAfter: '30', // Invalid rotateAfter value
-      entries: [
-        {
-          value: 'secret-value',
-          environmentSlug: 'development'
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for CreateSecretResponseSchema
-  it('should validate a valid CreateSecretResponseSchema', () => {
-    const result = CreateSecretResponseSchema.safeParse({
-      id: 'secret123',
-      name: 'Secret Name',
-      slug: 'secret-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      rotateAt: null,
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'secret-value',
-          environment: {
-            id: 'env123',
-            slug: 'development'
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CreateSecretResponseSchema', () => {
-    const result = CreateSecretResponseSchema.safeParse({
-      id: 'secret123',
-      name: 'Secret Name',
-      slug: 'secret-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      rotateAt: null,
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'secret-value',
-          environment: {
-            id: 'env123'
-            // Missing slug
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for UpdateSecretRequestSchema
-  it('should validate a valid UpdateSecretRequestSchema', () => {
-    const result = UpdateSecretRequestSchema.safeParse({
-      secretSlug: 'secret-slug',
-      name: 'Updated Secret Name',
-      note: 'Updated note'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateSecretRequestSchema', () => {
-    const result = UpdateSecretRequestSchema.safeParse({
-      secretSlug: 123, // Should be a string
-      name: 'Updated Secret Name',
-      note: 'Updated note'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for UpdateSecretResponseSchema
-  it('should validate a valid UpdateSecretResponseSchema', () => {
-    const result = UpdateSecretResponseSchema.safeParse({
-      secret: {
+  describe('SecretSchema Tests', () => {
+    it('should validate a valid SecretSchema', () => {
+      const result = SecretSchema.safeParse({
         id: 'secret123',
         name: 'Secret Name',
         slug: 'secret-slug',
-        note: 'This is a note'
-      },
-      updatedVersions: [
-        {
-          id: 'version123',
-          environment: {
-            id: 'env123',
-            slug: 'development'
-          },
-          value: 'secret-value',
-          version: 4
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateSecretResponseSchema', () => {
-    const result = UpdateSecretResponseSchema.safeParse({
-      secret: {
-        id: 'secret123',
-        name: 'Secret Name',
-        slug: 'secret-slug',
-        note: 'This is a note'
-      },
-      updatedVersions: [
-        {
-          id: 'version123',
-          environment: {
-            id: 'env123'
-            // Missing slug
-          },
-          value: 'secret-value'
-          // Missing version
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for DeleteSecretRequestSchema
-  it('should validate a valid DeleteSecretRequestSchema', () => {
-    const result = DeleteSecretRequestSchema.safeParse({
-      secretSlug: 'secret-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteSecretRequestSchema', () => {
-    const result = DeleteSecretRequestSchema.safeParse({
-      secretSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for DeleteSecretResponseSchema
-  it('should validate a valid DeleteSecretResponseSchema', () => {
-    const result = DeleteSecretResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteSecretResponseSchema', () => {
-    const result = DeleteSecretResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for RollBackSecretRequestSchema
-  it('should validate a valid RollBackSecretRequestSchema', () => {
-    const result = RollBackSecretRequestSchema.safeParse({
-      environmentSlug: 'development',
-      version: 1,
-      secretSlug: 'secret-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid RollBackSecretRequestSchema', () => {
-    const result = RollBackSecretRequestSchema.safeParse({
-      environmentSlug: 'development',
-      version: 'one', // Should be a number
-      secretSlug: 'secret-slug'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for RollBackSecretResponseSchema
-  it('should validate a valid RollBackSecretResponseSchema', () => {
-    const result = RollBackSecretResponseSchema.safeParse({
-      count: '1'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid RollBackSecretResponseSchema', () => {
-    const result = RollBackSecretResponseSchema.safeParse({
-      count: 1 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for GetAllSecretsOfProjectRequestSchema
-  it('should validate a valid GetAllSecretsOfProjectRequestSchema', () => {
-    const result = GetAllSecretsOfProjectRequestSchema.safeParse({
-      projectSlug: 'project-slug',
-      decryptValue: true,
-      page: 1,
-      limit: 10
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetAllSecretsOfProjectRequestSchema', () => {
-    const result = GetAllSecretsOfProjectRequestSchema.safeParse({
-      projectSlug: 123, // Should be a string
-      decryptValue: 'false', // Should be a boolean
-      page: 1,
-      limit: 10
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for GetAllSecretsOfProjectResponseSchema
-  it('should validate a valid GetAllSecretsOfProjectResponseSchema', () => {
-    const result = GetAllSecretsOfProjectResponseSchema.safeParse({
-      items: [
-        {
-          secret: {
-            id: 'secret123',
-            name: 'Secret Name',
-            slug: 'secret-slug',
-            createdAt: '2024-10-01T00:00:00Z',
-            updatedAt: '2024-10-01T00:00:00Z',
-            rotateAt: null,
-            note: 'This is a note',
-            lastUpdatedById: 'user123',
-            projectId: 'project123',
-            lastUpdatedBy: {
-              id: 'user123',
-              name: 'John Doe'
-            }
-          },
-          values: {
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        rotateAt: null,
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'secret-value',
             environment: {
               id: 'env123',
-              name: 'Development',
+              slug: 'development'
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid SecretSchema', () => {
+      const result = SecretSchema.safeParse({
+        id: 'secret123',
+        name: 'Secret Name',
+        slug: 'secret-slug',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        rotateAt: null,
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'secret-value',
+            environment: {
+              id: 'env123'
+              // Missing slug
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('CreateSecretRequestSchema Tests', () => {
+    it('should validate a valid CreateSecretRequestSchema', () => {
+      const result = CreateSecretRequestSchema.safeParse({
+        projectSlug: 'project-slug',
+        name: 'Secret Name',
+        note: 'This is a note',
+        rotateAfter: rotateAfterEnum.enum['24'],
+        entries: [
+          {
+            value: 'secret-value',
+            environmentSlug: 'development'
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid CreateSecretRequestSchema', () => {
+      const result = CreateSecretRequestSchema.safeParse({
+        projectSlug: 'project-slug',
+        name: 'Secret Name',
+        note: 'This is a note',
+        rotateAfter: '30', // Invalid rotateAfter value
+        entries: [
+          {
+            value: 'secret-value',
+            environmentSlug: 'development'
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('CreateSecretResponseSchema Tests', () => {
+    it('should validate a valid CreateSecretResponseSchema', () => {
+      const result = CreateSecretResponseSchema.safeParse({
+        id: 'secret123',
+        name: 'Secret Name',
+        slug: 'secret-slug',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        rotateAt: null,
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'secret-value',
+            environment: {
+              id: 'env123',
+              slug: 'development'
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid CreateSecretResponseSchema', () => {
+      const result = CreateSecretResponseSchema.safeParse({
+        id: 'secret123',
+        name: 'Secret Name',
+        slug: 'secret-slug',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        rotateAt: null,
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'secret-value',
+            environment: {
+              id: 'env123'
+              // Missing slug
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('UpdateSecretRequestSchema Tests', () => {
+    it('should validate a valid UpdateSecretRequestSchema', () => {
+      const result = UpdateSecretRequestSchema.safeParse({
+        secretSlug: 'secret-slug',
+        name: 'Updated Secret Name',
+        note: 'Updated note'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid UpdateSecretRequestSchema', () => {
+      const result = UpdateSecretRequestSchema.safeParse({
+        secretSlug: 123, // Should be a string
+        name: 'Updated Secret Name',
+        note: 'Updated note'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('UpdateSecretResponseSchema Tests', () => {
+    it('should validate a valid UpdateSecretResponseSchema', () => {
+      const result = UpdateSecretResponseSchema.safeParse({
+        secret: {
+          id: 'secret123',
+          name: 'Secret Name',
+          slug: 'secret-slug',
+          note: 'This is a note'
+        },
+        updatedVersions: [
+          {
+            id: 'version123',
+            environment: {
+              id: 'env123',
               slug: 'development'
             },
             value: 'secret-value',
-            version: 1
+            version: 4
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid UpdateSecretResponseSchema', () => {
+      const result = UpdateSecretResponseSchema.safeParse({
+        secret: {
+          id: 'secret123',
+          name: 'Secret Name',
+          slug: 'secret-slug',
+          note: 'This is a note'
+        },
+        updatedVersions: [
+          {
+            id: 'version123',
+            environment: {
+              id: 'env123'
+              // Missing slug
+            },
+            value: 'secret-value'
+            // Missing version
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('DeleteSecretRequestSchema Tests', () => {
+    it('should validate a valid DeleteSecretRequestSchema', () => {
+      const result = DeleteSecretRequestSchema.safeParse({
+        secretSlug: 'secret-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeleteSecretRequestSchema', () => {
+      const result = DeleteSecretRequestSchema.safeParse({
+        secretSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('DeleteSecretResponseSchema Tests', () => {
+    it('should validate a valid DeleteSecretResponseSchema', () => {
+      const result = DeleteSecretResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeleteSecretResponseSchema', () => {
+      const result = DeleteSecretResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('RollBackSecretRequestSchema Tests', () => {
+    it('should validate a valid RollBackSecretRequestSchema', () => {
+      const result = RollBackSecretRequestSchema.safeParse({
+        environmentSlug: 'development',
+        version: 1,
+        secretSlug: 'secret-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid RollBackSecretRequestSchema', () => {
+      const result = RollBackSecretRequestSchema.safeParse({
+        environmentSlug: 'development',
+        version: 'one', // Should be a number
+        secretSlug: 'secret-slug'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('RollBackSecretResponseSchema Tests', () => {
+    it('should validate a valid RollBackSecretResponseSchema', () => {
+      const result = RollBackSecretResponseSchema.safeParse({
+        count: '1'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid RollBackSecretResponseSchema', () => {
+      const result = RollBackSecretResponseSchema.safeParse({
+        count: 1 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('GetAllSecretsOfProjectRequestSchema Tests', () => {
+    it('should validate a valid GetAllSecretsOfProjectRequestSchema', () => {
+      const result = GetAllSecretsOfProjectRequestSchema.safeParse({
+        projectSlug: 'project-slug',
+        decryptValue: true,
+        page: 1,
+        limit: 10
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetAllSecretsOfProjectRequestSchema', () => {
+      const result = GetAllSecretsOfProjectRequestSchema.safeParse({
+        projectSlug: 123, // Should be a string
+        decryptValue: 'false', // Should be a boolean
+        page: 1,
+        limit: 10
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('GetAllSecretsOfProjectResponseSchema Tests', () => {
+    it('should validate a valid GetAllSecretsOfProjectResponseSchema', () => {
+      const result = GetAllSecretsOfProjectResponseSchema.safeParse({
+        items: [
+          {
+            secret: {
+              id: 'secret123',
+              name: 'Secret Name',
+              slug: 'secret-slug',
+              createdAt: '2024-10-01T00:00:00Z',
+              updatedAt: '2024-10-01T00:00:00Z',
+              rotateAt: null,
+              note: 'This is a note',
+              lastUpdatedById: 'user123',
+              projectId: 'project123',
+              lastUpdatedBy: {
+                id: 'user123',
+                name: 'John Doe'
+              }
+            },
+            values: {
+              environment: {
+                id: 'env123',
+                name: 'Development',
+                slug: 'development'
+              },
+              value: 'secret-value',
+              version: 1
+            }
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
           }
         }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetAllSecretsOfProjectResponseSchema', () => {
+      const result = GetAllSecretsOfProjectResponseSchema.safeParse({
+        items: 'not-an-array', // Should be an array
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid GetAllSecretsOfProjectResponseSchema', () => {
-    const result = GetAllSecretsOfProjectResponseSchema.safeParse({
-      items: 'not-an-array', // Should be an array
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+  describe('GetAllSecretsOfEnvironmentRequestSchema Tests', () => {
+    it('should validate a valid GetAllSecretsOfEnvironmentRequestSchema', () => {
+      const result = GetAllSecretsOfEnvironmentRequestSchema.safeParse({
+        projectSlug: 'project-slug',
+        environmentSlug: 'development'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for GetAllSecretsOfEnvironmentRequestSchema
-  it('should validate a valid GetAllSecretsOfEnvironmentRequestSchema', () => {
-    const result = GetAllSecretsOfEnvironmentRequestSchema.safeParse({
-      projectSlug: 'project-slug',
-      environmentSlug: 'development'
+    it('should not validate an invalid GetAllSecretsOfEnvironmentRequestSchema', () => {
+      const result = GetAllSecretsOfEnvironmentRequestSchema.safeParse({
+        projectSlug: 123, // Should be a string
+        environmentSlug: 'development'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid GetAllSecretsOfEnvironmentRequestSchema', () => {
-    const result = GetAllSecretsOfEnvironmentRequestSchema.safeParse({
-      projectSlug: 123, // Should be a string
-      environmentSlug: 'development'
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for GetAllSecretsOfEnvironmentResponseSchema
-  it('should validate a valid GetAllSecretsOfEnvironmentResponseSchema', () => {
-    const result = GetAllSecretsOfEnvironmentResponseSchema.safeParse([
-      {
-        name: 'SECRET_NAME',
-        value: 'SECRET_VALUE',
-        isPlaintext: true
-      }
-    ])
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetAllSecretsOfEnvironmentResponseSchema', () => {
-    const result = GetAllSecretsOfEnvironmentResponseSchema.safeParse([
-      {
-        name: 'SECRET_NAME',
-        value: 123, // Should be a string
-        isPlaintext: 'true' // Should be a boolean
-      }
-    ])
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for GetRevisionsOfSecretRequestSchema
-  it('should validate a valid GetRevisionsOfSecretRequestSchema', () => {
-    const result = GetRevisionsOfSecretRequestSchema.safeParse({
-      secretSlug: 'my-secret',
-      environmentSlug: 'development',
-      page: 1,
-      limit: 10
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetRevisionsOfSecretRequestSchema', () => {
-    const result = GetRevisionsOfSecretRequestSchema.safeParse({
-      secretSlug: 'my-secret',
-      environmentSlug: 123, // Should be a string
-      page: 'one' // Should be a number
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for GetRevisionsOfSecretResponseSchema
-  it('should validate a valid GetRevisionsOfSecretResponseSchema', () => {
-    const result = GetRevisionsOfSecretResponseSchema.safeParse({
-      items: [
+  describe('GetAllSecretsOfEnvironmentResponseSchema Tests', () => {
+    it('should validate a valid GetAllSecretsOfEnvironmentResponseSchema', () => {
+      const result = GetAllSecretsOfEnvironmentResponseSchema.safeParse([
         {
-          id: 'revision123',
-          value: 'secret-value',
-          version: 1,
-          secretId: 'secret123',
-          createdOn: '2024-10-01T00:00:00Z',
-          createdById: 'user123',
-          environmentId: 'env123'
+          name: 'SECRET_NAME',
+          value: 'SECRET_VALUE',
+          isPlaintext: true
         }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+      ])
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid GetAllSecretsOfEnvironmentResponseSchema', () => {
+      const result = GetAllSecretsOfEnvironmentResponseSchema.safeParse([
+        {
+          name: 'SECRET_NAME',
+          value: 123, // Should be a string
+          isPlaintext: 'true' // Should be a boolean
+        }
+      ])
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate an invalid GetRevisionsOfSecretResponseSchema', () => {
-    const result = GetRevisionsOfSecretResponseSchema.safeParse({
-      items: [
-        {
-          id: 'revision123',
-          value: 'secret-value',
-          version: 'one', // Should be a number
-          // Missing secretId
-          createdOn: '2024-10-01T00:00:00Z',
-          createdById: 'user123',
-          environmentId: 'env123'
-        }
-      ],
-      metadata: {
+  describe('GetRevisionsOfSecretRequestSchema Tests', () => {
+    it('should validate a valid GetRevisionsOfSecretRequestSchema', () => {
+      const result = GetRevisionsOfSecretRequestSchema.safeParse({
+        secretSlug: 'my-secret',
+        environmentSlug: 'development',
         page: 1,
-        perPage: 'ten', // Should be a number
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+        limit: 10
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
+
+    it('should not validate an invalid GetRevisionsOfSecretRequestSchema', () => {
+      const result = GetRevisionsOfSecretRequestSchema.safeParse({
+        secretSlug: 'my-secret',
+        environmentSlug: 123, // Should be a string
+        page: 'one' // Should be a number
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('GetRevisionsOfSecretResponseSchema Tests', () => {
+    it('should validate a valid GetRevisionsOfSecretResponseSchema', () => {
+      const result = GetRevisionsOfSecretResponseSchema.safeParse({
+        items: [
+          {
+            id: 'revision123',
+            value: 'secret-value',
+            version: 1,
+            secretId: 'secret123',
+            createdOn: '2024-10-01T00:00:00Z',
+            createdById: 'user123',
+            environmentId: 'env123'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetRevisionsOfSecretResponseSchema', () => {
+      const result = GetRevisionsOfSecretResponseSchema.safeParse({
+        items: [
+          {
+            id: 'revision123',
+            value: 'secret-value',
+            version: 'one', // Should be a number
+            // Missing secretId
+            createdOn: '2024-10-01T00:00:00Z',
+            createdById: 'user123',
+            environmentId: 'env123'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 'ten', // Should be a number
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 })

--- a/packages/schema/tests/secret.spec.ts
+++ b/packages/schema/tests/secret.spec.ts
@@ -292,14 +292,14 @@ describe('Secret Schema Tests', () => {
   describe('RollBackSecretResponseSchema Tests', () => {
     it('should validate a valid RollBackSecretResponseSchema', () => {
       const result = RollBackSecretResponseSchema.safeParse({
-        count: '1'
+        count: 1
       })
       expect(result.success).toBe(true)
     })
 
     it('should not validate an invalid RollBackSecretResponseSchema', () => {
       const result = RollBackSecretResponseSchema.safeParse({
-        count: 1 // Should be a string
+        count: '1' // Should be a number
       })
       expect(result.success).toBe(false)
       expect(result.error?.issues).toHaveLength(1)

--- a/packages/schema/tests/user.spec.ts
+++ b/packages/schema/tests/user.spec.ts
@@ -12,244 +12,254 @@ import {
 } from '@/user'
 
 describe('User Schema Tests', () => {
-  // Tests for UserSchema
-  it('should validate a valid UserSchema', () => {
-    const result = UserSchema.safeParse({
-      id: 'user123',
-      email: 'user@example.com',
-      name: 'User Name',
-      profilePictureUrl: 'http://example.com/profile.jpg',
-      isActive: true,
-      isOnboardingFinished: true,
-      isAdmin: false,
-      authProvider: 'google'
+  describe('UserSchema Tests', () => {
+    it('should validate a valid UserSchema', () => {
+      const result = UserSchema.safeParse({
+        id: 'user123',
+        email: 'user@example.com',
+        name: 'User Name',
+        profilePictureUrl: 'http://example.com/profile.jpg',
+        isActive: true,
+        isOnboardingFinished: true,
+        isAdmin: false,
+        authProvider: 'google'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid UserSchema', () => {
-    const result = UserSchema.safeParse({
-      id: 'user123',
-      email: 'user@example', // Invalid email
-      name: 'User Name',
-      profilePictureUrl: 'http://example.com/profile.jpg',
-      isActive: true,
-      isOnboardingFinished: true,
-      isAdmin: false,
-      authProvider: 'google'
+    it('should not validate an invalid UserSchema', () => {
+      const result = UserSchema.safeParse({
+        id: 'user123',
+        email: 'user@example', // Invalid email
+        name: 'User Name',
+        profilePictureUrl: 'http://example.com/profile.jpg',
+        isActive: true,
+        isOnboardingFinished: true,
+        isAdmin: false,
+        authProvider: 'google'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  it('should not validate an invalid UserSchema with missing fields', () => {
-    const result = UserSchema.safeParse({
-      id: 'user123',
-      email: 'user@example.com',
-      name: 'User Name',
-      isActive: true,
-      isOnboardingFinished: true,
-      isAdmin: false,
-      authProvider: 'google'
-      // Missing profilePictureUrl
+    it('should not validate an invalid UserSchema with missing fields', () => {
+      const result = UserSchema.safeParse({
+        id: 'user123',
+        email: 'user@example.com',
+        name: 'User Name',
+        isActive: true,
+        isOnboardingFinished: true,
+        isAdmin: false,
+        authProvider: 'google'
+        // Missing profilePictureUrl
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  it('should not validate an invalid UserSchema with incorrect types', () => {
-    const result = UserSchema.safeParse({
-      id: 'user123',
-      email: 'user@example.com',
-      name: 'User Name',
-      profilePictureUrl: 'http://example.com/profile.jpg',
-      isActive: 'true', // Should be a boolean
-      isOnboardingFinished: true,
-      isAdmin: false,
-      authProvider: 'google'
+    it('should not validate an invalid UserSchema with incorrect types', () => {
+      const result = UserSchema.safeParse({
+        id: 'user123',
+        email: 'user@example.com',
+        name: 'User Name',
+        profilePictureUrl: 'http://example.com/profile.jpg',
+        isActive: 'true', // Should be a boolean
+        isOnboardingFinished: true,
+        isAdmin: false,
+        authProvider: 'google'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1) // Adjust the number based on incorrect types
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1) // Adjust the number based on incorrect types
   })
 
-  // Tests for GetSelfResponseSchema
-  it('should validate a valid GetSelfResponseSchema', () => {
-    const result = GetSelfResponseSchema.safeParse({
-      id: 'user123',
-      email: 'user@example.com',
-      name: 'John Doe',
-      profilePictureUrl: null,
-      isActive: true,
-      isOnboardingFinished: false,
-      isAdmin: false,
-      authProvider: 'email',
-      defaultWorkspace: {
-        id: 'workspace123',
-        name: 'My Workspace',
-        slug: 'my-workspace',
-        icon: 'icon.png',
-        isFreeTier: true,
-        createdAt: '2024-10-01T00:00:00Z',
-        updatedAt: '2024-10-01T00:00:00Z',
-        ownerId: 'owner123',
-        isDefault: true,
-        lastUpdatedById: 'user123'
-      }
+  describe('GetSelfResponseSchema Tests', () => {
+    it('should validate a valid GetSelfResponseSchema', () => {
+      const result = GetSelfResponseSchema.safeParse({
+        id: 'user123',
+        email: 'user@example.com',
+        name: 'John Doe',
+        profilePictureUrl: null,
+        isActive: true,
+        isOnboardingFinished: false,
+        isAdmin: false,
+        authProvider: 'email',
+        defaultWorkspace: {
+          id: 'workspace123',
+          name: 'My Workspace',
+          slug: 'my-workspace',
+          icon: 'icon.png',
+          isFreeTier: true,
+          createdAt: '2024-10-01T00:00:00Z',
+          updatedAt: '2024-10-01T00:00:00Z',
+          ownerId: 'owner123',
+          isDefault: true,
+          lastUpdatedById: 'user123'
+        }
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should fail validation for invalid GetSelfResponseSchema', () => {
-    const result = GetSelfResponseSchema.safeParse({
-      email: 'invalid-email',
-      name: 'John Doe'
-      // Missing required fields and invalid email
+    it('should fail validation for invalid GetSelfResponseSchema', () => {
+      const result = GetSelfResponseSchema.safeParse({
+        email: 'invalid-email',
+        name: 'John Doe'
+        // Missing required fields and invalid email
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(8)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(8)
   })
 
-  // Tests for UpdateSelfRequestSchema
-  it('should validate a valid UpdateSelfRequestSchema', () => {
-    const result = UpdateSelfRequestSchema.safeParse({
-      name: 'Jane Doe',
-      email: 'jane@example.com',
-      isOnboardingFinished: true
+  describe('UpdateSelfRequestSchema Tests', () => {
+    it('should validate a valid UpdateSelfRequestSchema', () => {
+      const result = UpdateSelfRequestSchema.safeParse({
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        isOnboardingFinished: true
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should fail validation for invalid UpdateSelfRequestSchema', () => {
-    const result = UpdateSelfRequestSchema.safeParse({
-      email: 'invalid-email-format'
+    it('should fail validation for invalid UpdateSelfRequestSchema', () => {
+      const result = UpdateSelfRequestSchema.safeParse({
+        email: 'invalid-email-format'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
   })
 
-  // Tests for UpdateSelfResponseSchema
-  it('should validate a valid UpdateSelfResponseSchema', () => {
-    const result = UpdateSelfResponseSchema.safeParse({
-      id: 'user123',
-      email: 'jane@example.com',
-      name: 'Jane Doe',
-      isActive: true,
-      profilePictureUrl: null,
-      isOnboardingFinished: false,
-      isAdmin: false,
-      authProvider: 'email'
+  describe('UpdateSelfResponseSchema Tests', () => {
+    it('should validate a valid UpdateSelfResponseSchema', () => {
+      const result = UpdateSelfResponseSchema.safeParse({
+        id: 'user123',
+        email: 'jane@example.com',
+        name: 'Jane Doe',
+        isActive: true,
+        profilePictureUrl: null,
+        isOnboardingFinished: false,
+        isAdmin: false,
+        authProvider: 'email'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should fail validation for invalid UpdateSelfResponseSchema', () => {
-    const result = UpdateSelfResponseSchema.safeParse({
-      id: 123, // Should be a string
-      email: 'jane@example.com'
-      // Missing required fields
+    it('should fail validation for invalid UpdateSelfResponseSchema', () => {
+      const result = UpdateSelfResponseSchema.safeParse({
+        id: 123, // Should be a string
+        email: 'jane@example.com'
+        // Missing required fields
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(7)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(7)
   })
 
-  // Tests for DeleteSelfRequestSchema
-  it('should validate a valid DeleteSelfRequestSchema', () => {
-    const result = DeleteSelfRequestSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should fail validation for invalid DeleteSelfRequestSchema', () => {
-    const result = DeleteSelfRequestSchema.safeParse({
-      unexpectedField: 'value'
+  describe('DeleteSelfRequestSchema Tests', () => {
+    it('should validate a valid DeleteSelfRequestSchema', () => {
+      const result = DeleteSelfRequestSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
-  })
 
-  // Tests for DeleteSelfResponseSchema
-  it('should validate a valid DeleteSelfResponseSchema', () => {
-    const result = DeleteSelfResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should fail validation for invalid DeleteSelfResponseSchema', () => {
-    const result = DeleteSelfResponseSchema.safeParse({
-      success: true
+    it('should fail validation for invalid DeleteSelfRequestSchema', () => {
+      const result = DeleteSelfRequestSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
   })
 
-  // Tests for ValidateEmailChangeOTPRequestSchema
-  it('should validate a valid ValidateEmailChangeOTPRequestSchema', () => {
-    const result = ValidateEmailChangeOTPRequestSchema.safeParse({
-      otp: '123456'
+  describe('DeleteSelfResponseSchema Tests', () => {
+    it('should validate a valid DeleteSelfResponseSchema', () => {
+      const result = DeleteSelfResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should fail validation for OTP of length other than 6 ValidateEmailChangeOTPRequestSchema', () => {
-    const result = ValidateEmailChangeOTPRequestSchema.safeParse({
-      otp: '234' // Should be a 6 digit string
+    it('should fail validation for invalid DeleteSelfResponseSchema', () => {
+      const result = DeleteSelfResponseSchema.safeParse({
+        success: true
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
   })
 
-  it('should fail validation for invalid ValidateEmailChangeOTPRequestSchema', () => {
-    const result = ValidateEmailChangeOTPRequestSchema.safeParse({
-      otp: 123456 // Should be a string
+  describe('ValidateEmailChangeOTPRequestSchema Tests', () => {
+    it('should validate a valid ValidateEmailChangeOTPRequestSchema', () => {
+      const result = ValidateEmailChangeOTPRequestSchema.safeParse({
+        otp: '123456'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
-  })
 
-  // Tests for ValidateEmailChangeOTPResponseSchema
-  it('should validate a valid ValidateEmailChangeOTPResponseSchema', () => {
-    const result = ValidateEmailChangeOTPResponseSchema.safeParse({
-      id: 'user123',
-      email: 'user@example.com',
-      name: 'John Doe',
-      profilePictureUrl: null,
-      isActive: true,
-      isOnboardingFinished: false,
-      isAdmin: false,
-      authProvider: 'email'
+    it('should fail validation for OTP of length other than 6 ValidateEmailChangeOTPRequestSchema', () => {
+      const result = ValidateEmailChangeOTPRequestSchema.safeParse({
+        otp: '234' // Should be a 6 digit string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should fail validation for invalid ValidateEmailChangeOTPResponseSchema', () => {
-    const result = ValidateEmailChangeOTPResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
-  })
-
-  // Tests for ResendEmailChangeOTPRequestSchema
-  it('should validate a valid ResendEmailChangeOTPRequestSchema', () => {
-    const result = ResendEmailChangeOTPRequestSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should fail validation for invalid ResendEmailChangeOTPRequestSchema', () => {
-    const result = ResendEmailChangeOTPRequestSchema.safeParse({
-      extraField: 'value' // Should not have any fields
+    it('should fail validation for invalid ValidateEmailChangeOTPRequestSchema', () => {
+      const result = ValidateEmailChangeOTPRequestSchema.safeParse({
+        otp: 123456 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
   })
 
-  // Tests for ResendEmailChangeOTPResponseSchema
-  it('should validate a valid ResendEmailChangeOTPResponseSchema', () => {
-    const result = ResendEmailChangeOTPResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should fail validation for invalid ResendEmailChangeOTPResponseSchema', () => {
-    const result = ResendEmailChangeOTPResponseSchema.safeParse({
-      success: true
+  describe('ValidateEmailChangeOTPResponseSchema Tests', () => {
+    it('should validate a valid ValidateEmailChangeOTPResponseSchema', () => {
+      const result = ValidateEmailChangeOTPResponseSchema.safeParse({
+        id: 'user123',
+        email: 'user@example.com',
+        name: 'John Doe',
+        profilePictureUrl: null,
+        isActive: true,
+        isOnboardingFinished: false,
+        isAdmin: false,
+        authProvider: 'email'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues.length).toBe(1)
+
+    it('should fail validation for invalid ValidateEmailChangeOTPResponseSchema', () => {
+      const result = ValidateEmailChangeOTPResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
+    })
+  })
+
+  describe('ResendEmailChangeOTPRequestSchema Tests', () => {
+    it('should validate a valid ResendEmailChangeOTPRequestSchema', () => {
+      const result = ResendEmailChangeOTPRequestSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should fail validation for invalid ResendEmailChangeOTPRequestSchema', () => {
+      const result = ResendEmailChangeOTPRequestSchema.safeParse({
+        extraField: 'value' // Should not have any fields
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
+    })
+  })
+
+  describe('ResendEmailChangeOTPResponseSchema Tests', () => {
+    it('should validate a valid ResendEmailChangeOTPResponseSchema', () => {
+      const result = ResendEmailChangeOTPResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should fail validation for invalid ResendEmailChangeOTPResponseSchema', () => {
+      const result = ResendEmailChangeOTPResponseSchema.safeParse({
+        success: true
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues.length).toBe(1)
+    })
   })
 })

--- a/packages/schema/tests/variable.spec.ts
+++ b/packages/schema/tests/variable.spec.ts
@@ -318,14 +318,14 @@ describe('Variable Schema Tests', () => {
   describe('RollBackVariableResponseSchema Tests', () => {
     it('should validate a valid RollBackVariableResponseSchema', () => {
       const result = RollBackVariableResponseSchema.safeParse({
-        count: '1'
+        count: 1
       })
       expect(result.success).toBe(true)
     })
 
     it('should not validate an invalid RollBackVariableResponseSchema', () => {
       const result = RollBackVariableResponseSchema.safeParse({
-        count: 1 // Should be a string
+        count: '1' // Should be a number
       })
       expect(result.success).toBe(false)
       expect(result.error?.issues).toHaveLength(1)

--- a/packages/schema/tests/variable.spec.ts
+++ b/packages/schema/tests/variable.spec.ts
@@ -13,435 +13,446 @@ import {
 } from '@/variable'
 
 describe('Variable Schema Tests', () => {
-  // Tests for VariableSchema
-  it('should validate a valid VariableSchema', () => {
-    const result = VariableSchema.safeParse({
-      id: 'variable123',
-      name: 'Variable Name',
-      slug: 'variable-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'variable-value',
-          environment: {
-            id: 'env123',
-            slug: 'development'
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate a valid VariableSchema with no note', () => {
-    const result = VariableSchema.safeParse({
-      id: 'variable123',
-      name: 'Variable Name',
-      slug: 'variable-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      note: null,
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'variable-value',
-          environment: {
-            id: 'env123',
-            slug: 'development'
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid VariableSchema', () => {
-    const result = VariableSchema.safeParse({
-      id: 'variable123',
-      name: 'Variable Name',
-      slug: 'variable-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'variable-value',
-          environmentId: 'env123',
-          environment: {
-            id: 'env123'
-            // Missing slug
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for CreateVariableRequestSchema
-  it('should validate if proper input is specified for CreateVariableRequestSchema', () => {
-    const result = CreateVariableRequestSchema.safeParse({
-      projectSlug: 'projectTest',
-      name: 'Variable Test',
-      entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate if only required fields are specified for CreateVariableRequestSchema', () => {
-    const result = CreateVariableRequestSchema.safeParse({
-      projectSlug: 'projectTest',
-      name: 'Variable Test'
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if required fields are missing for CreateVariableRequestSchema', () => {
-    const result = CreateVariableRequestSchema.safeParse({
-      entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  it('should not validate if invalid types are specified for CreateVariableRequestSchema', () => {
-    const result = CreateVariableRequestSchema.safeParse({
-      projectSlug: 123,
-      name: 456,
-      entries: [{ environmentSlug: 'env123', value: 456 }]
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  it('should validate if optional fields are omitted for CreateVariableRequestSchema', () => {
-    const result = CreateVariableRequestSchema.safeParse({
-      projectSlug: 'projectTest',
-      name: 'Variable Test',
-      entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate if note field is provided for CreateVariableRequestSchema', () => {
-    const result = CreateVariableRequestSchema.safeParse({
-      projectSlug: 'projectTest',
-      name: 'Variable Test',
-      note: 'This is a note',
-      entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  // Tests for CreateVariableResponseSchema
-  it('should validate a valid CreateVariableResponseSchema', () => {
-    const result = CreateVariableResponseSchema.safeParse({
-      id: 'variable123',
-      name: 'Variable Name',
-      slug: 'variable-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'variable-value',
-          environment: {
-            id: 'env123',
-            slug: 'development'
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CreateVariableResponseSchema', () => {
-    const result = CreateVariableResponseSchema.safeParse({
-      id: 'variable123',
-      name: 'Variable Name',
-      slug: 'variable-slug',
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      note: 'This is a note',
-      lastUpdatedById: 'user123',
-      projectId: 'project123',
-      project: {
-        workspaceId: 'workspace123'
-      },
-      versions: [
-        {
-          value: 'variable-value',
-          environment: {
-            id: 'env123'
-            // Missing slug
-          }
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for UpdateVariableRequestSchema
-  it('should validate a valid UpdateVariableRequestSchema', () => {
-    const result = UpdateVariableRequestSchema.safeParse({
-      variableSlug: 'variable-slug',
-      name: 'Updated Variable Name',
-      note: 'Updated note',
-      entries: [
-        {
-          value: 'variable-value',
-          environmentSlug: 'development'
-        }
-      ]
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateVariableRequestSchema', () => {
-    const result = UpdateVariableRequestSchema.safeParse({
-      variableSlug: 123, // Should be a string
-      name: 'Updated Variable Name',
-      note: 'Updated note',
-      entries: [
-        {
-          value: 'variable-value',
-          environmentSlug: 'development'
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for UpdateVariableResponseSchema
-  it('should validate a valid UpdateVariableResponseSchema', () => {
-    const result = UpdateVariableResponseSchema.safeParse({
-      variable: {
+  describe('VariableSchema Tests', () => {
+    it('should validate a valid VariableSchema', () => {
+      const result = VariableSchema.safeParse({
         id: 'variable123',
         name: 'Variable Name',
         slug: 'variable-slug',
-        note: 'This is a note'
-      },
-      updatedVersions: [
-        {
-          id: 'variable123',
-          value: 'variable-value',
-          version: 4,
-          environment: {
-            id: 'env123',
-            slug: 'development'
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'variable-value',
+            environment: {
+              id: 'env123',
+              slug: 'development'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid UpdateVariableResponseSchema', () => {
-    const result = UpdateVariableResponseSchema.safeParse({
-      variable: {
+    it('should validate a valid VariableSchema with no note', () => {
+      const result = VariableSchema.safeParse({
         id: 'variable123',
         name: 'Variable Name',
         slug: 'variable-slug',
-        note: 'This is a note'
-      },
-      updatedVersions: [
-        {
-          id: 'variable123',
-          value: 'variable-value',
-          // Missing version
-          environment: {
-            id: 'env123'
-            // Missing slug
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        note: null,
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'variable-value',
+            environment: {
+              id: 'env123',
+              slug: 'development'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
 
-  // Tests for RollBackVariableRequestSchema
-  it('should validate a valid RollBackVariableRequestSchema', () => {
-    const result = RollBackVariableRequestSchema.safeParse({
-      variableSlug: 'variable-slug',
-      version: 1,
-      environmentSlug: 'development'
+    it('should not validate an invalid VariableSchema', () => {
+      const result = VariableSchema.safeParse({
+        id: 'variable123',
+        name: 'Variable Name',
+        slug: 'variable-slug',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'variable-value',
+            environmentId: 'env123',
+            environment: {
+              id: 'env123'
+              // Missing slug
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid RollBackVariableRequestSchema', () => {
-    const result = RollBackVariableRequestSchema.safeParse({
-      variableSlug: 'variable-slug',
-      version: 'one', // Should be a number
-      environmentSlug: 'development'
+  describe('CreateVariableRequestSchema Tests', () => {
+    it('should validate if proper input is specified for CreateVariableRequestSchema', () => {
+      const result = CreateVariableRequestSchema.safeParse({
+        projectSlug: 'projectTest',
+        name: 'Variable Test',
+        entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
+      })
+
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for RollBackVariableResponseSchema
-  it('should validate a valid RollBackVariableResponseSchema', () => {
-    const result = RollBackVariableResponseSchema.safeParse({
-      count: '1'
+    it('should validate if only required fields are specified for CreateVariableRequestSchema', () => {
+      const result = CreateVariableRequestSchema.safeParse({
+        projectSlug: 'projectTest',
+        name: 'Variable Test'
+      })
+
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid RollBackVariableResponseSchema', () => {
-    const result = RollBackVariableResponseSchema.safeParse({
-      count: 1 // Should be a string
+    it('should not validate if required fields are missing for CreateVariableRequestSchema', () => {
+      const result = CreateVariableRequestSchema.safeParse({
+        entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for DeleteVariableRequestSchema
-  it('should validate a valid DeleteVariableRequestSchema', () => {
-    const result = DeleteVariableRequestSchema.safeParse({
-      variableSlug: 'variable-slug'
+    it('should not validate if invalid types are specified for CreateVariableRequestSchema', () => {
+      const result = CreateVariableRequestSchema.safeParse({
+        projectSlug: 123,
+        name: 456,
+        entries: [{ environmentSlug: 'env123', value: 456 }]
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid DeleteVariableRequestSchema', () => {
-    const result = DeleteVariableRequestSchema.safeParse({
-      variableSlug: 123 // Should be a string
+    it('should validate if optional fields are omitted for CreateVariableRequestSchema', () => {
+      const result = CreateVariableRequestSchema.safeParse({
+        projectSlug: 'projectTest',
+        name: 'Variable Test',
+        entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
+      })
+
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for DeleteVariableResponseSchema
-  it('should validate a valid DeleteVariableResponseSchema', () => {
-    const result = DeleteVariableResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
+    it('should validate if note field is provided for CreateVariableRequestSchema', () => {
+      const result = CreateVariableRequestSchema.safeParse({
+        projectSlug: 'projectTest',
+        name: 'Variable Test',
+        note: 'This is a note',
+        entries: [{ environmentSlug: 'env123', value: 'variable-value' }]
+      })
 
-  it('should not validate an invalid DeleteVariableResponseSchema', () => {
-    const result = DeleteVariableResponseSchema.safeParse({
-      unexpectedField: 'value'
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
   })
 
-  // Tests for GetAllVariablesOfProjectRequestSchema
-  it('should validate a valid GetAllVariablesOfProjectRequestSchema', () => {
-    const result = GetAllVariablesOfProjectRequestSchema.safeParse({
-      projectSlug: 'project-slug',
-      page: 1,
-      limit: 10
+  describe('CreateVariableResponseSchema Tests', () => {
+    it('should validate a valid CreateVariableResponseSchema', () => {
+      const result = CreateVariableResponseSchema.safeParse({
+        id: 'variable123',
+        name: 'Variable Name',
+        slug: 'variable-slug',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'variable-value',
+            environment: {
+              id: 'env123',
+              slug: 'development'
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid GetAllVariablesOfProjectRequestSchema', () => {
-    const result = GetAllVariablesOfProjectRequestSchema.safeParse({
-      projectSlug: 123, // Should be a string
-      page: 1,
-      limit: 10
+    it('should not validate an invalid CreateVariableResponseSchema', () => {
+      const result = CreateVariableResponseSchema.safeParse({
+        id: 'variable123',
+        name: 'Variable Name',
+        slug: 'variable-slug',
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        note: 'This is a note',
+        lastUpdatedById: 'user123',
+        projectId: 'project123',
+        project: {
+          workspaceId: 'workspace123'
+        },
+        versions: [
+          {
+            value: 'variable-value',
+            environment: {
+              id: 'env123'
+              // Missing slug
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
   })
 
-  // Tests for GetAllVariablesOfProjectResponseSchema
-  it('should validate a valid GetAllVariablesOfProjectResponseSchema', () => {
-    const result = GetAllVariablesOfProjectResponseSchema.safeParse({
-      items: [
-        {
+  describe('UpdateVariableRequestSchema Tests', () => {
+    it('should validate a valid UpdateVariableRequestSchema', () => {
+      const result = UpdateVariableRequestSchema.safeParse({
+        variableSlug: 'variable-slug',
+        name: 'Updated Variable Name',
+        note: 'Updated note',
+        entries: [
+          {
+            value: 'variable-value',
+            environmentSlug: 'development'
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid UpdateVariableRequestSchema', () => {
+      const result = UpdateVariableRequestSchema.safeParse({
+        variableSlug: 123, // Should be a string
+        name: 'Updated Variable Name',
+        note: 'Updated note',
+        entries: [
+          {
+            value: 'variable-value',
+            environmentSlug: 'development'
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('UpdateVariableResponseSchema Tests', () => {
+    it('should validate a valid UpdateVariableResponseSchema', () => {
+      const result = UpdateVariableResponseSchema.safeParse({
+        variable: {
           id: 'variable123',
           name: 'Variable Name',
           slug: 'variable-slug',
-          createdAt: '2024-10-01T00:00:00Z',
-          updatedAt: '2024-10-01T00:00:00Z',
-          note: 'This is a note',
-          lastUpdatedById: 'user123',
-          projectId: 'project123',
-          variable: {
-            lastUpdatedBy: {
-              id: 'user123',
-              name: 'John Doe'
+          note: 'This is a note'
+        },
+        updatedVersions: [
+          {
+            id: 'variable123',
+            value: 'variable-value',
+            version: 4,
+            environment: {
+              id: 'env123',
+              slug: 'development'
             }
-          },
-          values: [
-            {
-              environment: {
-                id: 'env123',
-                name: 'Development',
-                slug: 'development'
-              },
-              value: 'variable-value',
-              version: 1
-            }
-          ]
-        }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
+    it('should not validate an invalid UpdateVariableResponseSchema', () => {
+      const result = UpdateVariableResponseSchema.safeParse({
+        variable: {
+          id: 'variable123',
+          name: 'Variable Name',
+          slug: 'variable-slug',
+          note: 'This is a note'
+        },
+        updatedVersions: [
+          {
+            id: 'variable123',
+            value: 'variable-value',
+            // Missing version
+            environment: {
+              id: 'env123'
+              // Missing slug
+            }
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate an invalid GetAllVariablesOfProjectResponseSchema', () => {
-    const result = GetAllVariablesOfProjectResponseSchema.safeParse({
-      items: 'not-an-array', // Should be an array
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+  describe('RollBackVariableRequestSchema Tests', () => {
+    it('should validate a valid RollBackVariableRequestSchema', () => {
+      const result = RollBackVariableRequestSchema.safeParse({
+        variableSlug: 'variable-slug',
+        version: 1,
+        environmentSlug: 'development'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid RollBackVariableRequestSchema', () => {
+      const result = RollBackVariableRequestSchema.safeParse({
+        variableSlug: 'variable-slug',
+        version: 'one', // Should be a number
+        environmentSlug: 'development'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('RollBackVariableResponseSchema Tests', () => {
+    it('should validate a valid RollBackVariableResponseSchema', () => {
+      const result = RollBackVariableResponseSchema.safeParse({
+        count: '1'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid RollBackVariableResponseSchema', () => {
+      const result = RollBackVariableResponseSchema.safeParse({
+        count: 1 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('DeleteVariableRequestSchema Tests', () => {
+    it('should validate a valid DeleteVariableRequestSchema', () => {
+      const result = DeleteVariableRequestSchema.safeParse({
+        variableSlug: 'variable-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeleteVariableRequestSchema', () => {
+      const result = DeleteVariableRequestSchema.safeParse({
+        variableSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('DeleteVariableResponseSchema Tests', () => {
+    it('should validate a valid DeleteVariableResponseSchema', () => {
+      const result = DeleteVariableResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeleteVariableResponseSchema', () => {
+      const result = DeleteVariableResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('GetAllVariablesOfProjectRequestSchema Tests', () => {
+    it('should validate a valid GetAllVariablesOfProjectRequestSchema', () => {
+      const result = GetAllVariablesOfProjectRequestSchema.safeParse({
+        projectSlug: 'project-slug',
+        page: 1,
+        limit: 10
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetAllVariablesOfProjectRequestSchema', () => {
+      const result = GetAllVariablesOfProjectRequestSchema.safeParse({
+        projectSlug: 123, // Should be a string
+        page: 1,
+        limit: 10
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('GetAllVariablesOfProjectResponseSchema Tests', () => {
+    it('should validate a valid GetAllVariablesOfProjectResponseSchema', () => {
+      const result = GetAllVariablesOfProjectResponseSchema.safeParse({
+        items: [
+          {
+            id: 'variable123',
+            name: 'Variable Name',
+            slug: 'variable-slug',
+            createdAt: '2024-10-01T00:00:00Z',
+            updatedAt: '2024-10-01T00:00:00Z',
+            note: 'This is a note',
+            lastUpdatedById: 'user123',
+            projectId: 'project123',
+            variable: {
+              lastUpdatedBy: {
+                id: 'user123',
+                name: 'John Doe'
+              }
+            },
+            values: [
+              {
+                environment: {
+                  id: 'env123',
+                  name: 'Development',
+                  slug: 'development'
+                },
+                value: 'variable-value',
+                version: 1
+              }
+            ]
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetAllVariablesOfProjectResponseSchema', () => {
+      const result = GetAllVariablesOfProjectResponseSchema.safeParse({
+        items: 'not-an-array', // Should be an array
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 })

--- a/packages/schema/tests/workspace-membership.spec.ts
+++ b/packages/schema/tests/workspace-membership.spec.ts
@@ -24,408 +24,429 @@ import {
 } from '@/workspace-membership'
 
 describe('Workspace Membership Schema Tests', () => {
-  // Tests for CreateWorkspaceMemberSchema
-  it('should validate a valid CreateWorkspaceMemberSchema', () => {
-    const result = CreateWorkspaceMemberSchema.safeParse({
-      email: 'user@example.com',
-      roleSlugs: ['admin', 'editor']
+  describe('CreateWorkspaceMemberSchema Tests', () => {
+    it('should validate a valid CreateWorkspaceMemberSchema', () => {
+      const result = CreateWorkspaceMemberSchema.safeParse({
+        email: 'user@example.com',
+        roleSlugs: ['admin', 'editor']
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid CreateWorkspaceMemberSchema', () => {
-    const result = CreateWorkspaceMemberSchema.safeParse({
-      email: 'user@example', // Invalid email
-      roleSlugs: 'admin' // Should be an array
+    it('should not validate an invalid CreateWorkspaceMemberSchema', () => {
+      const result = CreateWorkspaceMemberSchema.safeParse({
+        email: 'user@example', // Invalid email
+        roleSlugs: 'admin' // Should be an array
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
   })
 
-  // Tests for TransferOwnershipRequestSchema
-  it('should validate a valid TransferOwnershipRequestSchema', () => {
-    const result = TransferOwnershipRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      userEmail: 'user@example.com'
+  describe('TransferOwnershipRequestSchema Tests', () => {
+    it('should validate a valid TransferOwnershipRequestSchema', () => {
+      const result = TransferOwnershipRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        userEmail: 'user@example.com'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid TransferOwnershipRequestSchema', () => {
-    const result = TransferOwnershipRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      userEmail: 'user@example' // Invalid email
+    it('should not validate an invalid TransferOwnershipRequestSchema', () => {
+      const result = TransferOwnershipRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        userEmail: 'user@example' // Invalid email
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
   })
 
-  // Tests for TransferOwnershipResponseSchema
-  it('should validate a valid TransferOwnershipResponseSchema', () => {
-    const result = TransferOwnershipResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid TransferOwnershipResponseSchema', () => {
-    const result = TransferOwnershipResponseSchema.safeParse({
-      unexpectedField: 'value'
+  describe('TransferOwnershipResponseSchema Tests', () => {
+    it('should validate a valid TransferOwnershipResponseSchema', () => {
+      const result = TransferOwnershipResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-  })
 
-  // Tests for InviteUsersRequestSchema
-  it('should validate a valid InviteUsersRequestSchema', () => {
-    const result = InviteUsersRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      members: [
-        {
-          email: 'user1@example.com',
-          roleSlugs: ['admin', 'editor']
-        },
-        {
-          email: 'user2@example.com',
-          roleSlugs: ['viewer']
-        }
-      ]
+    it('should not validate an invalid TransferOwnershipResponseSchema', () => {
+      const result = TransferOwnershipResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid InviteUsersRequestSchema', () => {
-    const result = InviteUsersRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      members: [
-        {
-          email: 'user1@example', // Invalid email
-          roleSlugs: 'admin' // Should be an array
-        }
-      ]
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for InviteUsersResponseSchema
-  it('should validate a valid InviteUsersResponseSchema', () => {
-    const result = InviteUsersResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid InviteUsersResponseSchema', () => {
-    const result = InviteUsersResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for RemoveUsersRequestSchema
-  it('should validate a valid RemoveUsersRequestSchema', () => {
-    const result = RemoveUsersRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      userEmails: 'user1@example.com,user2@example.com'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid RemoveUsersRequestSchema', () => {
-    const result = RemoveUsersRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      userEmails: ['user1@example.com', 'user2@example.com'] // Should be a string of comma-separated emails
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for RemoveUsersResponseSchema
-  it('should validate a valid RemoveUsersResponseSchema', () => {
-    const result = RemoveUsersResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid RemoveUsersResponseSchema', () => {
-    const result = RemoveUsersResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for UpdateMemberRoleRequestSchema
-  it('should validate a valid UpdateMemberRoleRequestSchema', () => {
-    const result = UpdateMemberRoleRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      userEmail: 'user@example.com',
-      roleSlugs: ['admin', 'editor']
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateMemberRoleRequestSchema', () => {
-    const result = UpdateMemberRoleRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      userEmail: 'user@example', // Invalid email
-      roleSlugs: 'admin' // Should be an array
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
-
-  // Tests for UpdateMemberRoleResponseSchema
-  it('should validate a valid UpdateMemberRoleResponseSchema', () => {
-    const result = UpdateMemberRoleResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid UpdateMemberRoleResponseSchema', () => {
-    const result = UpdateMemberRoleResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for AcceptInvitationRequestSchema
-  it('should validate a valid AcceptInvitationRequestSchema', () => {
-    const result = AcceptInvitationRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid AcceptInvitationRequestSchema', () => {
-    const result = AcceptInvitationRequestSchema.safeParse({
-      workspaceSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for AcceptInvitationResponseSchema
-  it('should validate a valid AcceptInvitationResponseSchema', () => {
-    const result = AcceptInvitationResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid AcceptInvitationResponseSchema', () => {
-    const result = AcceptInvitationResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for DeclineInvitationRequestSchema
-  it('should validate a valid DeclineInvitationRequestSchema', () => {
-    const result = DeclineInvitationRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeclineInvitationRequestSchema', () => {
-    const result = DeclineInvitationRequestSchema.safeParse({
-      workspaceSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for DeclineInvitationResponseSchema
-  it('should validate a valid DeclineInvitationResponseSchema', () => {
-    const result = DeclineInvitationResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeclineInvitationResponseSchema', () => {
-    const result = DeclineInvitationResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for CancelInvitationRequestSchema
-  it('should validate a valid CancelInvitationRequestSchema', () => {
-    const result = CancelInvitationRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      userEmail: 'user@example.com'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CancelInvitationRequestSchema', () => {
-    const result = CancelInvitationRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      userEmail: 'user@example' // Invalid email
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for CancelInvitationResponseSchema
-  it('should validate a valid CancelInvitationResponseSchema', () => {
-    const result = CancelInvitationResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid CancelInvitationResponseSchema', () => {
-    const result = CancelInvitationResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for LeaveWorkspaceRequestSchema
-  it('should validate a valid LeaveWorkspaceRequestSchema', () => {
-    const result = LeaveWorkspaceRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid LeaveWorkspaceRequestSchema', () => {
-    const result = LeaveWorkspaceRequestSchema.safeParse({
-      workspaceSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for LeaveWorkspaceResponseSchema
-  it('should validate a valid LeaveWorkspaceResponseSchema', () => {
-    const result = LeaveWorkspaceResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid LeaveWorkspaceResponseSchema', () => {
-    const result = LeaveWorkspaceResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  // Tests for IsMemberRequestSchema
-  it('should validate a valid IsMemberRequestSchema', () => {
-    const result = IsMemberRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      userEmail: 'user@example.com'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid IsMemberRequestSchema', () => {
-    const result = IsMemberRequestSchema.safeParse({
-      workspaceSlug: 123, // Should be a string
-      userEmail: 'user@example' // Invalid email
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for IsMemberResponseSchema
-  it('should validate a valid IsMemberResponseSchema', () => {
-    const result = IsMemberResponseSchema.safeParse(true)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid IsMemberResponseSchema', () => {
-    const result = IsMemberResponseSchema.safeParse('true') // Should be a boolean
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  // Tests for GetMembersRequestSchema
-  it('should validate a valid GetMembersRequestSchema', () => {
-    const result = GetMembersRequestSchema.safeParse({
-      page: 1,
-      limit: 10,
-      sort: 'name',
-      order: 'asc',
-      search: 'admin',
-      workspaceSlug: 'workspace-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetMembersRequestSchema', () => {
-    const result = GetMembersRequestSchema.safeParse({
-      page: 'one', // Should be a number
-      limit: 10,
-      sort: 'name',
-      order: 'asc',
-      search: 'admin',
-      workspaceSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for GetMembersResponseSchema
-  it('should validate a valid GetMembersResponseSchema', () => {
-    const result = GetMembersResponseSchema.safeParse({
-      items: [
-        {
-          id: 'member123',
-          user: {
-            id: 'user123',
-            email: 'user@example.com',
-            name: 'User Name',
-            profilePictureUrl: 'http://example.com/profile.jpg',
-            isActive: true,
-            isOnboardingFinished: true,
-            isAdmin: false,
-            authProvider: 'google'
+  describe('InviteUsersRequestSchema Tests', () => {
+    it('should validate a valid InviteUsersRequestSchema', () => {
+      const result = InviteUsersRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        members: [
+          {
+            email: 'user1@example.com',
+            roleSlugs: ['admin', 'editor']
           },
-          roles: [
-            {
-              id: 'role123',
-              role: {
-                id: 'role123',
-                name: 'Admin Role',
-                description: 'Role with admin privileges',
-                colorCode: '#FF5733',
-                authorities: ['CREATE_PROJECT'],
-                projects: [
-                  {
-                    id: 'project123'
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      ],
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+          {
+            email: 'user2@example.com',
+            roleSlugs: ['viewer']
+          }
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid InviteUsersRequestSchema', () => {
+      const result = InviteUsersRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        members: [
+          {
+            email: 'user1@example', // Invalid email
+            roleSlugs: 'admin' // Should be an array
+          }
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
   })
 
-  it('should not validate an invalid GetMembersResponseSchema', () => {
-    const result = GetMembersResponseSchema.safeParse({
-      items: 'not-an-array', // Should be an array
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+  describe('InviteUsersResponseSchema Tests', () => {
+    it('should validate a valid InviteUsersResponseSchema', () => {
+      const result = InviteUsersResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid InviteUsersResponseSchema', () => {
+      const result = InviteUsersResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('RemoveUsersRequestSchema Tests', () => {
+    it('should validate a valid RemoveUsersRequestSchema', () => {
+      const result = RemoveUsersRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        userEmails: 'user1@example.com,user2@example.com'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid RemoveUsersRequestSchema', () => {
+      const result = RemoveUsersRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        userEmails: ['user1@example.com', 'user2@example.com'] // Should be a string of comma-separated emails
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('RemoveUsersResponseSchema Tests', () => {
+    it('should validate a valid RemoveUsersResponseSchema', () => {
+      const result = RemoveUsersResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid RemoveUsersResponseSchema', () => {
+      const result = RemoveUsersResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('UpdateMemberRoleRequestSchema Tests', () => {
+    it('should validate a valid UpdateMemberRoleRequestSchema', () => {
+      const result = UpdateMemberRoleRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        userEmail: 'user@example.com',
+        roleSlugs: ['admin', 'editor']
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid UpdateMemberRoleRequestSchema', () => {
+      const result = UpdateMemberRoleRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        userEmail: 'user@example', // Invalid email
+        roleSlugs: 'admin' // Should be an array
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
+    })
+  })
+
+  describe('UpdateMemberRoleResponseSchema Tests', () => {
+    it('should validate a valid UpdateMemberRoleResponseSchema', () => {
+      const result = UpdateMemberRoleResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid UpdateMemberRoleResponseSchema', () => {
+      const result = UpdateMemberRoleResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('AcceptInvitationRequestSchema Tests', () => {
+    it('should validate a valid AcceptInvitationRequestSchema', () => {
+      const result = AcceptInvitationRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid AcceptInvitationRequestSchema', () => {
+      const result = AcceptInvitationRequestSchema.safeParse({
+        workspaceSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('AcceptInvitationResponseSchema Tests', () => {
+    it('should validate a valid AcceptInvitationResponseSchema', () => {
+      const result = AcceptInvitationResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid AcceptInvitationResponseSchema', () => {
+      const result = AcceptInvitationResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('DeclineInvitationRequestSchema Tests', () => {
+    it('should validate a valid DeclineInvitationRequestSchema', () => {
+      const result = DeclineInvitationRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeclineInvitationRequestSchema', () => {
+      const result = DeclineInvitationRequestSchema.safeParse({
+        workspaceSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('DeclineInvitationResponseSchema Tests', () => {
+    it('should validate a valid DeclineInvitationResponseSchema', () => {
+      const result = DeclineInvitationResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid DeclineInvitationResponseSchema', () => {
+      const result = DeclineInvitationResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('CancelInvitationRequestSchema Tests', () => {
+    it('should validate a valid CancelInvitationRequestSchema', () => {
+      const result = CancelInvitationRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        userEmail: 'user@example.com'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid CancelInvitationRequestSchema', () => {
+      const result = CancelInvitationRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        userEmail: 'user@example' // Invalid email
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('CancelInvitationResponseSchema Tests', () => {
+    it('should validate a valid CancelInvitationResponseSchema', () => {
+      const result = CancelInvitationResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid CancelInvitationResponseSchema', () => {
+      const result = CancelInvitationResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('LeaveWorkspaceRequestSchema Tests', () => {
+    it('should validate a valid LeaveWorkspaceRequestSchema', () => {
+      const result = LeaveWorkspaceRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid LeaveWorkspaceRequestSchema', () => {
+      const result = LeaveWorkspaceRequestSchema.safeParse({
+        workspaceSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('LeaveWorkspaceResponseSchema Tests', () => {
+    it('should validate a valid LeaveWorkspaceResponseSchema', () => {
+      const result = LeaveWorkspaceResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid LeaveWorkspaceResponseSchema', () => {
+      const result = LeaveWorkspaceResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('IsMemberRequestSchema Tests', () => {
+    it('should validate a valid IsMemberRequestSchema', () => {
+      const result = IsMemberRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        userEmail: 'user@example.com'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid IsMemberRequestSchema', () => {
+      const result = IsMemberRequestSchema.safeParse({
+        workspaceSlug: 123, // Should be a string
+        userEmail: 'user@example' // Invalid email
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('IsMemberResponseSchema Tests', () => {
+    it('should validate a valid IsMemberResponseSchema', () => {
+      const result = IsMemberResponseSchema.safeParse(true)
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid IsMemberResponseSchema', () => {
+      const result = IsMemberResponseSchema.safeParse('true') // Should be a boolean
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
+  })
+
+  describe('GetMembersRequestSchema Tests', () => {
+    it('should validate a valid GetMembersRequestSchema', () => {
+      const result = GetMembersRequestSchema.safeParse({
+        page: 1,
+        limit: 10,
+        sort: 'name',
+        order: 'asc',
+        search: 'admin',
+        workspaceSlug: 'workspace-slug'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetMembersRequestSchema', () => {
+      const result = GetMembersRequestSchema.safeParse({
+        page: 'one', // Should be a number
+        limit: 10,
+        sort: 'name',
+        order: 'asc',
+        search: 'admin',
+        workspaceSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
+  })
+
+  describe('GetMembersResponseSchema Tests', () => {
+    it('should validate a valid GetMembersResponseSchema', () => {
+      const result = GetMembersResponseSchema.safeParse({
+        items: [
+          {
+            id: 'member123',
+            user: {
+              id: 'user123',
+              email: 'user@example.com',
+              name: 'User Name',
+              profilePictureUrl: 'http://example.com/profile.jpg',
+              isActive: true,
+              isOnboardingFinished: true,
+              isAdmin: false,
+              authProvider: 'google'
+            },
+            roles: [
+              {
+                id: 'role123',
+                role: {
+                  id: 'role123',
+                  name: 'Admin Role',
+                  description: 'Role with admin privileges',
+                  colorCode: '#FF5733',
+                  authorities: ['CREATE_PROJECT'],
+                  projects: [
+                    {
+                      id: 'project123'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should not validate an invalid GetMembersResponseSchema', () => {
+      const result = GetMembersResponseSchema.safeParse({
+        items: 'not-an-array', // Should be an array
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 })

--- a/packages/schema/tests/workspace-role.spec.ts
+++ b/packages/schema/tests/workspace-role.spec.ts
@@ -15,8 +15,7 @@ import {
 } from '@/workspace-role'
 import { authorityEnum } from '@/enums'
 
-describe('Workspace Role Schema Tests', () => {
-  // Tests for WorkspaceRoleSchema
+describe('WorkspaceRoleSchema Tests', () => {
   it('should validate a valid WorkspaceRoleSchema', () => {
     const result = WorkspaceRoleSchema.safeParse({
       id: 'role123',
@@ -93,410 +92,422 @@ describe('Workspace Role Schema Tests', () => {
     expect(result.error?.issues).toHaveLength(3)
   })
 
-  // Tests for CreateWorkspaceRoleRequestSchema
-  it('should validate if proper input is specified for CreateWorkspaceRoleRequestSchema', () => {
-    const result = CreateWorkspaceRoleRequestSchema.safeParse({
-      workspaceSlug: 'workspace-1',
-      name: 'Admin Role',
-      authorities: [authorityEnum.enum['CREATE_PROJECT']],
-      projectIds: ['project1', 'project2']
+  describe('CreateWorkspaceRoleRequestSchema Tests', () => {
+    it('should validate if proper input is specified for CreateWorkspaceRoleRequestSchema', () => {
+      const result = CreateWorkspaceRoleRequestSchema.safeParse({
+        workspaceSlug: 'workspace-1',
+        name: 'Admin Role',
+        authorities: [authorityEnum.enum['CREATE_PROJECT']],
+        projectIds: ['project1', 'project2']
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should validate if only required fields are specified for CreateWorkspaceRoleRequestSchema', () => {
+      const result = CreateWorkspaceRoleRequestSchema.safeParse({
+        workspaceSlug: 'workspace-1',
+        name: 'Viewer Role'
+      })
 
-  it('should validate if only required fields are specified for CreateWorkspaceRoleRequestSchema', () => {
-    const result = CreateWorkspaceRoleRequestSchema.safeParse({
-      workspaceSlug: 'workspace-1',
-      name: 'Viewer Role'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should validate if optional fields are omitted for CreateWorkspaceRoleRequestSchema', () => {
+      const result = CreateWorkspaceRoleRequestSchema.safeParse({
+        workspaceSlug: 'workspace-1',
+        name: 'Manager Role'
+      })
 
-  it('should validate if optional fields are omitted for CreateWorkspaceRoleRequestSchema', () => {
-    const result = CreateWorkspaceRoleRequestSchema.safeParse({
-      workspaceSlug: 'workspace-1',
-      name: 'Manager Role'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should not validate if required fields are missing for CreateWorkspaceRoleRequestSchema', () => {
+      const result = CreateWorkspaceRoleRequestSchema.safeParse({
+        // Missing workspaceSlug
+        // Missing name
+        authorities: [authorityEnum.enum['READ_USERS']]
+      })
 
-  it('should not validate if required fields are missing for CreateWorkspaceRoleRequestSchema', () => {
-    const result = CreateWorkspaceRoleRequestSchema.safeParse({
-      // Missing workspaceSlug
-      // Missing name
-      authorities: [authorityEnum.enum['READ_USERS']]
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
+    it('should not validate if invalid types are specified for CreateWorkspaceRoleRequestSchema', () => {
+      const result = CreateWorkspaceRoleRequestSchema.safeParse({
+        workspaceSlug: 123,
+        name: 123,
+        authorities: ['invalid_authority']
+      })
 
-  it('should not validate if invalid types are specified for CreateWorkspaceRoleRequestSchema', () => {
-    const result = CreateWorkspaceRoleRequestSchema.safeParse({
-      workspaceSlug: 123,
-      name: 123,
-      authorities: ['invalid_authority']
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
-  })
+    it('should validate if all optional fields are provided for CreateWorkspaceRoleRequestSchema', () => {
+      const result = CreateWorkspaceRoleRequestSchema.safeParse({
+        workspaceSlug: 'workspace-1',
+        name: 'Custom Role',
+        description: 'This is a custom role',
+        colorCode: '#FF5733',
+        authorities: [
+          authorityEnum.enum['CREATE_PROJECT'],
+          authorityEnum.enum['READ_USERS']
+        ],
+        projectIds: ['project1', 'project2']
+      })
 
-  it('should validate if all optional fields are provided for CreateWorkspaceRoleRequestSchema', () => {
-    const result = CreateWorkspaceRoleRequestSchema.safeParse({
-      workspaceSlug: 'workspace-1',
-      name: 'Custom Role',
-      description: 'This is a custom role',
-      colorCode: '#FF5733',
-      authorities: [
-        authorityEnum.enum['CREATE_PROJECT'],
-        authorityEnum.enum['READ_USERS']
-      ],
-      projectIds: ['project1', 'project2']
+      expect(result.success).toBe(true)
     })
-
-    expect(result.success).toBe(true)
   })
 
-  // Tests for CreateWorkspaceRoleResponseSchema
-  it('should validate a valid CreateWorkspaceRoleResponseSchema', () => {
-    const result = CreateWorkspaceRoleResponseSchema.safeParse({
-      id: 'role123',
-      name: 'Admin Role',
-      slug: 'admin-role',
-      description: 'Role with admin privileges',
-      colorCode: '#FF5733',
-      hasAdminAuthority: true,
-      createdAt: '2024-11-29T10:00:00Z',
-      updatedAt: '2024-11-29T10:00:00Z',
-      authorities: [authorityEnum.enum['CREATE_PROJECT']],
-      workspaceId: 'workspace123',
-      projects: [
-        {
-          project: {
-            id: 'project123',
-            name: 'Project Name',
-            slug: 'project-slug'
+  describe('CreateWorkspaceRoleResponseSchema Tests', () => {
+    it('should validate a valid CreateWorkspaceRoleResponseSchema', () => {
+      const result = CreateWorkspaceRoleResponseSchema.safeParse({
+        id: 'role123',
+        name: 'Admin Role',
+        slug: 'admin-role',
+        description: 'Role with admin privileges',
+        colorCode: '#FF5733',
+        hasAdminAuthority: true,
+        createdAt: '2024-11-29T10:00:00Z',
+        updatedAt: '2024-11-29T10:00:00Z',
+        authorities: [authorityEnum.enum['CREATE_PROJECT']],
+        workspaceId: 'workspace123',
+        projects: [
+          {
+            project: {
+              id: 'project123',
+              name: 'Project Name',
+              slug: 'project-slug'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid CreateWorkspaceRoleResponseSchema', () => {
-    const result = CreateWorkspaceRoleResponseSchema.safeParse({
-      id: 'role123',
-      name: 'Admin Role',
-      slug: 'admin-role',
-      description: 'Role with admin privileges',
-      colorCode: '#FF5733',
-      hasAdminAuthority: true,
-      createdAt: 'invalid-date', // Should be a valid date string
-      updatedAt: '2024-11-29T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'], // Invalid authority
-      workspaceId: 'workspace123',
-      projects: [
-        {
-          project: {
-            id: 'project123',
-            name: 'Project Name',
-            slug: 'project-slug'
+    it('should not validate an invalid CreateWorkspaceRoleResponseSchema', () => {
+      const result = CreateWorkspaceRoleResponseSchema.safeParse({
+        id: 'role123',
+        name: 'Admin Role',
+        slug: 'admin-role',
+        description: 'Role with admin privileges',
+        colorCode: '#FF5733',
+        hasAdminAuthority: true,
+        createdAt: 'invalid-date', // Should be a valid date string
+        updatedAt: '2024-11-29T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'], // Invalid authority
+        workspaceId: 'workspace123',
+        projects: [
+          {
+            project: {
+              id: 'project123',
+              name: 'Project Name',
+              slug: 'project-slug'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
   })
 
-  // Tests for UpdateWorkspaceRoleRequestSchema
-  it('should validate a valid UpdateWorkspaceRoleRequestSchema', () => {
-    const result = UpdateWorkspaceRoleRequestSchema.safeParse({
-      workspaceRoleSlug: 'admin-role',
-      name: 'Updated Admin Role',
-      description: 'Updated role with admin privileges',
-      colorCode: '#FF5733'
+  describe('UpdateWorkspaceRoleRequestSchema Tests', () => {
+    it('should validate a valid UpdateWorkspaceRoleRequestSchema', () => {
+      const result = UpdateWorkspaceRoleRequestSchema.safeParse({
+        workspaceRoleSlug: 'admin-role',
+        name: 'Updated Admin Role',
+        description: 'Updated role with admin privileges',
+        colorCode: '#FF5733'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid UpdateWorkspaceRoleRequestSchema', () => {
+      const result = UpdateWorkspaceRoleRequestSchema.safeParse({
+        workspaceRoleSlug: 123, // Should be a string
+        name: 'Updated Admin Role',
+        description: 'Updated role with admin privileges',
+        colorCode: '#FF5733',
+        authorities: ['INVALID_AUTHORITY'], // Invalid authority
+        projectSlugs: ['project-slug']
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate an invalid UpdateWorkspaceRoleRequestSchema', () => {
-    const result = UpdateWorkspaceRoleRequestSchema.safeParse({
-      workspaceRoleSlug: 123, // Should be a string
-      name: 'Updated Admin Role',
-      description: 'Updated role with admin privileges',
-      colorCode: '#FF5733',
-      authorities: ['INVALID_AUTHORITY'], // Invalid authority
-      projectSlugs: ['project-slug']
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for UpdateWorkspaceRoleResponseSchema
-  it('should validate a valid UpdateWorkspaceRoleResponseSchema', () => {
-    const result = UpdateWorkspaceRoleResponseSchema.safeParse({
-      id: 'role123',
-      name: 'Admin Role',
-      slug: 'admin-role',
-      description: 'Role with admin privileges',
-      colorCode: '#FF5733',
-      hasAdminAuthority: true,
-      createdAt: '2024-11-29T10:00:00Z',
-      updatedAt: '2024-11-29T10:00:00Z',
-      authorities: [authorityEnum.enum['CREATE_PROJECT']],
-      workspaceId: 'workspace123',
-      projects: [
-        {
-          project: {
-            id: 'project123',
-            name: 'Project Name',
-            slug: 'project-slug'
+  describe('UpdateWorkspaceRoleResponseSchema Tests', () => {
+    it('should validate a valid UpdateWorkspaceRoleResponseSchema', () => {
+      const result = UpdateWorkspaceRoleResponseSchema.safeParse({
+        id: 'role123',
+        name: 'Admin Role',
+        slug: 'admin-role',
+        description: 'Role with admin privileges',
+        colorCode: '#FF5733',
+        hasAdminAuthority: true,
+        createdAt: '2024-11-29T10:00:00Z',
+        updatedAt: '2024-11-29T10:00:00Z',
+        authorities: [authorityEnum.enum['CREATE_PROJECT']],
+        workspaceId: 'workspace123',
+        projects: [
+          {
+            project: {
+              id: 'project123',
+              name: 'Project Name',
+              slug: 'project-slug'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid UpdateWorkspaceRoleResponseSchema', () => {
-    const result = UpdateWorkspaceRoleResponseSchema.safeParse({
-      id: 'role123',
-      name: 'Admin Role',
-      slug: 'admin-role',
-      description: 'Role with admin privileges',
-      colorCode: '#FF5733',
-      hasAdminAuthority: true,
-      createdAt: 'invalid-date', // Should be a valid date string
-      updatedAt: '2024-11-29T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'], // Invalid authority
-      workspaceId: 'workspace123',
-      projects: [
-        {
-          project: {
-            id: 'project123',
-            name: 'Project Name',
-            slug: 'project-slug'
+    it('should not validate an invalid UpdateWorkspaceRoleResponseSchema', () => {
+      const result = UpdateWorkspaceRoleResponseSchema.safeParse({
+        id: 'role123',
+        name: 'Admin Role',
+        slug: 'admin-role',
+        description: 'Role with admin privileges',
+        colorCode: '#FF5733',
+        hasAdminAuthority: true,
+        createdAt: 'invalid-date', // Should be a valid date string
+        updatedAt: '2024-11-29T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'], // Invalid authority
+        workspaceId: 'workspace123',
+        projects: [
+          {
+            project: {
+              id: 'project123',
+              name: 'Project Name',
+              slug: 'project-slug'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
   })
 
-  // Tests for DeleteWorkspaceRoleRequestSchema
-  it('should validate a valid DeleteWorkspaceRoleRequestSchema', () => {
-    const result = DeleteWorkspaceRoleRequestSchema.safeParse({
-      workspaceRoleSlug: 'admin-role'
+  describe('DeleteWorkspaceRoleRequestSchema Tests', () => {
+    it('should validate a valid DeleteWorkspaceRoleRequestSchema', () => {
+      const result = DeleteWorkspaceRoleRequestSchema.safeParse({
+        workspaceRoleSlug: 'admin-role'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid DeleteWorkspaceRoleRequestSchema', () => {
-    const result = DeleteWorkspaceRoleRequestSchema.safeParse({
-      workspaceRoleSlug: 123 // Should be a string
+    it('should not validate an invalid DeleteWorkspaceRoleRequestSchema', () => {
+      const result = DeleteWorkspaceRoleRequestSchema.safeParse({
+        workspaceRoleSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
   })
 
-  // Tests for DeleteWorkspaceRoleResponseSchema
-  it('should validate a valid DeleteWorkspaceRoleResponseSchema', () => {
-    const result = DeleteWorkspaceRoleResponseSchema.safeParse(undefined)
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid DeleteWorkspaceRoleResponseSchema', () => {
-    const result = DeleteWorkspaceRoleResponseSchema.safeParse({
-      unexpectedField: 'value'
+  describe('DeleteWorkspaceRoleResponseSchema Tests', () => {
+    it('should validate a valid DeleteWorkspaceRoleResponseSchema', () => {
+      const result = DeleteWorkspaceRoleResponseSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-  })
 
-  // Tests for CheckWorkspaceRoleExistsRequestSchema
-  it('should validate a valid CheckWorkspaceRoleExistsRequestSchema', () => {
-    const result = CheckWorkspaceRoleExistsRequestSchema.safeParse({
-      workspaceSlug: 'my-workpace-0',
-      workspaceRoleName: 'admin-role123'
+    it('should not validate an invalid DeleteWorkspaceRoleResponseSchema', () => {
+      const result = DeleteWorkspaceRoleResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+      expect(result.success).toBe(false)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid CheckWorkspaceRoleExistsRequestSchema', () => {
-    const result = CheckWorkspaceRoleExistsRequestSchema.safeParse({
-      // Missing workspaceSlug
-      workspaceRoleName: 'role-123'
+  describe('CheckWorkspaceRoleExistsRequestSchema Tests', () => {
+    it('should validate a valid CheckWorkspaceRoleExistsRequestSchema', () => {
+      const result = CheckWorkspaceRoleExistsRequestSchema.safeParse({
+        workspaceSlug: 'my-workpace-0',
+        workspaceRoleName: 'admin-role123'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for CheckWorkspaceRoleExistsResponseSchema
-  it('should validate a valid CheckWorkspaceRoleExistsResponseSchema', () => {
-    const result = CheckWorkspaceRoleExistsResponseSchema.safeParse({
-      exists: true
+    it('should not validate an invalid CheckWorkspaceRoleExistsRequestSchema', () => {
+      const result = CheckWorkspaceRoleExistsRequestSchema.safeParse({
+        // Missing workspaceSlug
+        workspaceRoleName: 'role-123'
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid CheckWorkspaceRoleExistsResponseSchema', () => {
-    const result = CheckWorkspaceRoleExistsResponseSchema.safeParse({
-      exists: 'true' // Should be a boolean
+  describe('CheckWorkspaceRoleExistsResponseSchema Tests', () => {
+    it('should validate a valid CheckWorkspaceRoleExistsResponseSchema', () => {
+      const result = CheckWorkspaceRoleExistsResponseSchema.safeParse({
+        exists: true
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
 
-  // Tests for GetWorkspaceRoleRequestSchema
-  it('should validate a valid GetWorkspaceRoleRequestSchema', () => {
-    const result = GetWorkspaceRoleRequestSchema.safeParse({
-      workspaceRoleSlug: 'admin-role'
+    it('should not validate an invalid CheckWorkspaceRoleExistsResponseSchema', () => {
+      const result = CheckWorkspaceRoleExistsResponseSchema.safeParse({
+        exists: 'true' // Should be a boolean
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate an invalid GetWorkspaceRoleRequestSchema', () => {
-    const result = GetWorkspaceRoleRequestSchema.safeParse({
-      workspaceRoleSlug: 123 // Should be a string
+  describe('GetWorkspaceRoleRequestSchema Tests', () => {
+    it('should validate a valid GetWorkspaceRoleRequestSchema', () => {
+      const result = GetWorkspaceRoleRequestSchema.safeParse({
+        workspaceRoleSlug: 'admin-role'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+
+    it('should not validate an invalid GetWorkspaceRoleRequestSchema', () => {
+      const result = GetWorkspaceRoleRequestSchema.safeParse({
+        workspaceRoleSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  // Tests for GetWorkspaceRoleResponseSchema
-  it('should validate a valid GetWorkspaceRoleResponseSchema', () => {
-    const result = GetWorkspaceRoleResponseSchema.safeParse({
-      id: 'role123',
-      name: 'Admin Role',
-      slug: 'admin-role',
-      description: 'Role with admin privileges',
-      colorCode: '#FF5733',
-      hasAdminAuthority: true,
-      createdAt: '2024-11-29T10:00:00Z',
-      updatedAt: '2024-11-29T10:00:00Z',
-      authorities: [authorityEnum.enum['CREATE_PROJECT']],
-      workspaceId: 'workspace123',
-      projects: [
-        {
-          project: {
-            id: 'project123',
-            name: 'Project Name',
-            slug: 'project-slug'
+  describe('GetWorkspaceRoleResponseSchema Tests', () => {
+    it('should validate a valid GetWorkspaceRoleResponseSchema', () => {
+      const result = GetWorkspaceRoleResponseSchema.safeParse({
+        id: 'role123',
+        name: 'Admin Role',
+        slug: 'admin-role',
+        description: 'Role with admin privileges',
+        colorCode: '#FF5733',
+        hasAdminAuthority: true,
+        createdAt: '2024-11-29T10:00:00Z',
+        updatedAt: '2024-11-29T10:00:00Z',
+        authorities: [authorityEnum.enum['CREATE_PROJECT']],
+        workspaceId: 'workspace123',
+        projects: [
+          {
+            project: {
+              id: 'project123',
+              name: 'Project Name',
+              slug: 'project-slug'
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
-  })
 
-  it('should not validate an invalid GetWorkspaceRoleResponseSchema', () => {
-    const result = GetWorkspaceRoleResponseSchema.safeParse({
-      id: 'role123',
-      name: 'Admin Role',
-      slug: 'admin-role',
-      description: 'Role with admin privileges',
-      colorCode: '#FF5733',
-      hasAdminAuthority: true,
-      createdAt: 'invalid-date', // Should be a valid date string
-      updatedAt: '2024-11-29T10:00:00Z',
-      authorities: ['INVALID_AUTHORITY'], // Invalid authority
-      workspaceId: 'workspace123',
-      projects: [
-        {
-          project: {
-            id: 'project123',
-            name: 'Project Name'
-            // Missing slug
+    it('should not validate an invalid GetWorkspaceRoleResponseSchema', () => {
+      const result = GetWorkspaceRoleResponseSchema.safeParse({
+        id: 'role123',
+        name: 'Admin Role',
+        slug: 'admin-role',
+        description: 'Role with admin privileges',
+        colorCode: '#FF5733',
+        hasAdminAuthority: true,
+        createdAt: 'invalid-date', // Should be a valid date string
+        updatedAt: '2024-11-29T10:00:00Z',
+        authorities: ['INVALID_AUTHORITY'], // Invalid authority
+        workspaceId: 'workspace123',
+        projects: [
+          {
+            project: {
+              id: 'project123',
+              name: 'Project Name'
+              // Missing slug
+            }
           }
-        }
-      ]
+        ]
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(3)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(3)
   })
 
-  // Tests for GetWorkspaceRolesOfWorkspaceRequestSchema
-  it('should validate a valid GetWorkspaceRolesOfWorkspaceRequestSchema', () => {
-    const result = GetWorkspaceRolesOfWorkspaceRequestSchema.safeParse({
-      page: 1,
-      limit: 10,
-      sortBy: 'name',
-      order: 'asc',
-      search: 'admin',
-      workspaceSlug: 'workspace-slug'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate an invalid GetWorkspaceRolesOfWorkspaceRequestSchema', () => {
-    const result = GetWorkspaceRolesOfWorkspaceRequestSchema.safeParse({
-      page: 'one', // Should be a number
-      limit: 10,
-      sortBy: 'name',
-      search: 'admin',
-      workspaceSlug: 123 // Should be a string
-    })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
-
-  // Tests for GetWorkspaceRolesOfWorkspaceResponseSchema
-  it('should validate a valid GetWorkspaceRolesOfWorkspaceResponseSchema', () => {
-    const result = GetWorkspaceRolesOfWorkspaceResponseSchema.safeParse({
-      items: [
-        {
-          id: 'role123',
-          name: 'Admin Role',
-          slug: 'admin-role',
-          description: 'Role with admin privileges',
-          colorCode: '#FF5733',
-          hasAdminAuthority: true,
-          createdAt: '2024-11-29T10:00:00Z',
-          updatedAt: '2024-11-29T10:00:00Z',
-          authorities: [authorityEnum.enum['CREATE_PROJECT']],
-          workspaceId: 'workspace123'
-        }
-      ],
-      metadata: {
+  describe('GetWorkspaceRolesOfWorkspaceRequestSchema Tests', () => {
+    it('should validate a valid GetWorkspaceRolesOfWorkspaceRequestSchema', () => {
+      const result = GetWorkspaceRolesOfWorkspaceRequestSchema.safeParse({
         page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
+        limit: 10,
+        sortBy: 'name',
+        order: 'asc',
+        search: 'admin',
+        workspaceSlug: 'workspace-slug'
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(true)
+
+    it('should not validate an invalid GetWorkspaceRolesOfWorkspaceRequestSchema', () => {
+      const result = GetWorkspaceRolesOfWorkspaceRequestSchema.safeParse({
+        page: 'one', // Should be a number
+        limit: 10,
+        sortBy: 'name',
+        search: 'admin',
+        workspaceSlug: 123 // Should be a string
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate an invalid GetWorkspaceRolesOfWorkspaceResponseSchema', () => {
-    const result = GetWorkspaceRolesOfWorkspaceResponseSchema.safeParse({
-      items: 'not-an-array', // Should be an array
-      metadata: {
-        page: 1,
-        perPage: 10,
-        pageCount: 1,
-        // Missing totalCount
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
+  describe('GetWorkspaceRolesOfWorkspaceResponseSchema Tests', () => {
+    it('should validate a valid GetWorkspaceRolesOfWorkspaceResponseSchema', () => {
+      const result = GetWorkspaceRolesOfWorkspaceResponseSchema.safeParse({
+        items: [
+          {
+            id: 'role123',
+            name: 'Admin Role',
+            slug: 'admin-role',
+            description: 'Role with admin privileges',
+            colorCode: '#FF5733',
+            hasAdminAuthority: true,
+            createdAt: '2024-11-29T10:00:00Z',
+            updatedAt: '2024-11-29T10:00:00Z',
+            authorities: [authorityEnum.enum['CREATE_PROJECT']],
+            workspaceId: 'workspace123'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
         }
-      }
+      })
+      expect(result.success).toBe(true)
     })
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
+
+    it('should not validate an invalid GetWorkspaceRolesOfWorkspaceResponseSchema', () => {
+      const result = GetWorkspaceRolesOfWorkspaceResponseSchema.safeParse({
+        items: 'not-an-array', // Should be an array
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          // Missing totalCount
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 })

--- a/packages/schema/tests/workspace.spec.ts
+++ b/packages/schema/tests/workspace.spec.ts
@@ -18,465 +18,497 @@ import {
 } from '@/workspace'
 
 describe('Workspace Schema Tests', () => {
-  it('should validate if proper input is specified for InviteMemberRequestSchema', () => {
-    const result = InviteMemberRequestSchema.safeParse({
-      email: 'test@example.com',
-      roleSlugs: ['role1', 'role2']
+  describe('InviteMemberRequestSchema Tests', () => {
+    it('should validate if proper input is specified for InviteMemberRequestSchema', () => {
+      const result = InviteMemberRequestSchema.safeParse({
+        email: 'test@example.com',
+        roleSlugs: ['role1', 'role2']
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should validate if only required fields are specified for InviteMemberRequestSchema', () => {
+      const result = InviteMemberRequestSchema.safeParse({
+        email: 'test@example.com'
+      })
 
-  it('should validate if only required fields are specified for InviteMemberRequestSchema', () => {
-    const result = InviteMemberRequestSchema.safeParse({
-      email: 'test@example.com'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should not validate if required fields are missing for InviteMemberRequestSchema', () => {
+      const result = InviteMemberRequestSchema.safeParse({
+        roleSlugs: ['role1']
+      })
 
-  it('should not validate if required fields are missing for InviteMemberRequestSchema', () => {
-    const result = InviteMemberRequestSchema.safeParse({
-      roleSlugs: ['role1']
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
+    it('should not validate if invalid email string is specified for InviteMemberRequestSchema', () => {
+      const result = InviteMemberRequestSchema.safeParse({
+        email: 'invalid-email'
+      })
 
-  it('should not validate if invalid email string is specified for InviteMemberRequestSchema', () => {
-    const result = InviteMemberRequestSchema.safeParse({
-      email: 'invalid-email'
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
+    it('should not validate if invalid types are specified for InviteMemberRequestSchema', () => {
+      const result = InviteMemberRequestSchema.safeParse({
+        email: 123,
+        roleSlugs: 'invalid_role'
+      })
 
-  it('should not validate if invalid types are specified for InviteMemberRequestSchema', () => {
-    const result = InviteMemberRequestSchema.safeParse({
-      email: 123,
-      roleSlugs: 'invalid_role'
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
+    it('should not validate if roleIds are specified instead of roleSlugs for InviteMemberRequestSchema', () => {
+      const result = InviteMemberRequestSchema.safeParse({
+        roleIds: ['role1', 'role2'] //should be roleSlugs
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should not validate if roleIds are specified instead of roleSlugs for InviteMemberRequestSchema', () => {
-    const result = InviteMemberRequestSchema.safeParse({
-      roleIds: ['role1', 'role2'] //should be roleSlugs
+  describe('InviteMemberResponseSchema Tests', () => {
+    it('should validate an empty response for InviteMemberResponseSchema', () => {
+      const result = InviteMemberResponseSchema.safeParse(undefined)
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+    it('should not validate if unexpected fields are provided for InviteMemberResponseSchema', () => {
+      const result = InviteMemberResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+    })
   })
 
-  it('should validate an empty response for InviteMemberResponseSchema', () => {
-    const result = InviteMemberResponseSchema.safeParse(undefined)
+  describe('CreateWorkspaceRequestSchema Tests', () => {
+    it('should validate if proper input is specified for CreateWorkspaceRequestSchema', () => {
+      const result = CreateWorkspaceRequestSchema.safeParse({
+        name: 'Workspace Test',
+        icon: 'icon.png'
+      })
 
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if unexpected fields are provided for InviteMemberResponseSchema', () => {
-    const result = InviteMemberResponseSchema.safeParse({
-      unexpectedField: 'value'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
+    it('should validate if only required fields are specified for CreateWorkspaceRequestSchema', () => {
+      const result = CreateWorkspaceRequestSchema.safeParse({
+        name: 'Workspace Test'
+      })
 
-  it('should validate if proper input is specified for CreateWorkspaceRequestSchema', () => {
-    const result = CreateWorkspaceRequestSchema.safeParse({
-      name: 'Workspace Test',
-      icon: 'icon.png'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should validate if optional fields are omitted for CreateWorkspaceRequestSchema', () => {
+      const result = CreateWorkspaceRequestSchema.safeParse({
+        name: 'Workspace Test'
+      })
 
-  it('should validate if only required fields are specified for CreateWorkspaceRequestSchema', () => {
-    const result = CreateWorkspaceRequestSchema.safeParse({
-      name: 'Workspace Test'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should not validate if required fields are missing for CreateWorkspaceRequestSchema', () => {
+      const result = CreateWorkspaceRequestSchema.safeParse({
+        isDefault: true
+      })
 
-  it('should validate if optional fields are omitted for CreateWorkspaceRequestSchema', () => {
-    const result = CreateWorkspaceRequestSchema.safeParse({
-      name: 'Workspace Test'
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
 
-    expect(result.success).toBe(true)
+    it('should not validate if invalid types are specified for CreateWorkspaceRequestSchema', () => {
+      const result = CreateWorkspaceRequestSchema.safeParse({
+        name: 123,
+        isDefault: 'true'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+    })
   })
 
-  it('should not validate if required fields are missing for CreateWorkspaceRequestSchema', () => {
-    const result = CreateWorkspaceRequestSchema.safeParse({
-      isDefault: true
+  describe('CreateWorkspaceResponseSchema Tests', () => {
+    it('should validate with proper input for CreateWorkspaceResponseSchema', () => {
+      const result = CreateWorkspaceResponseSchema.safeParse({
+        id: 'workspace-id',
+        name: 'Workspace Test',
+        slug: 'workspace-slug',
+        icon: 'icon.png',
+        isFreeTier: true,
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        ownerId: 'owner-id',
+        isDefault: false,
+        lastUpdatedById: 'user-id'
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
+    it('should not validate if required fields are missing for CreateWorkspaceResponseSchema', () => {
+      const result = CreateWorkspaceResponseSchema.safeParse({
+        id: 'workspace-id',
+        name: 'Workspace Test',
+        // slug is missing
+        icon: 'icon.png',
+        isFreeTier: true,
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        ownerId: 'owner-id',
+        isDefault: false,
+        lastUpdatedById: 'user-id'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+      expect(result.error?.issues[0].path).toEqual(['slug'])
+    })
   })
 
-  it('should not validate if invalid types are specified for CreateWorkspaceRequestSchema', () => {
-    const result = CreateWorkspaceRequestSchema.safeParse({
-      name: 123,
-      isDefault: 'true'
+  describe('UpdateWorkspaceRequestSchema Tests', () => {
+    it('should validate if proper input is specified for UpdateWorkspaceRequestSchema', () => {
+      const result = UpdateWorkspaceRequestSchema.safeParse({
+        name: 'Updated Workspace Test',
+        icon: 'new-icon.png',
+        workspaceSlug: 'workspace-slug'
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-  })
+    it('should validate if only required fields are specified for UpdateWorkspaceRequestSchema', () => {
+      const result = UpdateWorkspaceRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
 
-  it('should validate with proper input for CreateWorkspaceResponseSchema', () => {
-    const result = CreateWorkspaceResponseSchema.safeParse({
-      id: 'workspace-id',
-      name: 'Workspace Test',
-      slug: 'workspace-slug',
-      icon: 'icon.png',
-      isFreeTier: true,
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      ownerId: 'owner-id',
-      isDefault: false,
-      lastUpdatedById: 'user-id'
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
+    it('should not validate if invalid types are provided for UpdateWorkspaceRequestSchema', () => {
+      const result = UpdateWorkspaceRequestSchema.safeParse({
+        name: 123 // should be a string
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(2)
+      expect(result.error?.issues[0].path).toEqual(['name'])
+      expect(result.error?.issues[1].path).toEqual(['workspaceSlug'])
+    })
   })
 
-  it('should not validate if required fields are missing for CreateWorkspaceResponseSchema', () => {
-    const result = CreateWorkspaceResponseSchema.safeParse({
-      id: 'workspace-id',
-      name: 'Workspace Test',
-      // slug is missing
-      icon: 'icon.png',
-      isFreeTier: true,
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      ownerId: 'owner-id',
-      isDefault: false,
-      lastUpdatedById: 'user-id'
+  describe('UpdateWorkspaceResponseSchema Tests', () => {
+    it('should validate with proper input for UpdateWorkspaceResponseSchema', () => {
+      const result = UpdateWorkspaceResponseSchema.safeParse({
+        id: 'workspace-id',
+        name: 'Updated Workspace',
+        slug: 'workspace-slug',
+        icon: 'new-icon.png',
+        isFreeTier: true,
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-02T00:00:00Z',
+        ownerId: 'owner-id',
+        isDefault: false,
+        lastUpdatedById: 'user-id'
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-    expect(result.error?.issues[0].path).toEqual(['slug'])
+    it('should not validate if required fields are missing for UpdateWorkspaceResponseSchema', () => {
+      const result = UpdateWorkspaceResponseSchema.safeParse({
+        id: 'workspace-id',
+        name: 'Updated Workspace',
+        // slug is missing
+        icon: 'new-icon.png',
+        isFreeTier: true,
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-02T00:00:00Z',
+        ownerId: 'owner-id',
+        isDefault: false,
+        lastUpdatedById: 'user-id'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
+      expect(result.error?.issues[0].path).toEqual(['slug'])
+    })
   })
 
-  it('should validate if proper input is specified for UpdateWorkspaceRequestSchema', () => {
-    const result = UpdateWorkspaceRequestSchema.safeParse({
-      name: 'Updated Workspace Test',
-      icon: 'new-icon.png',
-      workspaceSlug: 'workspace-slug'
+  describe('DeleteWorkspaceRequestSchema Tests', () => {
+    it('should validate if proper input is specified for DeleteWorkspaceRequestSchema', () => {
+      const result = DeleteWorkspaceRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('DeleteWorkspaceResponseSchema Tests', () => {
+    it('should validate an empty response for DeleteWorkspaceResponseSchema', () => {
+      const result = DeleteWorkspaceResponseSchema.safeParse(undefined)
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should not validate if unexpected fields are provided for DeleteWorkspaceResponseSchema', () => {
+      const result = DeleteWorkspaceResponseSchema.safeParse({
+        unexpectedField: 'value'
+      })
 
-  it('should validate if only required fields are specified for UpdateWorkspaceRequestSchema', () => {
-    const result = UpdateWorkspaceRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toHaveLength(1)
     })
-
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate if invalid types are provided for UpdateWorkspaceRequestSchema', () => {
-    const result = UpdateWorkspaceRequestSchema.safeParse({
-      name: 123 // should be a string
+  describe('GetWorkspaceRequestSchema Tests', () => {
+    it('should validate if proper input is specified for GetWorkspaceRequestSchema', () => {
+      const result = GetWorkspaceRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
+
+      expect(result.success).toBe(true)
     })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(2)
-    expect(result.error?.issues[0].path).toEqual(['name'])
-    expect(result.error?.issues[1].path).toEqual(['workspaceSlug'])
   })
 
-  it('should validate with proper input for UpdateWorkspaceResponseSchema', () => {
-    const result = UpdateWorkspaceResponseSchema.safeParse({
-      id: 'workspace-id',
-      name: 'Updated Workspace',
-      slug: 'workspace-slug',
-      icon: 'new-icon.png',
-      isFreeTier: true,
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-02T00:00:00Z',
-      ownerId: 'owner-id',
-      isDefault: false,
-      lastUpdatedById: 'user-id'
+  describe('GetWorkspaceResponseSchema Tests', () => {
+    it('should validate with proper input for GetWorkspaceResponseSchema', () => {
+      const result = GetWorkspaceResponseSchema.safeParse({
+        id: 'workspace-id',
+        name: 'Workspace Test',
+        slug: 'workspace-slug',
+        icon: 'icon.png',
+        isFreeTier: true,
+        createdAt: '2024-10-01T00:00:00Z',
+        updatedAt: '2024-10-01T00:00:00Z',
+        ownerId: 'owner-id',
+        isDefault: false,
+        lastUpdatedById: 'user-id'
+      })
+
+      expect(result.success).toBe(true)
     })
-
-    expect(result.success).toBe(true)
   })
 
-  it('should not validate if required fields are missing for UpdateWorkspaceResponseSchema', () => {
-    const result = UpdateWorkspaceResponseSchema.safeParse({
-      id: 'workspace-id',
-      name: 'Updated Workspace',
-      // slug is missing
-      icon: 'new-icon.png',
-      isFreeTier: true,
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-02T00:00:00Z',
-      ownerId: 'owner-id',
-      isDefault: false,
-      lastUpdatedById: 'user-id'
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-    expect(result.error?.issues[0].path).toEqual(['slug'])
-  })
-
-  it('should validate if proper input is specified for DeleteWorkspaceRequestSchema', () => {
-    const result = DeleteWorkspaceRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate an empty response for DeleteWorkspaceResponseSchema', () => {
-    const result = DeleteWorkspaceResponseSchema.safeParse(undefined)
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate if unexpected fields are provided for DeleteWorkspaceResponseSchema', () => {
-    const result = DeleteWorkspaceResponseSchema.safeParse({
-      unexpectedField: 'value'
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues).toHaveLength(1)
-  })
-
-  it('should validate if proper input is specified for GetWorkspaceRequestSchema', () => {
-    const result = GetWorkspaceRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate with proper input for GetWorkspaceResponseSchema', () => {
-    const result = GetWorkspaceResponseSchema.safeParse({
-      id: 'workspace-id',
-      name: 'Workspace Test',
-      slug: 'workspace-slug',
-      icon: 'icon.png',
-      isFreeTier: true,
-      createdAt: '2024-10-01T00:00:00Z',
-      updatedAt: '2024-10-01T00:00:00Z',
-      ownerId: 'owner-id',
-      isDefault: false,
-      lastUpdatedById: 'user-id'
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate when correct page and limit are provided for GetAllWorkspacesOfUserRequestSchema', () => {
-    const result = GetAllWorkspacesOfUserRequestSchema.safeParse({
-      page: 1,
-      limit: 10
-    })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should validate with proper input for GetAllWorkspacesOfUserResponseSchema', () => {
-    const result = GetAllWorkspacesOfUserResponseSchema.safeParse({
-      items: [
-        {
-          id: 'workspace-id',
-          name: 'Workspace Test',
-          slug: 'workspace-slug',
-          icon: 'icon.png',
-          isFreeTier: true,
-          createdAt: '2024-10-01T00:00:00Z',
-          updatedAt: '2024-10-01T00:00:00Z',
-          ownerId: 'owner-id',
-          isDefault: false,
-          lastUpdatedById: 'user-id'
-        }
-      ],
-      metadata: {
+  describe('GetAllWorkspacesOfUserRequestSchema Tests', () => {
+    it('should validate when correct page and limit are provided for GetAllWorkspacesOfUserRequestSchema', () => {
+      const result = GetAllWorkspacesOfUserRequestSchema.safeParse({
         page: 1,
-        perPage: 10,
-        pageCount: 1,
-        totalCount: 1,
-        links: {
-          self: 'http://example.com/page/1',
-          first: 'http://example.com/page/1',
-          previous: null,
-          next: null,
-          last: 'http://example.com/page/1'
-        }
-      }
-    })
+        limit: 10
+      })
 
-    expect(result.success).toBe(true)
+      expect(result.success).toBe(true)
+    })
   })
 
-  it('should not validate if items are not an array in GetAllWorkspacesOfUserResponseSchema', () => {
-    const result = GetAllWorkspacesOfUserResponseSchema.safeParse({
-      items: 'not-an-array',
-      total: 1,
-      page: 1,
-      limit: 10
+  describe('GetAllWorkspacesOfUserResponseSchema Tests', () => {
+    it('should validate with proper input for GetAllWorkspacesOfUserResponseSchema', () => {
+      const result = GetAllWorkspacesOfUserResponseSchema.safeParse({
+        items: [
+          {
+            id: 'workspace-id',
+            name: 'Workspace Test',
+            slug: 'workspace-slug',
+            icon: 'icon.png',
+            isFreeTier: true,
+            createdAt: '2024-10-01T00:00:00Z',
+            updatedAt: '2024-10-01T00:00:00Z',
+            ownerId: 'owner-id',
+            isDefault: false,
+            lastUpdatedById: 'user-id'
+          }
+        ],
+        metadata: {
+          page: 1,
+          perPage: 10,
+          pageCount: 1,
+          totalCount: 1,
+          links: {
+            self: 'http://example.com/page/1',
+            first: 'http://example.com/page/1',
+            previous: null,
+            next: null,
+            last: 'http://example.com/page/1'
+          }
+        }
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0].path).toEqual(['items'])
+    it('should not validate if items are not an array in GetAllWorkspacesOfUserResponseSchema', () => {
+      const result = GetAllWorkspacesOfUserResponseSchema.safeParse({
+        items: 'not-an-array',
+        total: 1,
+        page: 1,
+        limit: 10
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].path).toEqual(['items'])
+    })
   })
 
-  it('should validate if proper input is specified for ExportDataRequestSchema', () => {
-    const result = ExportDataRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug'
-    })
+  describe('ExportDataRequestSchema Tests', () => {
+    it('should validate if proper input is specified for ExportDataRequestSchema', () => {
+      const result = ExportDataRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug'
+      })
 
-    expect(result.success).toBe(true)
+      expect(result.success).toBe(true)
+    })
   })
 
-  it('should validate with proper input for ExportDataResponseSchema', () => {
-    const result = ExportDataResponseSchema.safeParse({
-      name: 'Workspace Test',
-      icon: 'icon.png',
-      workspaceRoles: [
-        {
-          name: 'Admin',
-          description: 'Administrator role',
-          colorCode: '#FF0000',
-          hasAdminAuthority: true,
-          authorities: ['CREATE_PROJECT']
-        }
-      ],
-      projects: [
-        {
-          name: 'Project A',
-          description: 'Description of Project A',
-          publicKey: 'public-key',
-          privateKey: 'private-key',
-          storePrivateKey: true,
-          accessLevel: 'GLOBAL',
-          environments: [
-            {
-              name: 'Development',
-              description: 'Development Environment'
-            }
-          ],
-          secrets: [
-            {
-              name: 'API_KEY',
-              note: 'API Key for external service',
-              rotateAt: '720',
-              versions: [
-                {
-                  value: 'secret-value',
-                  version: 1
-                }
-              ]
-            }
-          ],
-          variables: [
-            {
-              name: 'ENV_VAR',
-              note: 'Environment Variable',
-              versions: [
-                {
-                  value: 'variable-value',
-                  version: 1
-                }
-              ]
-            }
-          ]
-        }
-      ]
+  describe('ExportDataResponseSchema Tests', () => {
+    it('should validate with proper input for ExportDataResponseSchema', () => {
+      const result = ExportDataResponseSchema.safeParse({
+        name: 'Workspace Test',
+        icon: 'icon.png',
+        workspaceRoles: [
+          {
+            name: 'Admin',
+            description: 'Administrator role',
+            colorCode: '#FF0000',
+            hasAdminAuthority: true,
+            authorities: ['CREATE_PROJECT']
+          }
+        ],
+        projects: [
+          {
+            name: 'Project A',
+            description: 'Description of Project A',
+            publicKey: 'public-key',
+            privateKey: 'private-key',
+            storePrivateKey: true,
+            accessLevel: 'GLOBAL',
+            environments: [
+              {
+                name: 'Development',
+                description: 'Development Environment'
+              }
+            ],
+            secrets: [
+              {
+                name: 'API_KEY',
+                note: 'API Key for external service',
+                rotateAt: '720',
+                versions: [
+                  {
+                    value: 'secret-value',
+                    version: 1
+                  }
+                ]
+              }
+            ],
+            variables: [
+              {
+                name: 'ENV_VAR',
+                note: 'Environment Variable',
+                versions: [
+                  {
+                    value: 'variable-value',
+                    version: 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
+    it('should not validate if required fields are missing in ExportDataResponseSchema', () => {
+      const result = ExportDataResponseSchema.safeParse({
+        // name is missing
+        icon: 'icon.png',
+        workspaceRoles: [],
+        projects: []
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].path).toEqual(['name'])
+    })
   })
 
-  it('should not validate if required fields are missing in ExportDataResponseSchema', () => {
-    const result = ExportDataResponseSchema.safeParse({
-      // name is missing
-      icon: 'icon.png',
-      workspaceRoles: [],
-      projects: []
-    })
+  describe('GlobalSearchRequestSchema Tests', () => {
+    it('should validate if proper input is specified for GlobalSearchRequestSchema', () => {
+      const result = GlobalSearchRequestSchema.safeParse({
+        workspaceSlug: 'workspace-slug',
+        search: 'search-term'
+      })
 
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0].path).toEqual(['name'])
+      expect(result.success).toBe(true)
+    })
   })
 
-  it('should validate if proper input is specified for GlobalSearchRequestSchema', () => {
-    const result = GlobalSearchRequestSchema.safeParse({
-      workspaceSlug: 'workspace-slug',
-      search: 'search-term'
+  describe('GlobalSearchResponseSchema Tests', () => {
+    it('should validate with proper input for GlobalSearchResponseSchema', () => {
+      const result = GlobalSearchResponseSchema.safeParse({
+        projects: [
+          {
+            slug: 'project-slug',
+            name: 'Project Name',
+            description: 'Project Description'
+          }
+        ],
+        environments: [
+          {
+            slug: 'environment-slug',
+            name: 'Environment Name',
+            description: 'Environment Description'
+          }
+        ],
+        secrets: [
+          {
+            slug: 'secret-slug',
+            name: 'Secret Name',
+            note: 'Secret Note'
+          }
+        ],
+        variables: [
+          {
+            slug: 'variable-slug',
+            name: 'Variable Name',
+            note: 'Variable Note'
+          }
+        ]
+      })
+
+      expect(result.success).toBe(true)
     })
 
-    expect(result.success).toBe(true)
-  })
+    it('should not validate when required fields are missing for GlobalSearchResponseSchema', () => {
+      const result = GlobalSearchResponseSchema.safeParse({
+        projects: [
+          {
+            slug: 'project-slug',
+            name: 'Project Name'
+            // description is missing
+          }
+        ],
+        environments: [],
+        secrets: [],
+        variables: []
+      })
 
-  it('should validate with proper input for GlobalSearchResponseSchema', () => {
-    const result = GlobalSearchResponseSchema.safeParse({
-      projects: [
-        {
-          slug: 'project-slug',
-          name: 'Project Name',
-          description: 'Project Description'
-        }
-      ],
-      environments: [
-        {
-          slug: 'environment-slug',
-          name: 'Environment Name',
-          description: 'Environment Description'
-        }
-      ],
-      secrets: [
-        {
-          slug: 'secret-slug',
-          name: 'Secret Name',
-          note: 'Secret Note'
-        }
-      ],
-      variables: [
-        {
-          slug: 'variable-slug',
-          name: 'Variable Name',
-          note: 'Variable Note'
-        }
-      ]
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0]?.path).toEqual([
+        'projects',
+        0,
+        'description'
+      ])
     })
-
-    expect(result.success).toBe(true)
-  })
-
-  it('should not validate when required fields are missing for GlobalSearchResponseSchema', () => {
-    const result = GlobalSearchResponseSchema.safeParse({
-      projects: [
-        {
-          slug: 'project-slug',
-          name: 'Project Name'
-          // description is missing
-        }
-      ],
-      environments: [],
-      secrets: [],
-      variables: []
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.error?.issues[0]?.path).toEqual([
-      'projects',
-      0,
-      'description'
-    ])
   })
 })


### PR DESCRIPTION
### **User description**
## Description
@keyshade/schema:
- Create describe blocks to contain tests for each kind of schema. Removed old test comments.
- Change count type from string to number in secret and variable RollbackResponses.
<br />

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Tests


___

### **Description**
- Refactored all schema tests by introducing `describe` blocks for better organization and readability.
- Grouped existing test cases under appropriate `describe` blocks to enhance test structure.
- Added missing assertions and validation checks in some test files.
- Removed old test comments to clean up the test files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.spec.ts</strong><dd><code>Refactor tests with `describe` blocks for schema organization.</code></dd></summary>
<hr>

packages/schema/tests/secret.spec.ts

<li>Added <code>describe</code> blocks to organize tests by schema type.<br> <li> Grouped existing tests under new <code>describe</code> blocks for better structure.<br> <li> Ensured all test cases are wrapped within appropriate <code>describe</code> blocks.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-7a93602dd4b5ea05ac408d21cadfb97dce9a7e5134273631dcf57d9fe176cf9e">+428/-413</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace.spec.ts</strong><dd><code>Organize workspace tests using `describe` blocks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/workspace.spec.ts

<li>Introduced <code>describe</code> blocks for each schema test group.<br> <li> Organized tests into logical sections using <code>describe</code>.<br> <li> Enhanced test readability and structure with <code>describe</code> blocks.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-cc5087f98800be588f42b5237f6e2c07fed0f17e812415ddc8bda7385ca235da">+410/-378</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace-role.spec.ts</strong><dd><code>Categorize workspace role tests with `describe` blocks.</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/workspace-role.spec.ts

<li>Added <code>describe</code> blocks to categorize tests by schema.<br> <li> Improved test organization with <code>describe</code> blocks.<br> <li> Structured tests for better clarity and maintenance.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-140b020306a3daab4011fe546684503298b72e981c6c47b47a0a62eb272b49a5">+341/-330</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>integration.spec.ts</strong><dd><code>Structure integration tests using `describe` blocks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/integration.spec.ts

<li>Implemented <code>describe</code> blocks for integration schema tests.<br> <li> Structured tests into sections using <code>describe</code>.<br> <li> Enhanced test clarity and organization with <code>describe</code> blocks.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-b62f0ad4db05234295539a2adcd2d8a423e95ab55cbd93891265dca3994c18d1">+326/-315</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth.spec.ts</strong><dd><code>Organize auth tests with `describe` blocks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/auth.spec.ts

<li>Introduced <code>describe</code> blocks for auth schema tests.<br> <li> Organized tests into sections using <code>describe</code>.<br> <li> Improved test readability and structure with <code>describe</code> blocks.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-262b1260d24250d92a6fbb0f309583679bc8f39681dd4aa1ce7b76205d401f38">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace-membership.spec.ts</strong><dd><code>Refactor tests with `describe` blocks for schema organization</code></dd></summary>
<hr>

packages/schema/tests/workspace-membership.spec.ts

<li>Introduced <code>describe</code> blocks to organize tests by schema type.<br> <li> Enhanced test readability by grouping related tests.<br> <li> Added missing assertions for test validations.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-06fc0ac10be16a8050613524589ba809f0f4eb24874dc6b2c1b49c7e12d9a8d8">+334/-313</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variable.spec.ts</strong><dd><code>Organize variable schema tests with `describe` blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/variable.spec.ts

<li>Added <code>describe</code> blocks to group tests by schema type.<br> <li> Improved test structure and readability.<br> <li> Included additional assertions for validation checks.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-448ac8d64e27b446b36c35f5e178ade6f631aeba88592e33e7586314c89a7d07">+363/-352</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api-key.spec.ts</strong><dd><code>Refactor API key tests using `describe` blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/api-key.spec.ts

<li>Grouped tests with <code>describe</code> blocks for better organization.<br> <li> Enhanced test clarity and structure.<br> <li> Added assertions for validation results.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-1fc360b5dc6d059c5ea0d9e3eeb3ff6f0f7e7b888777e12e60d90e6b487c07ae">+280/-266</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>environment.spec.ts</strong><dd><code>Organize environment schema tests with `describe` blocks</code>&nbsp; </dd></summary>
<hr>

packages/schema/tests/environment.spec.ts

<li>Utilized <code>describe</code> blocks to categorize tests by schema.<br> <li> Improved test organization and readability.<br> <li> Added assertions for validation outcomes.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-1b074cba90a8785d2bea5ccda58461d9cc5fdb052699ff8938f86ccfbe6f36cd">+265/-254</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user.spec.ts</strong><dd><code>Refactor user schema tests with `describe` blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/user.spec.ts

<li>Implemented <code>describe</code> blocks to organize user schema tests.<br> <li> Enhanced test readability and structure.<br> <li> Added assertions for validation checks.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-ee3e9718b7ec6ef4d5032c67b2cf103c9afdcc524734dc9853be89589b4d9089">+207/-197</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pagination.spec.ts</strong><dd><code>Refactor pagination schema tests with describe blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/pagination.spec.ts

<li>Added <code>describe</code> blocks to group tests for <code>PageRequestSchema</code>, <br><code>PageResponseSchema</code>, <code>ResponseErrorSchema</code>, and <code>ClientResponseSchema</code>.<br> <li> Organized existing test cases under their respective <code>describe</code> blocks.<br> <li> Removed old test comments and improved test structure.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-1b63386aadd5f5d011f5a2f498c32174dbe858567729fb36fb6b7a4f12b2d643">+150/-146</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>event.spec.ts</strong><dd><code>Refactor event schema tests with describe blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/event.spec.ts

<li>Introduced <code>describe</code> blocks for <code>GetEventsRequestSchema</code> and <br><code>GetEventsResponseSchema</code> tests.<br> <li> Structured existing test cases within the new <code>describe</code> blocks.<br> <li> Enhanced test organization and readability.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-03b60f9706eaef27b2a4000a4e3a1054de2d2d1456e27ca213dcd33bdbdd5555">+110/-108</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enums.test.ts</strong><dd><code>Refactor enum tests with describe blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/tests/enums.test.ts

<li>Added <code>describe</code> blocks for each enum type test.<br> <li> Organized tests for <code>integrationTypeEnum</code>, <code>expiresAfterEnum</code>, <br><code>rotateAfterEnum</code>, <code>eventSourceEnum</code>, <code>eventTriggererEnum</code>, <br><code>eventSeverityEnum</code>, <code>eventTypeEnum</code>, <code>authorityEnum</code>, and <br><code>projectAccessLevelEnum</code>.<br> <li> Improved test clarity and structure.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/577/files#diff-7857b1442b713837779e4cb4cbc57f8a3812e028f4f233e39e5ea2f70457c910">+136/-118</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information