### PR TITLE
feat(api, schema): Add preview field in API Key

### DIFF
--- a/apps/api/src/api-key/api-key.e2e.spec.ts
+++ b/apps/api/src/api-key/api-key.e2e.spec.ts
@@ -85,7 +85,12 @@ describe('Api Key Role Controller Tests', () => {
       expect(response.json().name).toBe('Test')
       expect(response.json().slug).toBeDefined()
       expect(response.json().value).toMatch(/^ks_*/)
+      expect(response.json().preview).toMatch(/^ks_*/)
       expect(response.json().authorities).toEqual(['READ_API_KEY'])
+
+      const last4CharsOfValue = response.json().value.slice(-4)
+      const last4CharsOfPreview = response.json().preview.slice(-4)
+      expect(last4CharsOfValue).toBe(last4CharsOfPreview)
 
       const apiKey = await prisma.apiKey.findUnique({
         where: {
@@ -254,6 +259,7 @@ describe('Api Key Role Controller Tests', () => {
         id: apiKey.id,
         name: 'Test Key',
         slug: apiKey.slug,
+        preview: apiKey.preview,
         authorities: ['READ_API_KEY', 'CREATE_ENVIRONMENT'],
         expiresAt: expect.any(String),
         createdAt: expect.any(String),

--- a/apps/api/src/api-key/service/api-key.service.ts
+++ b/apps/api/src/api-key/service/api-key.service.ts
@@ -22,6 +22,7 @@ export class ApiKeyService {
   private apiKeySelect = {
     id: true,
     expiresAt: true,
+    preview: true,
     name: true,
     slug: true,
     authorities: true,
@@ -41,12 +42,20 @@ export class ApiKeyService {
     await this.isApiKeyUnique(user, dto.name)
 
     const plainTextApiKey = generateApiKey()
+
+    // Generate the preview key in format ks_****<last 4 chars>
+    const previewKey = `ks_****${plainTextApiKey.slice(-4)}`
+    this.logger.log(
+      `User ${user.id} created API key ${previewKey} with name ${dto.name}`
+    )
+
     const hashedApiKey = toSHA256(plainTextApiKey)
     const apiKey = await this.prisma.apiKey.create({
       data: {
         name: dto.name,
         slug: await generateEntitySlug(dto.name, 'API_KEY', this.prisma),
         value: hashedApiKey,
+        preview: previewKey,
         authorities: dto.authorities
           ? {
               set: dto.authorities

--- a/apps/api/src/environment/service/environment.service.ts
+++ b/apps/api/src/environment/service/environment.service.ts
@@ -325,12 +325,10 @@ export class EnvironmentService {
 
     // Parse the secret and variable counts for each environment
     for (const environment of items) {
-      const [secrets, variables] = await Promise.all([
-        this.getSecretCount(environment.id),
-        this.getVariableCount(environment.id)
-      ])
-      environment['secrets'] = secrets
-      environment['variables'] = variables
+      const secretCount = await this.getSecretCount(environment.id)
+      const variableCount = await this.getVariableCount(environment.id)
+      environment['secrets'] = secretCount
+      environment['variables'] = variableCount
     }
 
     // Calculate metadata for pagination

--- a/apps/api/src/prisma/migrations/20250130160517_add_preview_in_api_key/migration.sql
+++ b/apps/api/src/prisma/migrations/20250130160517_add_preview_in_api_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ApiKey" ADD COLUMN     "preview" TEXT NOT NULL DEFAULT 'ks_******';

--- a/apps/api/src/prisma/schema.prisma
+++ b/apps/api/src/prisma/schema.prisma
@@ -429,6 +429,7 @@ model Variable {
 model ApiKey {
   id          String      @id @default(cuid())
   name        String
+  preview     String      @default("ks_******")
   slug        String      @unique
   value       String      @unique
   expiresAt   DateTime?

--- a/packages/schema/src/api-key/index.ts
+++ b/packages/schema/src/api-key/index.ts
@@ -7,6 +7,7 @@ export const ApiKeySchema = z.object({
   name: z.string(),
   slug: z.string(),
   value: z.string(),
+  preview: z.string(),
   expiresAt: z.string().datetime().nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/packages/schema/tests/api-key.spec.ts
+++ b/packages/schema/tests/api-key.spec.ts
@@ -22,6 +22,7 @@ describe('API Key Schemas Tests', () => {
         name: 'API Key Name',
         slug: 'api-key-slug',
         value: 'api-key-value',
+        preview: 'api-key-preview',
         expiresAt: '2024-10-10T10:00:00Z',
         createdAt: '2024-10-09T10:00:00Z',
         updatedAt: '2024-10-09T10:00:00Z',
@@ -44,7 +45,7 @@ describe('API Key Schemas Tests', () => {
         // no userId
       })
       expect(result.success).toBe(false)
-      expect(result.error?.issues).toHaveLength(3)
+      expect(result.error?.issues).toHaveLength(4)
     })
   })
 
@@ -95,6 +96,7 @@ describe('API Key Schemas Tests', () => {
         name: 'API Key Name',
         slug: 'api-key-slug',
         value: 'api-key-value',
+        preview: 'api-key-preview',
         expiresAt: '2024-10-10T10:00:00Z',
         createdAt: '2024-10-09T10:00:00Z',
         updatedAt: '2024-10-09T10:00:00Z',
@@ -118,7 +120,7 @@ describe('API Key Schemas Tests', () => {
         // no userId
       })
       expect(result.success).toBe(false)
-      expect(result.error?.issues).toHaveLength(3)
+      expect(result.error?.issues).toHaveLength(4)
     })
   })
 
@@ -151,6 +153,7 @@ describe('API Key Schemas Tests', () => {
         id: 'apikey123',
         name: 'API Key Name',
         slug: 'api-key-slug',
+        preview: 'api-key-preview',
         expiresAt: '2024-10-10T10:00:00Z',
         createdAt: '2024-10-09T10:00:00Z',
         updatedAt: '2024-10-09T10:00:00Z',
@@ -170,7 +173,7 @@ describe('API Key Schemas Tests', () => {
         authorities: ['INVALID_AUTHORITY'] // Invalid authority
       })
       expect(result.success).toBe(false)
-      expect(result.error?.issues).toHaveLength(2)
+      expect(result.error?.issues).toHaveLength(3)
     })
   })
 
@@ -232,6 +235,7 @@ describe('API Key Schemas Tests', () => {
             id: 'apikey123',
             name: 'API Key Name',
             slug: 'api-key-slug',
+            preview: 'api-key-preview',
             expiresAt: '2024-10-10T10:00:00Z',
             createdAt: '2024-10-09T10:00:00Z',
             updatedAt: '2024-10-09T10:00:00Z',
@@ -283,7 +287,7 @@ describe('API Key Schemas Tests', () => {
         }
       })
       expect(result.success).toBe(false)
-      expect(result.error?.issues).toHaveLength(2)
+      expect(result.error?.issues).toHaveLength(3)
     })
   })
 
@@ -310,6 +314,7 @@ describe('API Key Schemas Tests', () => {
         id: 'apikey123',
         name: 'API Key Name',
         slug: 'api-key-slug',
+        preview: 'api-key-preview',
         expiresAt: '2024-10-10T10:00:00Z',
         createdAt: '2024-10-09T10:00:00Z',
         updatedAt: '2024-10-09T10:00:00Z',
@@ -329,7 +334,7 @@ describe('API Key Schemas Tests', () => {
         authorities: ['INVALID_AUTHORITY'] // Invalid authority
       })
       expect(result.success).toBe(false)
-      expect(result.error?.issues).toHaveLength(2)
+      expect(result.error?.issues).toHaveLength(3)
     })
   })
 

--- a/packages/schema/tests/variable.spec.ts
+++ b/packages/schema/tests/variable.spec.ts
@@ -42,7 +42,6 @@ describe('Variable Schema Tests', () => {
           }
         ]
       })
-      console.log(result.error)
       expect(result.success).toBe(true)
     })
 


### PR DESCRIPTION
### **User description**
## Description

- Add a `preview` field in API Key model that stores the api key value in the format `ks_****<last 4 chars>`
- Added DB migrations
- Updates schema package to reflect the changes
- Add tests

## Screenshots

- Creating API key 
<img width="2053" alt="image" src="https://github.com/user-attachments/assets/500c1df1-dc25-4e8a-8a16-9a814b81b32f" />

- Get API key: 
<img width="2053" alt="image" src="https://github.com/user-attachments/assets/b6a42d7f-05c9-4420-a704-d076d0a09ce1" />


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a `preview` field to the API Key model for masked key representation.

- Updated API key creation logic to generate and store the `preview` field.

- Modified schema and database migrations to include the `preview` field.

- Enhanced tests to validate the `preview` field functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-key.e2e.spec.ts</strong><dd><code>Add tests for `preview` field in API Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/api-key.e2e.spec.ts

<li>Added tests to validate the <code>preview</code> field format.<br> <li> Verified the last 4 characters of <code>value</code> and <code>preview</code> match.<br> <li> Included <code>preview</code> in API key response validation.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/680/files#diff-6562811269d6b42c99951dca3009d7754fd60e6e6c20a3a89c69c86414fe4234">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-key.service.ts</strong><dd><code>Implement `preview` field generation in API Key service</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/service/api-key.service.ts

<li>Added logic to generate <code>preview</code> field during API key creation.<br> <li> Logged the creation of the <code>preview</code> field.<br> <li> Updated API key selection to include <code>preview</code>.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/680/files#diff-9fefafaa7fbbd90c1f65410a2414bfab311e6faeb1277c532fe372060a33ebef">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>environment.service.ts</strong><dd><code>Refactor secret and variable count logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/environment/service/environment.service.ts

<li>Refactored secret and variable count retrieval logic.<br> <li> Simplified asynchronous operations for better readability.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/680/files#diff-658d3ecf90efc583248d280885f43ee30a341ca9949c2a48c1312d3ed6f3acbd">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update schema to include `preview` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/schema/src/api-key/index.ts

- Added `preview` field to API Key schema definition.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/680/files#diff-eb680e1da49b1fb5b8806fe44f2a7cafcbef3240be6a1ea689f865b58bb363ec">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Add migration for `preview` field in API Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/migrations/20250130160517_add_preview_in_api_key/migration.sql

<li>Added a database migration to include <code>preview</code> field in <code>ApiKey</code> table.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/680/files#diff-e785c254b6b67bc454af2f57e8f3f9ecd78a9efdf61e8694aa632f90948b2469">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma schema for `preview` field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/prisma/schema.prisma

- Updated Prisma schema to include `preview` field in `ApiKey` model.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/680/files#diff-24191263d57c55d02e0cdf394de15225b628d1da20bd826b1541b59b6b02adb4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>