### PR TITLE
fix(platfrom): navigation tab render bug

### DIFF
--- a/apps/platform/src/components/shared/navbar/index.tsx
+++ b/apps/platform/src/components/shared/navbar/index.tsx
@@ -18,38 +18,34 @@ import {
 } from '@/components/ui/dropdown-menu'
 import LineTab from '@/components/ui/line-tab'
 import AvatarComponent from '@/components/common/avatar'
-import { selectedProjectAtom, userAtom } from '@/store'
+import { selectedProjectAtom, selectedWorkspaceAtom, userAtom } from '@/store'
+
+interface Tab {
+  id: string
+  label: string
+  icon?: React.ReactNode
+}
 
 function Navbar(): React.JSX.Element {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [isApple, setIsApple] = useState<boolean>(false)
   const user = useAtomValue(userAtom)
   const selectedProject = useAtomValue(selectedProjectAtom)
+  const selectedWorkspace = useAtomValue(selectedWorkspaceAtom)
 
   const pathname = usePathname()
 
-  const settingsTabs = [
-    { id: 'profile', label: 'Profile' },
-    { id: 'billing', label: 'Billing' }
-  ]
-
-  const projectTabs = [
-    {
-      id: 'secret',
-      label: 'Secret',
-      icon: <SecretSVG />
-    },
-    {
-      id: 'variable',
-      label: 'Variable',
-      icon: <VariableSVG />
-    },
-    {
-      id: 'environment',
-      label: 'Environment',
-      icon: <EnvironmentSVG />
-    }
-  ]
+  const TAB_CONFIGS = {
+    settings: [
+      { id: 'profile', label: 'Profile' },
+      { id: 'billing', label: 'Billing' }
+    ],
+    project: [
+      { id: 'secret', label: 'Secret', icon: <SecretSVG /> },
+      { id: 'variable', label: 'Variable', icon: <VariableSVG /> },
+      { id: 'environment', label: 'Environment', icon: <EnvironmentSVG /> }
+    ]
+  }
 
   useEffect(() => {
     const down = (e: KeyboardEvent): void => {
@@ -83,6 +79,30 @@ function Navbar(): React.JSX.Element {
     // Using window.location because at times next router throws up this error: https://nextjs.org/docs/messages/next-router-not-mounted
     window.location.href = '/auth'
   }, [])
+
+  const getProjectPath = (): string => 
+    selectedWorkspace?.slug && selectedProject?.slug 
+      ? `/${selectedWorkspace.slug}/${selectedProject.slug}`
+      : ''
+
+  const shouldRenderTab = (): boolean => {
+    const allowedPaths = ['/settings', getProjectPath()] // modify the list based on what paths you want to have tab
+    return pathname !== '/' && allowedPaths.includes(pathname)
+  }
+
+  const renderTabs = (): Tab[] => {
+    // You need to update the case if you want to have a tab for a specific path
+    switch (pathname) {
+      case `/${selectedWorkspace?.slug}/${selectedProject?.slug}`:
+        return TAB_CONFIGS.project
+
+      case '/settings':
+        return TAB_CONFIGS.settings
+
+      default:
+        return []
+    }
+  }
 
   return (
     <>
@@ -153,18 +173,9 @@ function Navbar(): React.JSX.Element {
               </DropdownMenu>
             </div>
             <div className="px-4">
-              {pathname !== '/' &&
-                (pathname === '/settings' ||
-                  pathname.split('/')[2] === selectedProject?.slug) && (
-                  <LineTab
-                    customID="linetab"
-                    tabs={
-                      pathname.split('/')[2] === selectedProject?.slug
-                        ? projectTabs
-                        : settingsTabs
-                    }
-                  />
-                )}
+              {shouldRenderTab() && (
+                <LineTab customID="linetab" tabs={renderTabs()} />
+              )}
             </div>
           </nav>
           <SearchModel isOpen={isOpen} setIsOpen={setIsOpen} />


### PR DESCRIPTION
### **User description**
## Description


This pull request includes significant changes to the `Navbar` component in the `apps/platform/src/components/shared/navbar/index.tsx` file. The changes aim to improve the tab rendering logic and introduce new configurations for tabs based on the selected workspace and project.

### Improvements to tab rendering logic:

* Added `selectedWorkspaceAtom` to the imports and updated the component to use the `selectedWorkspace` state.
* Introduced a `Tab` interface and a `TAB_CONFIGS` object to centralize tab configurations for different paths.
* Added a `getProjectPath` function to dynamically construct the project path based on the selected workspace and project.
* Added a `shouldRenderTab` function to determine if tabs should be rendered based on the current pathname.
* Refactored the tab rendering logic to use the `shouldRenderTab` and `renderTabs` functions, simplifying the JSX structure.<br />

## Screenshots of relevant screens

_Add screenshots of relevant screens_

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed navigation tab rendering bug in `Navbar`.

- Introduced `Tab` interface and centralized `TAB_CONFIGS`.

- Added `getProjectPath` and `shouldRenderTab` functions for dynamic tab rendering.

- Simplified JSX structure using `renderTabs` function.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Enhanced and fixed tab rendering in `Navbar`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/shared/navbar/index.tsx

<li>Fixed navigation tab rendering logic.<br> <li> Added <code>Tab</code> interface and <code>TAB_CONFIGS</code> for tab configuration.<br> <li> Introduced <code>getProjectPath</code> and <code>shouldRenderTab</code> functions.<br> <li> Refactored JSX to use <code>renderTabs</code> for cleaner structure.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/817/files#diff-1463cdbabc4495c0e3893848022efb23ea972381c8d4de0f1ad206b210a0a6ca">+46/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>