### PR TITLE
feat(api): Workspace-membership invitationAccepted included

### DIFF
--- a/apps/api/src/workspace-membership/service/workspace-membership.service.ts
+++ b/apps/api/src/workspace-membership/service/workspace-membership.service.ts
@@ -516,7 +516,8 @@ export class WorkspaceMembershipService {
               }
             }
           }
-        }
+        },
+        invitationAccepted: true
       }
     })
 

--- a/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
+++ b/apps/api/src/workspace-membership/workspace-membership.e2e.spec.ts
@@ -1087,8 +1087,18 @@ describe('Workspace Membership Controller Tests', () => {
       })
 
       expect(response.statusCode).toBe(200)
-      expect(response.json().items).toBeInstanceOf(Array)
-      expect(response.json().items).toHaveLength(1)
+
+      const workspaceMembers = response.json().items
+
+      expect(workspaceMembers).toBeInstanceOf(Array)
+      expect(workspaceMembers).toHaveLength(1)
+
+      const workspaceMember = workspaceMembers[0]
+
+      expect(workspaceMember.id).toBeDefined()
+      expect(workspaceMember.user).toBeDefined()
+      expect(workspaceMember.roles).toBeDefined()
+      expect(workspaceMember.invitationAccepted).toBeDefined()
 
       //check metadata
       const metadata = response.json().metadata


### PR DESCRIPTION
### **User description**
## Description

`WorkspaceMember.invitationAccepted` returned in `/api/workspace-membership/{workspaceSlug}/members`

Fixes #406

## Screenshots of relevant screens

![image](https://github.com/user-attachments/assets/ab1027c6-d5f9-4ad2-a2e2-fe18ae34ab85)

## Developer's checklist

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-check on my work

**If changes are made in the code:**

- [X] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [X] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [X] I have added relevant screenshots in my PR
- [X] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [X] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Enhancement


___

### **Description**
- Added `invitationAccepted` field to workspace membership API response.

- Enhanced `/api/workspace/{workspaceId}/members` endpoint to include membership status.

- Updated service logic to fetch and return invitation status.

- Improved API functionality for better workspace member management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace-membership.service.ts</strong><dd><code>Include invitation status in workspace membership API</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace-membership/service/workspace-membership.service.ts

<li>Added <code>invitationAccepted</code> field to the API response.<br> <li> Enhanced query to include invitation status in the returned data.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/665/files#diff-510c8dfb0963173c1ce7e47b2433e04050f9e999e298ba59d3fd771ceceb7419">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>