### PR TITLE
fix(platform): ui issues on otp & session expiry toasts

### DIFF
--- a/apps/platform/src/app/auth/otp/page.tsx
+++ b/apps/platform/src/app/auth/otp/page.tsx
@@ -25,7 +25,6 @@ export default function AuthOTPPage(): React.JSX.Element {
 
   const [otp, setOtp] = useState<string>('')
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [isLoadingRefresh, setIsLoadingRefresh] = useState<boolean>(false)
 
   const router = useRouter()
 
@@ -80,7 +79,6 @@ export default function AuthOTPPage(): React.JSX.Element {
     }
 
     setIsLoading(true)
-    setIsLoadingRefresh(true)
     toast.loading('Verifying OTP...')
 
     try {
@@ -104,7 +102,6 @@ export default function AuthOTPPage(): React.JSX.Element {
       }
     } finally {
       setIsLoading(false)
-      setIsLoadingRefresh(false)
       toast.dismiss()
     }
   }
@@ -115,7 +112,6 @@ export default function AuthOTPPage(): React.JSX.Element {
     }
 
     setIsLoading(true)
-    setIsLoadingRefresh(true)
     toast.loading('Sending OTP...')
 
     try {
@@ -126,7 +122,6 @@ export default function AuthOTPPage(): React.JSX.Element {
       }
     } finally {
       setIsLoading(false)
-      setIsLoadingRefresh(false)
       toast.dismiss()
     }
   }
@@ -180,24 +175,16 @@ export default function AuthOTPPage(): React.JSX.Element {
             >
               {isLoading ? <LoadingSVG className="w-10" /> : 'Verify'}
             </Button>
-            <div className="space-x-reverse-2 flex items-center justify-center text-[#71717A]">
+            <div className="gap-2 flex items-center justify-center text-[#71717A]">
               <span>Didn’t receive OTP?</span>
-              <span>
-                {isLoadingRefresh ? (
-                  <span>
-                    <LoadingSVG className="h-10 w-10" />
-                  </span>
-                ) : (
-                  <Button
-                    className="text-[#71717A]"
-                    disabled={isLoading}
-                    onClick={handleResendOtp}
-                    variant="link"
-                  >
-                    Resend OTP
-                  </Button>
-                )}
-              </span>
+              <Button
+                className="text-[#71717A]"
+                disabled={isLoading}
+                onClick={handleResendOtp}
+                variant="link"
+              >
+                Resend OTP
+              </Button>
             </div>
           </form>
         </div>

--- a/apps/platform/src/hooks/use-http.ts
+++ b/apps/platform/src/hooks/use-http.ts
@@ -6,12 +6,23 @@ import { toast } from 'sonner'
 import * as Sentry from '@sentry/nextjs'
 import { logout } from '@/lib/utils'
 
+// Add a flag to track if we've already shown the session expired toast
+let isHandling403 = false
+
 function handle403() {
+  if (isHandling403) return
+
+  isHandling403 = true
+
   toast.info('Session expired', {
-    description: 'Session expired. Please sign in again.'
+    description: createElement('p', { className: 'text-xs text-blue-300' }, 'Session expired. Please sign in again.')
   })
 
   logout()
+
+  setTimeout(() => {
+    isHandling403 = false
+  }, 1000)
 }
 
 function handle500(error) {

--- a/apps/platform/src/hooks/use-http.ts
+++ b/apps/platform/src/hooks/use-http.ts
@@ -22,7 +22,7 @@ function handle403() {
 
   setTimeout(() => {
     isHandling403 = false
-  }, 1000)
+  }, 5000)
 }
 
 function handle500(error) {


### PR DESCRIPTION
### **User description**
## Description
This PR solves the following
1. The "Resend OTP" button is being disabled instead of showing a loading state resulting in cleanup of certain code.
2. Only one "Session Expired" toast is displayed at a time & the description text color is of blue shade.

Fixes #829 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens

Issue 1: OTP Resend Button Behavior
![Screenshot (118)](https://github.com/user-attachments/assets/f1a1ebfd-932c-4cbe-850f-7a6983ad625f)

Issue 2: Duplicate Session Expiry Notifications & Color Issue
![Screenshot (119)](https://github.com/user-attachments/assets/5fcfb1cf-cb5d-48cf-ad43-5953c04a73b7)

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed "Resend OTP" button to disable instead of showing a loading state.

- Prevented multiple "Session Expired" toasts from appearing simultaneously.

- Updated "Session Expired" toast description text to match the blue shade.

- Removed unnecessary loading state management for OTP resend functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-http.ts</strong><dd><code>Prevent duplicate session expiry toasts and update text color</code></dd></summary>
<hr>

apps/platform/src/hooks/use-http.ts

<li>Added a flag to prevent multiple "Session Expired" toasts.<br> <li> Updated toast description text to use a blue shade.<br> <li> Reset the flag after a timeout to allow future toasts.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/832/files#diff-46acad8eaa400ab49cdf1da41046c900df586191cbadafa4c77f444770db7bdf">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactor OTP resend button behavior and UI logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/app/auth/otp/page.tsx

<li>Removed unnecessary loading state for OTP resend.<br> <li> Updated "Resend OTP" button to disable during loading.<br> <li> Simplified UI logic for OTP resend and verification.<br> <li> Adjusted button layout for better readability.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/832/files#diff-3ae286985cfeac090cabd429156a45eeaae5875dc9d9e23d93549e3b289387ba">+9/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>