### PR TITLE
fix(platform): Improve button layout and text truncation in Slug comp…

### DIFF
--- a/apps/platform/src/components/common/slug.tsx
+++ b/apps/platform/src/components/common/slug.tsx
@@ -23,11 +23,12 @@ export default function Slug({ text }: SlugProps): React.JSX.Element {
 
   return (
     <button
-      className={`${roboto.className} flex cursor-copy gap-2 rounded-lg bg-white/10 px-3 py-2 font-mono text-sm text-white/50 hover:bg-white/15`}
+      className={`${roboto.className} flex cursor-copy items-center justify-between gap-2 rounded-lg bg-white/10 px-3 py-2 font-mono text-sm text-white/50 hover:bg-white/15 w-full overflow-hidden`}
       onClick={copyToClipboard}
       type="button"
     >
-      {text} <CopySVG className="w-[20px]" />
+      <span className="truncate">{text}</span>
+      <CopySVG className="w-[20px] flex-shrink-0" />
     </button>
   )
 }


### PR DESCRIPTION
# Fix Copy Button Overflow in Environment Component

## Description

Fixed the copy button overflow issue in the Environment component by implementing proper layout and overflow handling.

Fixes #710

## Dependencies

No new dependencies added. Using existing Tailwind CSS classes.

## Changes Made

- Added proper layout constraints to the Slug component button
- Implemented text truncation for long environment names
- Ensured copy button stays within container bounds
- Added responsive design considerations
- Improved overall component alignment

## Technical Details

Updated the Slug component with:
- Added `w-full` for full width container
- Implemented `overflow-hidden` to prevent content spillover
- Added `truncate` class for text overflow handling
- Used `flex-shrink-0` for copy icon stability
- Improved flex layout with `items-center` and `justify-between`

## Mentions

@rajdip-b Please review the UI changes
@Allan2000-Git For verification of the fix

## Testing Instructions

1. Navigate to the Environment tab
2. Check if the copy button stays within its container
3. Test with various environment name lengths
4. Verify copy functionality still works as expected