### PR TITLE
fix(api): Enable global project access

### DIFF
--- a/apps/api/src/project/project.e2e.spec.ts
+++ b/apps/api/src/project/project.e2e.spec.ts
@@ -867,23 +867,26 @@ describe('Project Controller Tests', () => {
       await prisma.workspace.deleteMany()
     })
 
-    // it('should allow any user to access a global project', async () => {
-    //   const response = await app.inject({
-    //     method: 'GET',
-    //     url: `/project/${globalProject.slug}`,
-    //     headers: {
-    //       'x-e2e-user-email': user2.email // user2 is not a member of workspace1
-    //     }
-    //   })
+    it('should allow any user to access a global project', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/project/${globalProject.slug}`,
+        headers: {
+          'x-e2e-user-email': user2.email // user2 is not a member of workspace1
+        }
+      })
 
-    //   expect(response.statusCode).toBe(200)
-    //   expect(response.json()).toEqual({
-    //     ...globalProject,
-    //     lastUpdatedById: user1.id,
-    //     createdAt: expect.any(String),
-    //     updatedAt: expect.any(String)
-    //   })
-    // })
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        ...globalProject,
+        lastUpdatedById: user1.id,
+        environmentCount: 1,
+        secretCount: 0,
+        variableCount: 0,
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String)
+      })
+    })
 
     it('should allow workspace members with READ_PROJECT to access an internal project', async () => {
       const response = await app.inject({

--- a/apps/api/src/project/service/project.service.ts
+++ b/apps/api/src/project/service/project.service.ts
@@ -1221,11 +1221,14 @@ export class ProjectService {
         await this.authorityCheckerService.checkAuthorityOverEnvironment({
           userId: user.id,
           entity: { slug: env.slug },
-          authorities: [
-            Authority.READ_ENVIRONMENT,
-            Authority.READ_SECRET,
-            Authority.READ_VARIABLE
-          ],
+          authorities:
+            project.accessLevel == ProjectAccessLevel.GLOBAL
+              ? []
+              : [
+                  Authority.READ_ENVIRONMENT,
+                  Authority.READ_SECRET,
+                  Authority.READ_VARIABLE
+                ],
           prisma: this.prisma
         })
       if (hasRequiredPermission) {


### PR DESCRIPTION
### **User description**
## Description
- Created a condition for authorityCheck over environment when projects accesslevel is global. Previously the permittedAuthorites and authorites were compared, but a non member would not have those roles.
- Add environmentCount, variableCount, secretCount properties in a test.

Fixes #575

## Screenshots of relevant screens
Previously:

    Permitted Authorities for Workspace:

    Authorities: READ_ENVIRONMENT,READ_SECRET,READ_VARIABLE

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enabled and enhanced a test to verify that any user can access a global project, including checks for `environmentCount`, `secretCount`, and `variableCount`.
- Modified the authority check logic in the `ProjectService` to allow access to global projects without requiring specific authorities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.e2e.spec.ts</strong><dd><code>Enable and enhance test for global project access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/project/project.e2e.spec.ts

<li>Uncommented and enabled a test for global project access.<br> <li> Added checks for <code>environmentCount</code>, <code>secretCount</code>, and <code>variableCount</code> in <br>the test.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/580/files#diff-f1b22baab0b4173d825570c9030ef014582bc75bb67ef2e544f0dd879ff941a2">+20/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.service.ts</strong><dd><code>Adjust authority checks for global project access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/project/service/project.service.ts

<li>Modified authority check for global projects.<br> <li> Removed authority requirements for global project access.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/580/files#diff-d85f483eff15c28a4b3e5f7a54c9b159c71003f8a95ef7a4be00eb80ec72b2fa">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information