### PR TITLE
fix(api): Variables with empty names

### DIFF
--- a/apps/api/src/decorators/non-empty-trimmed-string.decorator.ts
+++ b/apps/api/src/decorators/non-empty-trimmed-string.decorator.ts
@@ -1,10 +1,7 @@
-import { IsNotEmpty } from "class-validator"
-import { TrimmedString } from "@/decorators/trimmed-string.decorator"
-import { applyDecorators } from "@nestjs/common"
+import { IsNotEmpty } from 'class-validator'
+import { TrimmedString } from '@/decorators/trimmed-string.decorator'
+import { applyDecorators } from '@nestjs/common'
 
 export function NonEmptyTrimmedString() {
-  return applyDecorators(
-    TrimmedString(),
-    IsNotEmpty()
-  );
+  return applyDecorators(TrimmedString(), IsNotEmpty())
 }

--- a/apps/api/src/decorators/non-empty-trimmed-string.decorator.ts
+++ b/apps/api/src/decorators/non-empty-trimmed-string.decorator.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty } from "class-validator"
+import { TrimmedString } from "@/decorators/trimmed-string.decorator"
+import { applyDecorators } from "@nestjs/common"
+
+export function NonEmptyTrimmedString() {
+  return applyDecorators(
+    TrimmedString(),
+    IsNotEmpty()
+  );
+}

--- a/apps/api/src/decorators/trim-string.decorator.ts
+++ b/apps/api/src/decorators/trim-string.decorator.ts
@@ -2,6 +2,6 @@ import { Transform } from 'class-transformer'
 
 export function TrimString() {
   return Transform(({ value }) =>
-    typeof value === 'string' ? value?.trim() : value
+    typeof value === 'string' ? value.trim() : value
   )
 }

--- a/apps/api/src/decorators/trimmed-string.decorator.ts
+++ b/apps/api/src/decorators/trimmed-string.decorator.ts
@@ -1,0 +1,10 @@
+import { IsString } from "class-validator"
+import { TrimString } from "@/decorators/trim-string.decorator"
+import { applyDecorators } from "@nestjs/common"
+
+export function TrimmedString() {
+  return applyDecorators(
+    TrimString(),
+    IsString()
+  )
+}

--- a/apps/api/src/decorators/trimmed-string.decorator.ts
+++ b/apps/api/src/decorators/trimmed-string.decorator.ts
@@ -1,10 +1,7 @@
-import { IsString } from "class-validator"
-import { TrimString } from "@/decorators/trim-string.decorator"
-import { applyDecorators } from "@nestjs/common"
+import { IsString } from 'class-validator'
+import { TrimString } from '@/decorators/trim-string.decorator'
+import { applyDecorators } from '@nestjs/common'
 
 export function TrimmedString() {
-  return applyDecorators(
-    TrimString(),
-    IsString()
-  )
+  return applyDecorators(TrimString(), IsString())
 }

--- a/apps/api/src/secret/dto/create.secret/create.secret.ts
+++ b/apps/api/src/secret/dto/create.secret/create.secret.ts
@@ -8,17 +8,15 @@ import {
   Length,
   ValidateNested
 } from 'class-validator'
-import { TrimString } from '@/decorators/trim-string.decorator'
+import { NonEmptyTrimmedString } from '@/decorators/non-empty-trimmed-string.decorator'
 
 export class CreateSecret {
-  @IsString()
-  @IsNotEmpty()
-  @TrimString()
+  @NonEmptyTrimmedString()
   name: string
 
-  @IsString()
   @IsOptional()
   @Length(0, 100)
+  @NonEmptyTrimmedString()
   note?: string
 
   @IsString()
@@ -33,13 +31,9 @@ export class CreateSecret {
 }
 
 class Entry {
-  @IsString()
-  @IsNotEmpty()
-  @TrimString()
+  @NonEmptyTrimmedString()
   environmentSlug: string
 
-  @IsString()
-  @IsNotEmpty()
-  @TrimString()
+  @NonEmptyTrimmedString()
   value: string
 }

--- a/apps/api/src/variable/dto/create.variable/create.variable.ts
+++ b/apps/api/src/variable/dto/create.variable/create.variable.ts
@@ -7,16 +7,15 @@ import {
   Length,
   ValidateNested
 } from 'class-validator'
+import { NonEmptyTrimmedString } from '@/decorators/non-empty-trimmed-string.decorator'
 
 export class CreateVariable {
-  @IsString()
-  @Transform(({ value }) => value.trim())
+  @NonEmptyTrimmedString()
   name: string
 
-  @IsString()
   @IsOptional()
   @Length(0, 100)
-  @Transform(({ value }) => (value ? value.trim() : null))
+  @NonEmptyTrimmedString()
   note?: string
 
   @IsOptional()
@@ -27,11 +26,9 @@ export class CreateVariable {
 }
 
 class Entry {
-  @IsString()
-  @Transform(({ value }) => value.trim())
+  @NonEmptyTrimmedString()
   environmentSlug: string
 
-  @IsString()
-  @Transform(({ value }) => value.trim())
+  @NonEmptyTrimmedString()
   value: string
 }

--- a/apps/api/src/variable/variable.e2e.spec.ts
+++ b/apps/api/src/variable/variable.e2e.spec.ts
@@ -252,9 +252,7 @@ describe('Variable Controller Tests', () => {
       const messages = response.json().message
 
       expect(messages).toHaveLength(1)
-      expect(messages[0]).toEqual(
-        'name should not be empty'
-      )
+      expect(messages[0]).toEqual('name should not be empty')
     })
 
     it('should not be able to create a variable with a non-existing environment', async () => {
@@ -391,9 +389,7 @@ describe('Variable Controller Tests', () => {
       const messages = response.json().message
 
       expect(messages).toHaveLength(1)
-      expect(messages[0]).toEqual(
-        'name should not be empty'
-      )
+      expect(messages[0]).toEqual('name should not be empty')
     })
 
     it('should not be able to update a variable with same name in the same project', async () => {

--- a/apps/api/src/variable/variable.e2e.spec.ts
+++ b/apps/api/src/variable/variable.e2e.spec.ts
@@ -37,6 +37,7 @@ import { UserService } from '@/user/service/user.service'
 import { UserModule } from '@/user/user.module'
 import { QueryTransformPipe } from '@/common/pipes/query.transform.pipe'
 import { fetchEvents } from '@/common/event'
+import { ValidationPipe } from '@nestjs/common'
 
 describe('Variable Controller Tests', () => {
   let app: NestFastifyApplication
@@ -84,7 +85,13 @@ describe('Variable Controller Tests', () => {
     eventService = moduleRef.get(EventService)
     userService = moduleRef.get(UserService)
 
-    app.useGlobalPipes(new QueryTransformPipe())
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true
+      }),
+      new QueryTransformPipe()
+    )
 
     await app.init()
     await app.getHttpAdapter().getInstance().ready()
@@ -186,7 +193,7 @@ describe('Variable Controller Tests', () => {
           entries: [
             {
               value: 'Variable 3 value',
-              environmentId: environment2.id
+              environmentSlug: environment2.slug
             }
           ]
         },
@@ -226,6 +233,28 @@ describe('Variable Controller Tests', () => {
       expect(variableVersion).toBeDefined()
       expect(variableVersion.value).toBe('Variable 1 value')
       expect(variableVersion.version).toBe(1)
+    })
+
+    it('should not be able to create variable with empty name', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/variable/${project1.slug}`,
+        payload: {
+          name: ' '
+        },
+        headers: {
+          'x-e2e-user-email': user1.email
+        }
+      })
+
+      expect(response.statusCode).toBe(400)
+
+      const messages = response.json().message
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toEqual(
+        'name should not be empty'
+      )
     })
 
     it('should not be able to create a variable with a non-existing environment', async () => {
@@ -342,6 +371,28 @@ describe('Variable Controller Tests', () => {
       expect(response.statusCode).toBe(404)
       expect(response.json().message).toEqual(
         'Variable non-existing-variable-slug not found'
+      )
+    })
+
+    it('should not be able to update variable with empty name', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/variable/${variable1.slug}`,
+        payload: {
+          name: ' '
+        },
+        headers: {
+          'x-e2e-user-email': user1.email
+        }
+      })
+
+      expect(response.statusCode).toBe(400)
+
+      const messages = response.json().message
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toEqual(
+        'name should not be empty'
       )
     })
 


### PR DESCRIPTION
### **User description**
## Description

`NonEmptyTrimmedString` validation decorator has been created and added to CreateVariable/UpdateVariable DTOs in order to avoid any variables with empty names created or updated to.

Related to #702

## Developer's checklist

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-check on my work

**If changes are made in the code:**

- [X] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [X] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [X] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [X] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [X] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Introduced `NonEmptyTrimmedString` decorator to validate non-empty, trimmed strings.

- Replaced individual string validation logic with `NonEmptyTrimmedString` in DTOs.

- Enhanced e2e tests to validate empty name scenarios for variables and secrets.

- Updated global validation pipeline to include `ValidationPipe` for stricter validation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>non-empty-trimmed-string.decorator.ts</strong><dd><code>Introduced `NonEmptyTrimmedString` decorator for validation</code></dd></summary>
<hr>

apps/api/src/decorators/non-empty-trimmed-string.decorator.ts

<li>Added a new decorator <code>NonEmptyTrimmedString</code>.<br> <li> Combines <code>TrimmedString</code> and <code>IsNotEmpty</code> for validation.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-fdd940e6fa963c42f624dc052e3d3a459a224a72cb34f4d11e384e9ce27a9351">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trimmed-string.decorator.ts</strong><dd><code>Added `TrimmedString` decorator for string validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/decorators/trimmed-string.decorator.ts

<li>Added <code>TrimmedString</code> decorator combining <code>TrimString</code> and <code>IsString</code>.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-646f6bdc37d1439436898f96d891eb55039ef22b35be53d35b5040aa68f4bce6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create.secret.ts</strong><dd><code>Updated secret DTO to use `NonEmptyTrimmedString`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/secret/dto/create.secret/create.secret.ts

<li>Replaced individual string validation with <code>NonEmptyTrimmedString</code>.<br> <li> Applied to <code>name</code>, <code>note</code>, and <code>Entry</code> fields.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-0ba28109a277c57e22c8bdc661163b0d1f3b4ae8171a89d3fc72cf3e620529cb">+5/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create.variable.ts</strong><dd><code>Updated variable DTO to use `NonEmptyTrimmedString`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/variable/dto/create.variable/create.variable.ts

<li>Replaced individual string validation with <code>NonEmptyTrimmedString</code>.<br> <li> Applied to <code>name</code>, <code>note</code>, and <code>Entry</code> fields.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-f00a0e578eb924e62fd50241ef8fb0583302b9737b42c98cf2f41b965b42c5c3">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trim-string.decorator.ts</strong><dd><code>Adjusted formatting in `TrimString` decorator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/decorators/trim-string.decorator.ts

- Minor formatting changes for better readability.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-0bb9256b80801dbf23605f7804ae8cdd0950cd3f745120e040168d504fe9cd8e">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.e2e.spec.ts</strong><dd><code>Adjusted e2e tests for secret validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/secret/secret.e2e.spec.ts

- Simplified test assertions for empty name validation.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-598db59202ce7ecc8d2fb84528577afd14eac8275a30e174d704d6fc2b7f5c3b">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variable.e2e.spec.ts</strong><dd><code>Enhanced e2e tests for variable validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/variable/variable.e2e.spec.ts

<li>Added tests for empty name validation in variable creation and <br>updates.<br> <li> Updated global validation pipeline with <code>ValidationPipe</code>.<br> <li> Adjusted test payloads for stricter validation.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/745/files#diff-dceae01334e43922248d77f3d530ea057a22b95852ff26c944841e3ace70ef9d">+49/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>