### PR TITLE
fix(platform): roles tab breaking

### DIFF
--- a/apps/platform/src/components/common/avatar.tsx
+++ b/apps/platform/src/components/common/avatar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { User } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar'
 
 interface AvatarProps {
@@ -30,7 +31,7 @@ export default function AvatarComponent({
         src={profilePictureUrl === null ? undefined : profilePictureUrl}
       />
       <AvatarFallback className="font-semibold">
-        {getInitials(name)}
+        {name ? getInitials(name) : <User size={16} />}
       </AvatarFallback>
     </Avatar>
   )

--- a/apps/platform/src/components/roles/roleCard/index.tsx
+++ b/apps/platform/src/components/roles/roleCard/index.tsx
@@ -117,7 +117,7 @@ export default function RoleCard({
                 <TooltipTrigger>
                   <AvatarComponent
                     className="ml-[-0.3rem]"
-                    name={member.name}
+                    name={member.name || ''}
                     profilePictureUrl={member.profilePictureUrl}
                   />
                 </TooltipTrigger>
@@ -127,7 +127,7 @@ export default function RoleCard({
                 >
                   <AvatarComponent
                     className="h-10 w-10"
-                    name={member.name}
+                    name={member.name || ''}
                     profilePictureUrl={member.profilePictureUrl}
                   />
                   <div className="ml-2 mr-5 flex flex-col">

--- a/apps/platform/src/components/roles/roleCard/index.tsx
+++ b/apps/platform/src/components/roles/roleCard/index.tsx
@@ -122,7 +122,7 @@ export default function RoleCard({
                   />
                 </TooltipTrigger>
                 <TooltipContent
-                  className="flex w-fit items-start justify-between rounded-[6px] border-none bg-zinc-700 p-3 text-sm text-white"
+                  className="flex w-fit items-center justify-between rounded-[6px] border-none bg-zinc-700 p-3 text-sm text-white"
                   sideOffset={8}
                 >
                   <AvatarComponent
@@ -131,7 +131,9 @@ export default function RoleCard({
                     profilePictureUrl={member.profilePictureUrl}
                   />
                   <div className="ml-2 mr-5 flex flex-col">
-                    <div className="font-semibold">{member.name}</div>
+                    {
+                      member.name ? <div className="font-semibold">{member.name}</div> : null
+                    }
                     <div className="text-sm">{member.email}</div>
                   </div>
                   <div className="flex flex-col items-end">


### PR DESCRIPTION
### **User description**
## Description
Issue was due to member name being null in some cases if the member was invited. PR fixes this issue by conditionally rendering member name in RoleCard component and introduced a default user icon as a placeholder if both name & profile picture are not present

Fixes #886 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens
![Screenshot 2025-04-26 140508](https://github.com/user-attachments/assets/96d32cb2-e7c5-42c3-906f-8fb08ad3591c)

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


___

### **PR Type**
Bug fix


___

### **Description**
- Fix crash on Roles tab when member name is null

- Conditionally render member name in `RoleCard` component

- Show default user icon if name and profile picture are missing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>avatar.tsx</strong><dd><code>Add default user icon fallback in AvatarComponent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/common/avatar.tsx

<li>Import and use <code>User</code> icon from <code>lucide-react</code> as fallback.<br> <li> Render default user icon if <code>name</code> is not provided.<br> <li> Preserve initials rendering when name exists.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/893/files#diff-587933542dbc516c93ccbe569722872244ec2ef2b176cf498ae1c89f1071f2b0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Handle missing member name in RoleCard display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/roles/roleCard/index.tsx

<li>Pass empty string to <code>AvatarComponent</code> if member name is missing.<br> <li> Conditionally render member name in tooltip only if present.<br> <li> Adjust tooltip content alignment for better UI consistency.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/893/files#diff-1eac649a2f68d1d91333f9d732e5b48873fb62ed54b9b7b1690ebf421301a8ac">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>