### PR TITLE
fix: Empty name ("") accepted as a valid name while creating environments

### DIFF
--- a/apps/api/src/environment/dto/create.environment/create.environment.ts
+++ b/apps/api/src/environment/dto/create.environment/create.environment.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString } from 'class-validator'
+import {IsNotEmpty, IsOptional, IsString } from 'class-validator'
 
 export class CreateEnvironment {
   @IsString()

--- a/apps/api/src/environment/dto/create.environment/create.environment.ts
+++ b/apps/api/src/environment/dto/create.environment/create.environment.ts
@@ -2,6 +2,7 @@ import { IsOptional, IsString } from 'class-validator'
 
 export class CreateEnvironment {
   @IsString()
+  @IsNotEmpty()
   name: string
 
   @IsString()


### PR DESCRIPTION
## Description

Add class-validator to check the property(name) is not empty before making the environmet.  <br />

Fixes #576 

