### PR TITLE
fix(api): Issue with authorities and expiry field update in API Key

### DIFF
--- a/api-collection/Api Key Controller/Update API key.bru
+++ b/api-collection/Api Key Controller/Update API key.bru
@@ -11,7 +11,7 @@ put {
 }
 
 params:path {
-  api_key_slug: my-key-2
+  api_key_slug: test-key-0
 }
 
 auth:bearer {
@@ -20,18 +20,7 @@ auth:bearer {
 
 body:json {
   {
-      "authorities": [
-          "READ_API_KEY",
-          "READ_WORKSPACE",
-          "READ_PROJECT",
-          "READ_ENVIRONMENT",
-          "READ_VARIABLE",
-          "READ_SECRET",
-          "CREATE_WORKSPACE",
-          "UPDATE_WORKSPACE",
-          "DELETE_WORKSPACE",
-          "WORKSPACE_ADMIN"
-      ]
+    "expiresAfter": "never"
   }
 }
 

--- a/apps/api/src/api-key/dto/create.api-key/create.api-key.ts
+++ b/apps/api/src/api-key/dto/create.api-key/create.api-key.ts
@@ -11,5 +11,5 @@ export class CreateApiKey {
 
   @IsArray()
   @IsOptional()
-  authorities?: Authority[] = []
+  authorities?: Authority[]
 }

--- a/apps/api/src/api-key/service/api-key.service.ts
+++ b/apps/api/src/api-key/service/api-key.service.ts
@@ -125,9 +125,7 @@ export class ApiKeyService {
         slug: dto.name
           ? await generateEntitySlug(dto.name, 'API_KEY', this.prisma)
           : apiKey.slug,
-        authorities: {
-          set: dto.authorities ? dto.authorities : apiKey.authorities
-        },
+        authorities: dto.authorities ? dto.authorities : undefined,
         expiresAt: dto.expiresAfter
           ? addHoursToDate(dto.expiresAfter)
           : undefined

--- a/apps/api/src/common/util.ts
+++ b/apps/api/src/common/util.ts
@@ -98,8 +98,8 @@ export const excludeFields = <T, K extends keyof T>(
  * @param hours The number of hours to add to the current date
  * @returns The new date with the given number of hours added, or undefined if the hours is 'never'
  */
-export const addHoursToDate = (hours?: string | number): Date | undefined => {
-  if (!hours || hours === 'never') return undefined
+export const addHoursToDate = (hours?: string | number): Date | null => {
+  if (!hours || hours === 'never') return null
 
   const date = new Date()
   date.setHours(date.getHours() + +hours)


### PR DESCRIPTION
### **User description**
## Description

- `authorities` field was being set to `[]` even if no value was being specified
- `expiresAt` had prisma update error


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed `authorities` field default behavior in API Key creation.

- Resolved Prisma update error for `expiresAt` field.

- Updated `addHoursToDate` utility to return `null` instead of `undefined`.

- Adjusted API Key update request example in test file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.api-key.ts</strong><dd><code>Adjusted `authorities` field default behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/dto/create.api-key/create.api-key.ts

<li>Removed default empty array for <code>authorities</code> field.<br> <li> Ensured <code>authorities</code> is optional without default assignment.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/800/files#diff-a2638a572cac33510d842a287298ea994a8e41236c56ad51eabb84bbf905df12">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api-key.service.ts</strong><dd><code>Fixed Prisma update logic for API Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/api-key/service/api-key.service.ts

<li>Updated <code>authorities</code> field handling in API Key update logic.<br> <li> Fixed Prisma update logic for <code>expiresAt</code> field.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/800/files#diff-9fefafaa7fbbd90c1f65410a2414bfab311e6faeb1277c532fe372060a33ebef">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.ts</strong><dd><code>Updated `addHoursToDate` utility return behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/common/util.ts

<li>Modified <code>addHoursToDate</code> to return <code>null</code> instead of <code>undefined</code>.<br> <li> Improved clarity in handling <code>never</code> and undefined cases.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/800/files#diff-3d0310bffc5afe26e8cfb89a0bc51d425e4b96516c0e09bf82f3f9f862335806">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Update API key.bru</strong><dd><code>Adjusted API Key update test example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api-collection/Api Key Controller/Update API key.bru

<li>Updated example API Key slug in test file.<br> <li> Simplified example request body to focus on <code>expiresAfter</code>.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/800/files#diff-40243ee4d5c914354d5d911903ca77df86b8b0eddcf1909c6e9c8c86de7190dd">+2/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>