### PR TITLE
fix(schema): Add versions field to project secrets and variables response

### DIFF
--- a/packages/schema/src/secret/index.ts
+++ b/packages/schema/src/secret/index.ts
@@ -98,7 +98,16 @@ export const GetAllSecretsOfProjectResponseSchema = PageResponseSchema(
       lastUpdatedBy: z.object({
         id: z.string(),
         name: z.string()
-      })
+      }),
+      versions: z.array(
+        z.object({
+          environment: z.object({
+            id: EnvironmentSchema.shape.id,
+            slug: EnvironmentSchema.shape.slug,
+            name: EnvironmentSchema.shape.name
+          })
+        })
+      )
     }),
     values: z.object({
       environment: z.object({

--- a/packages/schema/src/variable/index.ts
+++ b/packages/schema/src/variable/index.ts
@@ -98,8 +98,16 @@ export const GetAllVariablesOfProjectRequestSchema = PageRequestSchema.extend({
 })
 
 export const GetAllVariablesOfProjectResponseSchema = PageResponseSchema(
-  VariableSchema.omit({ project: true, versions: true }).extend({
-    variable: z.object({
+  z.object({
+    variable: VariableSchema.omit({ project: true, versions: true }).extend({
+      versions: z.array(
+        z.object({
+          environment: z.object({
+            id: EnvironmentSchema.shape.id,
+            slug: EnvironmentSchema.shape.slug
+          })
+        })
+      ),
       lastUpdatedBy: z.object({
         id: z.string(),
         name: z.string()

--- a/packages/schema/tests/secret.spec.ts
+++ b/packages/schema/tests/secret.spec.ts
@@ -16,6 +16,7 @@ import {
   GetRevisionsOfSecretResponseSchema
 } from '@/secret'
 import { rotateAfterEnum } from '@/enums'
+import { env, versions } from 'process'
 
 describe('Secret Schema Tests', () => {
   describe('SecretSchema Tests', () => {
@@ -347,7 +348,16 @@ describe('Secret Schema Tests', () => {
               lastUpdatedBy: {
                 id: 'user123',
                 name: 'John Doe'
-              }
+              },
+              versions: [
+                {
+                  environment: {
+                    id: 'env123',
+                    slug: 'development',
+                    name: 'Development'
+                  }
+                }
+              ]
             },
             values: {
               environment: {

--- a/packages/schema/tests/variable.spec.ts
+++ b/packages/schema/tests/variable.spec.ts
@@ -389,19 +389,27 @@ describe('Variable Schema Tests', () => {
       const result = GetAllVariablesOfProjectResponseSchema.safeParse({
         items: [
           {
-            id: 'variable123',
-            name: 'Variable Name',
-            slug: 'variable-slug',
-            createdAt: '2024-10-01T00:00:00Z',
-            updatedAt: '2024-10-01T00:00:00Z',
-            note: 'This is a note',
-            lastUpdatedById: 'user123',
-            projectId: 'project123',
             variable: {
+              id: 'variable123',
+              name: 'Variable Name',
+              slug: 'variable-slug',
+              createdAt: '2024-10-01T00:00:00Z',
+              updatedAt: '2024-10-01T00:00:00Z',
+              note: 'This is a note',
+              lastUpdatedById: 'user123',
+              projectId: 'project123',
               lastUpdatedBy: {
                 id: 'user123',
                 name: 'John Doe'
-              }
+              },
+              versions: [
+                {
+                  environment: {
+                    id: 'env123',
+                    slug: 'development'
+                  }
+                }
+              ]
             },
             values: [
               {


### PR DESCRIPTION

## Description

In @keyshade/scehma fix inconsistencies of project response schema for variable and secret <br />

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
