### PR TITLE
feat(api): Add endpoint to fetch all workspace invitations for a user

### DIFF
--- a/api-collection/Workspace Controller/Get all invitations of user.bru
+++ b/api-collection/Workspace Controller/Get all invitations of user.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get all invitations of user to workspaces
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{BASE_URL}}/api/workspace/invitations?page=0&limit=10
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{JWT}}
+}
+
+docs {
+  ## Description
+  
+  Fetches all the workspaces where the user is invited to.
+}

--- a/apps/api/src/environment/dto/create.environment/create.environment.ts
+++ b/apps/api/src/environment/dto/create.environment/create.environment.ts
@@ -3,7 +3,6 @@ import { IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator'
 export class CreateEnvironment {
   @IsString()
   @IsNotEmpty()
-  @Matches(/^[a-zA-Z0-9-_]{1,64}$/)
   name: string
 
   @IsString()

--- a/apps/api/src/environment/environment.e2e.spec.ts
+++ b/apps/api/src/environment/environment.e2e.spec.ts
@@ -28,6 +28,7 @@ import { UserModule } from '@/user/user.module'
 import { UserService } from '@/user/service/user.service'
 import { QueryTransformPipe } from '@/common/pipes/query.transform.pipe'
 import { fetchEvents } from '@/common/event'
+import { ValidationPipe } from '@nestjs/common'
 
 describe('Environment Controller Tests', () => {
   let app: NestFastifyApplication
@@ -65,7 +66,7 @@ describe('Environment Controller Tests', () => {
     environmentService = moduleRef.get(EnvironmentService)
     userService = moduleRef.get(UserService)
 
-    app.useGlobalPipes(new QueryTransformPipe())
+    app.useGlobalPipes(new ValidationPipe(), new QueryTransformPipe())
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()
@@ -184,7 +185,7 @@ describe('Environment Controller Tests', () => {
           'x-e2e-user-email': user1.email
         }
       })
-    
+
       expect(response.statusCode).toBe(400)
       expect(response.json().message).toContain('name should not be empty')
     })

--- a/apps/api/src/prisma/migrations/20241211205448_add_created_on_in_workspace_member/migration.sql
+++ b/apps/api/src/prisma/migrations/20241211205448_add_created_on_in_workspace_member/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkspaceMember" ADD COLUMN     "createdOn" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -339,6 +339,7 @@ model WorkspaceMember {
   workspaceId        String
   invitationAccepted Boolean                          @default(false)
   roles              WorkspaceMemberRoleAssociation[]
+  createdOn          DateTime                         @default(now())
 
   @@unique([workspaceId, userId])
 }

--- a/apps/api/src/workspace-membership/service/workspace-membership.service.ts
+++ b/apps/api/src/workspace-membership/service/workspace-membership.service.ts
@@ -879,11 +879,14 @@ export class WorkspaceMembershipService {
         roleSet.add(role)
       }
 
+      const invitedOn = new Date()
+
       // Create the workspace membership
       const createMembership = this.prisma.workspaceMember.create({
         data: {
           workspaceId: workspace.id,
           userId,
+          createdOn: invitedOn,
           roles: {
             create: Array.from(roleSet).map((role) => ({
               role: {
@@ -904,7 +907,7 @@ export class WorkspaceMembershipService {
           workspace.name,
           `${process.env.WORKSPACE_FRONTEND_URL}/workspace/${workspace.slug}/join`,
           currentUser.name,
-          new Date().toISOString(),
+          invitedOn.toISOString(),
           true
         )
 

--- a/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
+++ b/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
@@ -425,7 +425,8 @@ describe('Workspace Membership Controller Tests', () => {
         id: expect.any(String),
         userId: user2.id,
         workspaceId: workspace1.id,
-        invitationAccepted: false
+        invitationAccepted: false,
+        createdOn: expect.any(Date)
       })
     })
 
@@ -909,7 +910,8 @@ describe('Workspace Membership Controller Tests', () => {
         id: expect.any(String),
         userId: user2.id,
         workspaceId: workspace1.id,
-        invitationAccepted: true
+        invitationAccepted: true,
+        createdOn: expect.any(Date)
       })
     })
 

--- a/apps/api/src/workspace/controller/workspace.controller.ts
+++ b/apps/api/src/workspace/controller/workspace.controller.ts
@@ -52,8 +52,7 @@ export class WorkspaceController {
     @Query('limit') limit: number = 10,
     @Query('sort') sort: string = 'name',
     @Query('order') order: string = 'asc',
-    @Query('search') search: string = '',
-    @Query('isAccepted') isAccepted: 'true' | 'false' | undefined = undefined
+    @Query('search') search: string = ''
   ) {
     return this.workspaceService.getAllWorkspaceInvitations(
       user,
@@ -61,8 +60,7 @@ export class WorkspaceController {
       limit,
       sort,
       order,
-      search,
-      isAccepted ? isAccepted === 'true' : undefined
+      search
     )
   }
 

--- a/apps/api/src/workspace/controller/workspace.controller.ts
+++ b/apps/api/src/workspace/controller/workspace.controller.ts
@@ -44,6 +44,28 @@ export class WorkspaceController {
     return this.workspaceService.deleteWorkspace(user, workspaceSlug)
   }
 
+  @Get('invitations')
+  @RequiredApiKeyAuthorities(Authority.READ_WORKSPACE)
+  async getAllInvitationsOfUser(
+    @CurrentUser() user: User,
+    @Query('page') page: number = 0,
+    @Query('limit') limit: number = 10,
+    @Query('sort') sort: string = 'name',
+    @Query('order') order: string = 'asc',
+    @Query('search') search: string = '',
+    @Query('isAccepted') isAccepted: 'true' | 'false' | undefined = undefined
+  ) {
+    return this.workspaceService.getInvitationsOfUser(
+      user,
+      page,
+      limit,
+      sort,
+      order,
+      search,
+      isAccepted ? isAccepted === 'true' : undefined
+    )
+  }
+
   @Get(':workspaceSlug')
   @RequiredApiKeyAuthorities(Authority.READ_WORKSPACE)
   async getWorkspace(

--- a/apps/api/src/workspace/controller/workspace.controller.ts
+++ b/apps/api/src/workspace/controller/workspace.controller.ts
@@ -55,7 +55,7 @@ export class WorkspaceController {
     @Query('search') search: string = '',
     @Query('isAccepted') isAccepted: 'true' | 'false' | undefined = undefined
   ) {
-    return this.workspaceService.getInvitationsOfUser(
+    return this.workspaceService.getAllWorkspaceInvitations(
       user,
       page,
       limit,

--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -446,7 +446,8 @@ export class WorkspaceService {
               }
             }
           }
-        }
+        },
+        createdOn: true
       }
     })
 
@@ -479,7 +480,14 @@ export class WorkspaceService {
       search
     })
 
-    return { items, metadata }
+    return {
+      items: items.map((item) => ({
+        ...item,
+        invitedOn: item.createdOn,
+        createdOn: undefined
+      })),
+      metadata
+    }
   }
 
   /**

--- a/apps/api/src/workspace/service/workspace.service.ts
+++ b/apps/api/src/workspace/service/workspace.service.ts
@@ -396,7 +396,7 @@ export class WorkspaceService {
    * @param isAccepted The invitation status to filter by
    * @returns The workspace invitations of the user, paginated, with metadata
    */
-  async getInvitationsOfUser(
+  async getAllWorkspaceInvitations(
     user: User,
     page: number,
     limit: number,

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -506,7 +506,7 @@ describe('Workspace Controller Tests', () => {
       expect(body.items).toHaveLength(1)
       expect(body.items[0].workspace.slug).not.toBe(workspace2.slug)
       expect(body.items[0]).toEqual({
-        invitedOn: expect.any(Date.toString()),
+        invitedOn: expect.any(String),
         workspace: {
           icon: workspace1.icon,
           id: workspace1.id,

--- a/apps/api/src/workspace/workspace.e2e.spec.ts
+++ b/apps/api/src/workspace/workspace.e2e.spec.ts
@@ -311,7 +311,8 @@ describe('Workspace Controller Tests', () => {
         id: expect.any(String),
         userId: user1.id,
         workspaceId: workspace1.id,
-        invitationAccepted: true
+        invitationAccepted: true,
+        createdOn: expect.any(Date)
       })
     })
   })
@@ -503,8 +504,24 @@ describe('Workspace Controller Tests', () => {
       const body = response.json()
 
       expect(body.items).toHaveLength(1)
-      expect(body.items[0].workspace.id).toBe(workspace1.id)
       expect(body.items[0].workspace.slug).not.toBe(workspace2.slug)
+      expect(body.items[0]).toEqual({
+        invitedOn: expect.any(Date.toString()),
+        workspace: {
+          icon: workspace1.icon,
+          id: workspace1.id,
+          name: workspace1.name,
+          slug: workspace1.slug
+        },
+        roles: [
+          {
+            role: {
+              name: memberRole.name,
+              colorCode: memberRole.colorCode
+            }
+          }
+        ]
+      })
       expect(body.metadata.totalCount).toBe(1)
       expect(body.metadata.links.self).toEqual(
         `/workspace/invitations?page=0&limit=10&sort=name&order=asc&search=`
@@ -567,7 +584,6 @@ describe('Workspace Controller Tests', () => {
       })
 
       const body = response.json()
-      console.log(body)
       expect(body.items).toHaveLength(0)
       expect(body.metadata).toEqual({})
     })


### PR DESCRIPTION
### **User description**
## Description

Created an endpoint /invitations under workspace to retrieve all unaccepted invitations. Three E2E Tests were also added.<br />

Fixes #550
Fixes #551

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new API endpoint `/invitations` to fetch all workspace invitations for a user, with support for pagination and filtering by acceptance status.
- Implemented the `getInvitationsOfUser` method in the `WorkspaceService` to handle the logic for fetching and paginating invitations.
- Added end-to-end tests to verify the functionality of the new endpoint, including tests for filtering by accepted invitations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.controller.ts</strong><dd><code>Add endpoint to fetch workspace invitations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/controller/workspace.controller.ts

<li>Added a new endpoint <code>GET /invitations</code> to fetch workspace invitations.<br> <li> Implemented query parameters for pagination and filtering.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/586/files#diff-97a7dec6a517fcb0f1f7b43973822237aed3fcf897f60e1bcc0237eb0e2fe8d7">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace.service.ts</strong><dd><code>Implement service method for fetching user invitations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/service/workspace.service.ts

<li>Added <code>getInvitationsOfUser</code> method to fetch user invitations.<br> <li> Implemented pagination and filtering logic for invitations.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/586/files#diff-a92613f23cf2834d52eaedb87c4e8c460d48b6fca8df4ccc968b2a8af19a9c3f">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.e2e.spec.ts</strong><dd><code>Add E2E tests for workspace invitations endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace/workspace.e2e.spec.ts

<li>Added end-to-end tests for the new invitations endpoint.<br> <li> Tested fetching invitations with and without acceptance filter.<br>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/586/files#diff-7a691e843fbdae323f1cabe7a12508154fbc917a1a738e5a67a1747fb7c581ea">+74/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information