### PR TITLE
fix: Avoid toast duplication & added optional description

### DIFF
--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/layout.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/layout.tsx
@@ -12,7 +12,6 @@ import SecretPage from './@secret/page'
 import EnvironmentPage from './@environment/page'
 import ControllerInstance from '@/lib/controller-instance'
 import AddSecretDialog from '@/components/dashboard/secret/addSecretDialogue'
-import { Toaster } from '@/components/ui/sonner'
 import { selectedProjectAtom, environmentsOfProjectAtom } from '@/store'
 import AddVariableDialogue from '@/components/dashboard/variable/addVariableDialogue'
 import AddEnvironmentDialogue from '@/components/dashboard/environment/addEnvironmentDialogue'
@@ -106,7 +105,6 @@ function DetailedProjectPage({
         {tab === 'variable' && <VariablePage />}
         {tab === 'environment' && <EnvironmentPage />}
       </div>
-      <Toaster />
     </main>
   )
 }

--- a/apps/platform/src/lib/clipboard.ts
+++ b/apps/platform/src/lib/clipboard.ts
@@ -1,17 +1,23 @@
+import { createElement } from 'react'
 import { toast } from 'sonner'
 
 export function copyToClipboard(
   message: string,
   successMsg = 'Text copied to clipboard!',
-  errorMsg = 'Failed to copy text.'
+  errorMsg = 'Failed to copy text.',
+  description?: string
 ): void {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- navigator.clipboard is checked
   if (navigator.clipboard) {
     navigator.clipboard
       .writeText(message)
-      .then(() => toast.success(successMsg))
+      .then(() => toast.success(successMsg, {
+        description: description ? createElement('p', { className: 'text-xs text-green-300' }, description) : null,
+      }))
       .catch((error) => {
-        toast.error(errorMsg)
+        toast.error(errorMsg, {
+          description: description ? createElement('p', { className: 'text-xs text-red-300' }, description) : null,
+        })
         // eslint-disable-next-line no-console -- console.error is used for debugging
         console.error(errorMsg, error)
       })


### PR DESCRIPTION
### **User description**
## Description
1. Eliminated redundant <Toaster /> from the layout file, as it was already included in the main layout. This prevents duplicate toasts from appearing.
2. Introduced an optional description argument to improve toast messaging when copying slugs (requirement for secret, variable, environment cards). Used `createElement `because it was a `.ts` file and we cannot use JSX outside React scope

Fixes #758

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b

## Screenshots of relevant screens
After the changes:
https://www.loom.com/share/b58d2d9325d64254a50538a9e44866c6

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed redundant `Toaster` component to prevent duplicate toasts.

- Enhanced `copyToClipboard` function with optional description support.

- Improved toast messaging for success and error scenarios.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove redundant `Toaster` to fix duplicate toasts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/app/(main)/(project)/[workspace]/[project]/layout.tsx

<li>Removed the redundant <code>Toaster</code> component from the layout.<br> <li> Prevented duplicate toast notifications by eliminating duplicate <br><code>Toaster</code> instances.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/759/files#diff-f0f3d6723aeef4841b772c43d01a0dbb6e5095bbe41eb89409c2c7f4ce8f5bfe">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clipboard.ts</strong><dd><code>Add optional description support for toast messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/lib/clipboard.ts

<li>Added optional <code>description</code> parameter to <code>copyToClipboard</code> function.<br> <li> Enhanced toast messages with optional descriptions for success and <br>error.<br> <li> Used <code>createElement</code> to dynamically create description elements.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/759/files#diff-069691a66e45a9ed266fd17f0f608cc0e6a8f11cfa6d679da574b9ed33788be9">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>