### PR TITLE
feat(cli): supports to specify environment(s) and its optional description

### DIFF
--- a/apps/cli/src/commands/project/create.project.ts
+++ b/apps/cli/src/commands/project/create.project.ts
@@ -91,12 +91,12 @@ export default class CreateProject extends BaseCommand {
     description?: string
     storePrivateKey: boolean
     accessLevel: 'PRIVATE' | 'GLOBAL' | 'INTERNAL'
-    environments?: { name: string; description?: string }[]
+    environments: Array<{ name: string; description?: string }> | undefined
   }> {
     let { name, description } = options
     const { storePrivateKey, accessLevel, environment } = options
 
-    let environments: { name: string; description?: string }[]
+    let environments: Array<{ name: string; description?: string }> | undefined
 
     if (!name) {
       name = await text({
@@ -113,8 +113,8 @@ export default class CreateProject extends BaseCommand {
       environments = environment.map((env: string) => {
         const split = env.split(':')
         return {
-          name: split[0],
-          description: split[1]
+          name: split[0].trim(),
+          description: split[1]?.trim() ?? null
         }
       })
     }

--- a/apps/cli/src/commands/project/create.project.ts
+++ b/apps/cli/src/commands/project/create.project.ts
@@ -55,7 +55,21 @@ export default class CreateProject extends BaseCommand {
       {
         short: '-e',
         long: '--environment <string...>',
-        description: 'Environment name(s) of the project. Default to Default'
+        description: `Should be in the format <name(mandatory)>[:<description>(optional)]
+
+Examples:
+ $ keyshade [...]
+ -> { name: "Default", description: ". . ." }
+
+ $ keyshade [...] -e "dev"
+ -> { name: "dev", description: NULL }
+
+ $ keyshade [...] -e "dev:sample env"
+ -> { name: "dev", description: "sample env" }
+
+ $ keyshade [...] -e " dev : surrounding blank spaces  "
+ -> { name: "dev", description: "surrounding blank spaces" }
+`
       }
     ]
   }

--- a/apps/cli/src/commands/project/create.project.ts
+++ b/apps/cli/src/commands/project/create.project.ts
@@ -51,6 +51,11 @@ export default class CreateProject extends BaseCommand {
         description: 'Access level of the project. Defaults to PRIVATE.',
         defaultValue: 'PRIVATE',
         choices: ['GLOBAL', 'PRIVATE', 'INTERNAL']
+      },
+      {
+        short: '-e',
+        long: '--environment <string...>',
+        description: 'Environment name(s) of the project. Default to Default'
       }
     ]
   }
@@ -86,9 +91,12 @@ export default class CreateProject extends BaseCommand {
     description?: string
     storePrivateKey: boolean
     accessLevel: 'PRIVATE' | 'GLOBAL' | 'INTERNAL'
+    environments?: { name: string; description?: string }[]
   }> {
     let { name, description } = options
-    const { storePrivateKey, accessLevel } = options
+    const { storePrivateKey, accessLevel, environment } = options
+
+    let environments: { name: string; description?: string }[]
 
     if (!name) {
       name = await text({
@@ -101,6 +109,16 @@ export default class CreateProject extends BaseCommand {
       description = name
     }
 
-    return { name, description, storePrivateKey, accessLevel }
+    if (environment) {
+      environments = environment.map((env: string) => {
+        const split = env.split(':')
+        return {
+          name: split[0],
+          description: split[1]
+        }
+      })
+    }
+
+    return { name, description, storePrivateKey, accessLevel, environments }
   }
 }


### PR DESCRIPTION
### **User description**
## Description
Fixes #617 

Add command option to specify one to multiple environments and its optional description.

The option's flag is `-e` (short) or `--environment` (long). the description of the option is `Environment name(s) of the project. Default to Default`.

Now the `project create --help` command would give this output:

```
$ pnpm dev:cli -- project create --help

# . . .

Creates a project
 
Arguments:
  Workspace Slug                 Slug of the workspace under which you want to create the project

Options:
  -n, --name <string>            Name of the project
  -d, --description <string>     Description of the project. Defaults to project name
  -k, --store-private-key        Store the private key in the project. Defaults to true (default: true)
  -a, --access-level <string>    Access level of the project. Defaults to PRIVATE. (choices: "GLOBAL", "PRIVATE", "INTERNAL", default: "PRIVATE")
  -e, --environment <string...>  Environment name(s) of the project. Default to Default
  -h, --help                     display help for command

```

**How to test:**
```shell
pnpm start:cli -- project create <WORKSPACE_SLUG> --base-url <BASE_URL> --api-key <API_KEY> -n <PROJECT_NAME> -e <ENVIRONMENT_NAME:ENVIRONMENT_DESCRIPTION> --environment <ENVIRONMENT2_NAME:ENVIRONMENT2_DESCRIPTION>
```

**Example:**
```shell
pnpm start:cli -- project create workspace-1-0 --base-url http://localhost:4200 --api-key ks_87eb7a747bfcd14984cb18643728defb53237d7be95f8bcf -n test-project -e "dev" --environment "stage:Environment for staging" -e "production:Environment for production"
```

## Dependencies

_Mention any dependencies/packages used_

## Future Improvements

_Mention any improvements to be done in future related to any file/feature_

## Mentions

_Mention and tag the people_

## Screenshots of relevant screens
**Image 1: Running the test command and the output in terminal**
![Screenshot From 2025-01-16 20-17-23](https://github.com/user-attachments/assets/d0df93fe-f91f-4fd3-b2b2-9b883e154700)

**Image 2: Result in database**

![Screenshot From 2025-01-16 19-41-32](https://github.com/user-attachments/assets/6dc1bd70-ea77-48fe-9f87-a592b08b7e52)

**Image 3: Printing help of the command**

![Screenshot From 2025-01-16 20-30-49](https://github.com/user-attachments/assets/67a0c8c5-50d5-4ffc-b04d-ee0838805e87)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [ ] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for specifying environments during project creation.

- Introduced `--environment` option with optional descriptions.

- Parsed and processed environment input into structured data.

- Updated CLI help output to include new option.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.project.ts</strong><dd><code>Support specifying environments with optional descriptions</code></dd></summary>
<hr>

apps/cli/src/commands/project/create.project.ts

<li>Added <code>--environment</code> option to specify environments.<br> <li> Parsed environment input into name and optional description.<br> <li> Updated return structure to include environments data.<br> <li> Enhanced CLI help output to reflect new functionality.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/634/files#diff-f48aa765b0244d698ca097a70d9774bda9ec113c9a5714cd815eef66994ab03f">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>