### PR TITLE
fix(cli): Create project --store-private-key option default value removed

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -60,3 +60,4 @@
 ## Patches
 
 - Fixed error when the CLI won't create `.keyshade` folder while initializing profiles on new devices
+- Projects always had `--store-private-key` set to true despite providing a false value. Fixed this.

--- a/apps/cli/src/commands/project/create.project.ts
+++ b/apps/cli/src/commands/project/create.project.ts
@@ -42,8 +42,7 @@ export default class CreateProject extends BaseCommand {
       {
         short: '-k',
         long: '--store-private-key',
-        description: 'Store the private key in the project. Defaults to true',
-        defaultValue: true
+        description: 'Store the private key in the project. Defaults to true'
       },
       {
         short: '-a',

--- a/apps/cli/src/commands/project/create.project.ts
+++ b/apps/cli/src/commands/project/create.project.ts
@@ -42,7 +42,7 @@ export default class CreateProject extends BaseCommand {
       {
         short: '-k',
         long: '--store-private-key',
-        description: 'Store the private key in the project. Defaults to true'
+        description: 'Store the private key in the project.'
       },
       {
         short: '-a',


### PR DESCRIPTION
### **User description**
## Description

Removed the default value of the --store-private-key option from the create project command, as this option is a Boolean flag, which otherwise could not be unset.

Fixes #618

## Screenshots of relevant screens

![image](https://github.com/user-attachments/assets/f2025b63-24fe-45e0-a532-858f8e9a4ae3)
![image](https://github.com/user-attachments/assets/2c216e6a-6fbd-4f93-8740-5a84a5d1b41a)
![image](https://github.com/user-attachments/assets/36796a0a-5361-4503-95bd-b685e6405430)

## Developer's checklist

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-check on my work

**If changes are made in the code:**

- [X] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [X] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [X] I have added relevant screenshots in my PR
- [X] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [X] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the default value for `--store-private-key` flag in project creation.

- Ensured the `--store-private-key` flag behaves as a Boolean without default.

- Addressed issue where private key was stored despite `-k false` flag.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.project.ts</strong><dd><code>Adjusted `--store-private-key` flag behavior in CLI.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/project/create.project.ts

<li>Removed default value for <code>--store-private-key</code> flag.<br> <li> Updated description to clarify default behavior.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/638/files#diff-f48aa765b0244d698ca097a70d9774bda9ec113c9a5714cd815eef66994ab03f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>