### PR TITLE
fix(platform): UseEffectEvent Build error fix

### DIFF
--- a/apps/platform/next.config.ts
+++ b/apps/platform/next.config.ts
@@ -17,6 +17,10 @@ const nextConfig: NextConfig = {
 
     if (!isServer) {
       config.resolve.alias['@public'] = path.join(__dirname, 'public')
+      config.resolve.alias['@radix-ui/react-use-effect-event'] = path.resolve(
+        __dirname,
+        'stubs/use-effect-event.js'
+      )
     }
 
     return config

--- a/apps/platform/stubs/use-effect-event.js
+++ b/apps/platform/stubs/use-effect-event.js
@@ -1,0 +1,15 @@
+// stubs/use-effect-event.js
+import * as React from 'react'
+
+export function useEffectEvent(handler) {
+  // keep ref to latest handler
+  const handlerRef = React.useRef(handler)
+  React.useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  // return a stable callback that always calls the latest handler
+  return React.useCallback((...args) => {
+    return handlerRef.current(...args)
+  }, [])
+}


### PR DESCRIPTION
### **User description**
## Description

_Give a summary of the change that you have made_ <br />

Fixes #[ISSUENO]

## Dependencies

_Mention any dependencies/packages used_

## Future Improvements

_Mention any improvements to be done in future related to any file/feature_

## Mentions

_Mention and tag the people_

## Screenshots of relevant screens

_Add screenshots of relevant screens_

## Developer's checklist

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [ ] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Stubbed `@radix-ui/react-use-effect-event` for client-side builds to fix build errors.

- Added a custom implementation of `useEffectEvent` in a new stub file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Add client-side alias for use-effect-event to fix build</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/next.config.ts

<li>Added alias for <code>@radix-ui/react-use-effect-event</code> to use a local stub <br>during client builds.<br> <li> Ensured the alias is only set when not on the server.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/884/files#diff-5b4980c5964c39c153f873bc5fdf49f983f2cbec1045c81d7acc962fe1564c17">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-effect-event.js</strong><dd><code>Add stub for useEffectEvent with React hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/stubs/use-effect-event.js

<li>Created a stub implementation of <code>useEffectEvent</code> using React hooks.<br> <li> Ensures a stable callback referencing the latest handler.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/884/files#diff-aa67dc650c474a9b32d6d277a8eef00e159a4edbdcd5ea8e75f1011c280e404e">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>