### PR TITLE
fix: join waitlist email error

### DIFF
--- a/apps/web/src/components/hero/index.tsx
+++ b/apps/web/src/components/hero/index.tsx
@@ -95,7 +95,7 @@ function Hero(): React.JSX.Element {
 
           <form onSubmit={onSubmit}>
             <div className="flex flex-col items-center gap-[1rem] md:flex-row">
-              <InputBorderSpotlight setEmail={setEmail} />
+              <InputBorderSpotlight email={email} setEmail={setEmail} />
               <div className="border-brandBlue/[8%] rounded-full border p-[0.31rem] ">
                 <EncryptButton
                   TARGET_TEXT="Join Waitlist"

--- a/apps/web/src/components/ui/input-spotlight.tsx
+++ b/apps/web/src/components/ui/input-spotlight.tsx
@@ -3,10 +3,12 @@ import type { Dispatch, SetStateAction } from 'react'
 import React, { useRef, useState } from 'react'
 
 interface InputBorderSpotlightProps {
+  email: string
   setEmail: Dispatch<SetStateAction<string>>
 }
 
 export function InputBorderSpotlight({
+  email,
   setEmail
 }: InputBorderSpotlightProps): React.JSX.Element {
   const divRef = useRef<HTMLInputElement>(null)
@@ -60,6 +62,7 @@ export function InputBorderSpotlight({
         placeholder="Enter your email address"
         size={25}
         type="email"
+        value={email}
       />
       <input
         aria-hidden="true"


### PR DESCRIPTION
### **User description**
## Description

We are now drilling "email" state to the child component.
After the '/subscriber/post' call, now the input is becoming an empty string.

Fixes #721 

## Dependencies

NA

## Future Improvements

NA

## Mentions

NA

## Screenshots of relevant screens

https://github.com/user-attachments/assets/947db725-4708-4834-bc46-e6a511d0c37a

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced email handling in the waitlist form.

- Passed `email` state to `InputBorderSpotlight` component.

- Updated input field to reflect the `email` state value.

- Improved user experience for duplicate email error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Pass email state to child component in Hero</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/hero/index.tsx

<li>Passed <code>email</code> state to <code>InputBorderSpotlight</code> component.<br> <li> Modified the <code>InputBorderSpotlight</code> usage to include <code>email</code> prop.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/861/files#diff-7613ce5c9e898c20a2427ba5bf13810f61bb0a532139896e00a54cd0285ad40c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>input-spotlight.tsx</strong><dd><code>Add email prop and bind to input field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/ui/input-spotlight.tsx

<li>Added <code>email</code> prop to <code>InputBorderSpotlight</code> component.<br> <li> Updated input field to use <code>email</code> state as its value.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/861/files#diff-b2b2f8d48b38435bdbd6873279ce115d3b3e0e78822533218d06ca816b9c40fe">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>