### PR TITLE
feat(platform): Add copy slug functionality to variable card context menu

### DIFF
--- a/apps/platform/src/components/dashboard/variable/variableCard/index.tsx
+++ b/apps/platform/src/components/dashboard/variable/variableCard/index.tsx
@@ -32,6 +32,7 @@ import {
   AccordionItem,
   AccordionTrigger
 } from '@/components/ui/accordion'
+import { copyToClipboard } from '@/lib/clipboard'
 
 export default function VariableCard(
   variableData: GetAllVariablesOfProjectResponse['items'][number]
@@ -41,6 +42,10 @@ export default function VariableCard(
   const setIsDeleteVariableOpen = useSetAtom(deleteVariableOpenAtom)
 
   const { variable, values } = variableData
+
+  const handleCopyToClipboard = () => {
+    copyToClipboard(variable.slug, 'You copied the slug successfully.', 'Failed to copy the slug.', 'You successfully copied the slug.')
+  }
 
   const handleEditClick = () => {
     setSelectedVariable(variableData)
@@ -126,9 +131,15 @@ export default function VariableCard(
           </Table>
         </AccordionContent>
       </AccordionItem>
-      <ContextMenuContent className="flex h-[6.375rem] w-[15.938rem] flex-col items-center justify-center rounded-lg bg-[#3F3F46]">
+      <ContextMenuContent className="flex w-[15.938rem] flex-col items-center justify-center rounded-lg bg-[#3F3F46]">
         <ContextMenuItem className="h-[33%] w-[15.938rem] border-b-[0.025rem] border-white/65 text-xs font-semibold tracking-wide">
           Show Version History
+        </ContextMenuItem>
+        <ContextMenuItem
+        className="w-[15.938rem] py-2 border-b-[0.025rem] border-white/65 text-xs font-semibold tracking-wide"
+        onSelect={handleCopyToClipboard}
+        >
+          Copy Slug
         </ContextMenuItem>
         <ContextMenuItem
           className="h-[33%] w-[15.938rem] text-xs font-semibold tracking-wide"


### PR DESCRIPTION
### **User description**
## Description
This PR adds an option 'Copy slug' to the context menu on variable card and upon selecting that option, the re-usable util `copyToClipboard` function is called and the toast is shown.

Fixes #732 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens
After the changes:

![Screenshot (103)](https://github.com/user-attachments/assets/5dd356c7-2afd-4e96-9b40-25ef60941e4e)
![Screenshot (100)](https://github.com/user-attachments/assets/db869b01-bfd7-49aa-950d-6410d51e4c49)

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


___

### **PR Type**
Enhancement


___

### **Description**
- Added "Copy Slug" option to variable card context menu.

- Implemented `handleCopyToClipboard` function using `copyToClipboard` utility.

- Updated UI to include the new context menu item.

- Enhanced user feedback with success/error toast messages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add "Copy Slug" option and clipboard functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/dashboard/variable/variableCard/index.tsx

<li>Imported <code>copyToClipboard</code> utility for clipboard operations.<br> <li> Added <code>handleCopyToClipboard</code> function to handle slug copying.<br> <li> Updated context menu to include "Copy Slug" option.<br> <li> Integrated toast messages for success and error feedback.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/769/files#diff-e0ee923c7b536f5a579b3a5f0079e32b5501ab2dd0edde64181421db9ef2425d">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>