### PR TITLE
feat(api): Return workspace membership creation date

### DIFF
--- a/apps/api/src/workspace-membership/workspace-membership.service.ts
+++ b/apps/api/src/workspace-membership/workspace-membership.service.ts
@@ -544,7 +544,8 @@ export class WorkspaceMembershipService {
             }
           }
         },
-        invitationAccepted: true
+        invitationAccepted: true,
+        createdOn: true
       }
     })
 

--- a/packages/schema/src/workspace-membership/index.ts
+++ b/packages/schema/src/workspace-membership/index.ts
@@ -94,6 +94,8 @@ export const GetMembersResponseSchema = PageResponseSchema(
           )
         })
       })
-    )
+    ),
+    invitationAccepted: z.boolean(),
+    createdOn: z.string().datetime()
   })
 )


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `createdOn` field to workspace membership service response.

- Updated schema to include `createdOn` and `invitationAccepted` fields.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace-membership.service.ts</strong><dd><code>Include `createdOn` field in workspace membership service</code></dd></summary>
<hr>

apps/api/src/workspace-membership/workspace-membership.service.ts

<li>Added <code>createdOn</code> field to the Prisma query response.<br> <li> Ensures the membership creation date is included in the API response.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/842/files#diff-fc343801ef5e7125005b1758ce379b5d4dffb01fbad63ab4fb11ea0ddb9a7db2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update schema to include `createdOn` and `invitationAccepted`</code></dd></summary>
<hr>

packages/schema/src/workspace-membership/index.ts

<li>Updated schema to include <code>createdOn</code> field as a datetime string.<br> <li> Added <code>invitationAccepted</code> field to the schema for completeness.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/842/files#diff-133bc36c619d172895a26aa9530700897d3da3105b7d253c5bb2f9c563206117">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>