### PR TITLE
feat: Added Pagination to Environments Screen

### DIFF
--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
@@ -77,7 +77,7 @@ function EnvironmentPage(): React.JSX.Element {
           <div
             className={`grid h-fit w-full grid-cols-1 gap-8  p-3 text-white md:grid-cols-2 xl:grid-cols-3 ${isDeleteEnvironmentOpen ? 'inert' : ''} `}
           >
-            {environments.slice(0, visibleCount).map((environment) => (
+            {environments?.slice(0, visibleCount)?.map((environment) => (
               <EnvironmentCard environment={environment} key={environment.id} />
             ))}
 

--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
@@ -18,7 +18,7 @@ import ControllerInstance from '@/lib/controller-instance'
 import { Button } from '@/components/ui/button'
 import { useHttp } from '@/hooks/use-http'
 
-const INITIAL_DISPLAY_COUNT = 4
+const INITIAL_DISPLAY_COUNT = 10
 
 function EnvironmentPage(): React.JSX.Element {
   const setIsCreateEnvironmentOpen = useSetAtom(createEnvironmentOpenAtom)

--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
@@ -34,25 +34,24 @@ function EnvironmentPage(): React.JSX.Element {
       {
         projectSlug: selectedProject!.slug,
         page,
+        limit:1
       }
     )
   )
 
   useEffect(() => {
-  if(!selectedProject) return
-   handleEnvironmentsFetch();
-  }, [selectedProject, getAllEnvironmentsOfProject, setEnvironments])
+    fetchEnvironments();
+  }, [selectedProject, getAllEnvironmentsOfProject, setEnvironments,page])
 
-  const handleEnvironmentsFetch = (newPage = 0) => {
+  const fetchEnvironments = () => {
     if (!selectedProject) return
     setIsLoading(true)
     getAllEnvironmentsOfProject()
       .then(({ data, success }) => {
         if (success && data) {
-          const newData = newPage === 0 ? data.items : [...environments, ...data.items]
-          if(newPage == 0 && page !== 0) setPage(0);
+          const newData = page === 0 ? data.items : [...environments, ...data.items]
           setEnvironments(newData)
-          if (newData.length >= data.metadata.totalCount) setHasMore(false)
+          if (!data.metadata.links.next) setHasMore(false)
         }
       })
       .finally(() => {
@@ -64,7 +63,6 @@ function EnvironmentPage(): React.JSX.Element {
     if (hasMore && !isLoading) {
       const finalPage = page + 1;
       setPage(finalPage)
-      handleEnvironmentsFetch(finalPage)
     }
   }
 

--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { EnvironmentSVG } from '@public/svg/dashboard'
 import {
@@ -18,6 +18,8 @@ import ControllerInstance from '@/lib/controller-instance'
 import { Button } from '@/components/ui/button'
 import { useHttp } from '@/hooks/use-http'
 
+const INITIAL_DISPLAY_COUNT = 4
+
 function EnvironmentPage(): React.JSX.Element {
   const setIsCreateEnvironmentOpen = useSetAtom(createEnvironmentOpenAtom)
   const isDeleteEnvironmentOpen = useAtomValue(deleteEnvironmentOpenAtom)
@@ -25,6 +27,7 @@ function EnvironmentPage(): React.JSX.Element {
   const [environments, setEnvironments] = useAtom(environmentsOfProjectAtom)
   const selectedProject = useAtomValue(selectedProjectAtom)
   const selectedEnvironment = useAtomValue(selectedEnvironmentAtom)
+  const [visibleCount, setVisibleCount] = useState<number>(INITIAL_DISPLAY_COUNT)
 
   const getAllEnvironmentsOfProject = useHttp(() =>
     ControllerInstance.getInstance().environmentController.getAllEnvironmentsOfProject(
@@ -69,23 +72,30 @@ function EnvironmentPage(): React.JSX.Element {
           </Button>
         </div>
       ) : (
-        // Showing this when environments are present
-        <div
-          className={`grid h-fit w-full grid-cols-1 gap-8  p-3 text-white md:grid-cols-2 xl:grid-cols-3 ${isDeleteEnvironmentOpen ? 'inert' : ''} `}
-        >
-          {environments.map((environment) => (
-            <EnvironmentCard environment={environment} key={environment.id} />
-          ))}
+        //Showing this when environments are present
+        <div className="flex w-full flex-col">
+          <div
+            className={`grid h-fit w-full grid-cols-1 gap-8  p-3 text-white md:grid-cols-2 xl:grid-cols-3 ${isDeleteEnvironmentOpen ? 'inert' : ''} `}
+          >
+            {environments.slice(0, visibleCount).map((environment) => (
+              <EnvironmentCard environment={environment} key={environment.id} />
+            ))}
 
-          {/* Delete environment alert dialog */}
-          {isDeleteEnvironmentOpen && selectedEnvironment ? (
-            <ConfirmDeleteEnvironment />
-          ) : null}
+            {/* Delete environment alert dialog */}
+            {isDeleteEnvironmentOpen && selectedEnvironment ? (
+              <ConfirmDeleteEnvironment />
+            ) : null}
 
-          {/* Edit environment dialog */}
-          {isEditEnvironmentOpen && selectedEnvironment ? (
-            <EditEnvironmentDialogue />
-          ) : null}
+            {/* Edit environment dialog */}
+            {isEditEnvironmentOpen && selectedEnvironment ? (
+              <EditEnvironmentDialogue />
+            ) : null}
+          </div>
+          {visibleCount < environments.length && (
+            <div className="my-2 flex w-full justify-center py-2">
+              <Button onClick={()=> setVisibleCount((prev) => prev + INITIAL_DISPLAY_COUNT)}>Load More</Button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx
@@ -27,7 +27,7 @@ function EnvironmentPage(): React.JSX.Element {
   const selectedEnvironment = useAtomValue(selectedEnvironmentAtom)
   const [page, setPage] = useState(0)
   const [hasMore, setHasMore] = useState(true)
-  const [loading, setLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
 
   const getAllEnvironmentsOfProject = useHttp(() =>
     ControllerInstance.getInstance().environmentController.getAllEnvironmentsOfProject(
@@ -39,24 +39,32 @@ function EnvironmentPage(): React.JSX.Element {
   )
 
   useEffect(() => {
-    if (!selectedProject) return 
-    setLoading(true)
+  if(!selectedProject) return
+   handleEnvironmentsFetch();
+  }, [selectedProject, getAllEnvironmentsOfProject, setEnvironments])
+
+  const handleEnvironmentsFetch = (newPage = 0) => {
+    if (!selectedProject) return
+    setIsLoading(true)
     getAllEnvironmentsOfProject()
       .then(({ data, success }) => {
         if (success && data) {
-          const newData = page === 0 ? data.items : [...environments, ...data.items];
-          setEnvironments(newData);
-          if (newData.length >= data.metadata.totalCount) setHasMore(false);
+          const newData = newPage === 0 ? data.items : [...environments, ...data.items]
+          if(newPage == 0 && page !== 0) setPage(0);
+          setEnvironments(newData)
+          if (newData.length >= data.metadata.totalCount) setHasMore(false)
         }
       })
       .finally(() => {
-        setLoading(false)
+        setIsLoading(false)
       })
-  }, [selectedProject, page, getAllEnvironmentsOfProject, setEnvironments])
+  }
 
   const handlePageShift = () => {
-    if (hasMore && !loading) {
-      setPage(prevPage => prevPage + 1)
+    if (hasMore && !isLoading) {
+      const finalPage = page + 1;
+      setPage(finalPage)
+      handleEnvironmentsFetch(finalPage)
     }
   }
 
@@ -105,14 +113,14 @@ function EnvironmentPage(): React.JSX.Element {
               <EditEnvironmentDialogue />
             ) : null}
 
-            {hasMore ? <div className="col-span-full flex justify-center">
-              <Button disabled={loading} onClick={handlePageShift}>
-                {loading ? 'Loading...' : 'Load More'}
-              </Button>
-            </div> : null}
-
+            {hasMore ? (
+              <div className="col-span-full flex justify-center">
+                <Button disabled={isLoading} onClick={handlePageShift}>
+                  {isLoading ? 'Loading...' : 'Load More'}
+                </Button>
+              </div>
+            ) : null}
           </div>
-          
         </div>
       )}
     </div>

--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/layout.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/layout.tsx
@@ -49,15 +49,6 @@ function DetailedProjectPage({
     })
   }, [getProject, params.project, setSelectedProject])
 
-  useEffect(() => {
-    selectedProject &&
-      getAllEnvironmentsOfProject().then(({ data, success }) => {
-        if (success && data) {
-          setEnvironments(data.items)
-        }
-      })
-  }, [getAllEnvironmentsOfProject, selectedProject, setEnvironments])
-
   return (
     <main className="flex h-full flex-col gap-4">
       <div className="flex h-[3.625rem] w-full justify-between p-3 ">


### PR DESCRIPTION
### **User description**
## Description

Now we dont get the all environments at one , now we can get it in the batch of 10 if user wants to see the next 10 environments they have to click on Load More Button  <br />

Fixes #707 

## Screenshots of relevant screens

<img width="1175" alt="Screenshot 2025-02-22 at 5 08 14 PM" src="https://github.com/user-attachments/assets/9e23a967-001b-41c4-b4cb-cfe7394d0822" />

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [ ] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Enhancement


___

### **Description**
- Added dynamic pagination to the environments page.

- Introduced a "Load More" button for additional environments.

- Limited initial environment display to 10 items.

- Updated UI layout to support dynamic loading.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Added dynamic pagination and "Load More" button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/app/(main)/(project)/[workspace]/[project]/@environment/page.tsx

<li>Added state management for visible environment count.<br> <li> Limited initial environment display to 10 items.<br> <li> Added "Load More" button to load additional environments.<br> <li> Updated UI structure to support dynamic pagination.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/780/files#diff-76129d9136c96acb95230b4518a5749ad0f04d42482a700f84f93a267dfc1d29">+26/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>