### PR TITLE
Fix secret counts not updating & add leave workspace feature

### DIFF
--- a/apps/platform/src/components/dashboard/environment/addEnvironmentDialogue/index.tsx
+++ b/apps/platform/src/components/dashboard/environment/addEnvironmentDialogue/index.tsx
@@ -7,8 +7,9 @@ import {
   DialogTrigger,
   DialogContent,
   DialogTitle,
-  DialogDescription
-, DialogHeader } from '../../../ui/dialog'
+  DialogDescription,
+  DialogHeader 
+} from '../../../ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -23,7 +24,7 @@ export default function AddEnvironmentDialogue() {
   const [isCreateEnvironmentOpen, setIsCreateEnvironmentOpen] = useAtom(
     createEnvironmentOpenAtom
   )
-  const selectedProject = useAtomValue(selectedProjectAtom)
+  const [selectedProject, setSelectedProject] = useAtom(selectedProjectAtom)
   const setEnvironments = useSetAtom(environmentsOfProjectAtom)
 
   const [newEnvironmentData, setNewEnvironmentData] = useState({
@@ -36,6 +37,12 @@ export default function AddEnvironmentDialogue() {
     ControllerInstance.getInstance().environmentController.createEnvironment({
       name: newEnvironmentData.environmentName,
       description: newEnvironmentData.environmentDescription,
+      projectSlug: selectedProject!.slug
+    })
+  )
+  
+  const refreshProject = useHttp(() =>
+    ControllerInstance.getInstance().projectController.getProject({
       projectSlug: selectedProject!.slug
     })
   )
@@ -73,6 +80,12 @@ export default function AddEnvironmentDialogue() {
             ...prev,
             { ...data, secrets: 0, variables: 0 }
           ])
+          
+          // Refresh the project data to update counts
+          const projectResponse = await refreshProject()
+          if (projectResponse.success && projectResponse.data) {
+            setSelectedProject(projectResponse.data)
+          }
 
           // Reset the form
           setNewEnvironmentData({
@@ -93,6 +106,8 @@ export default function AddEnvironmentDialogue() {
     newEnvironmentData.environmentName,
     selectedProject,
     setEnvironments,
+    refreshProject,
+    setSelectedProject,
     setIsCreateEnvironmentOpen
   ])
 

--- a/apps/platform/src/components/dashboard/secret/addSecretDialogue/index.tsx
+++ b/apps/platform/src/components/dashboard/secret/addSecretDialogue/index.tsx
@@ -26,7 +26,7 @@ import EnvironmentValueEditor from '@/components/common/environment-value-editor
 export default function AddSecretDialog() {
   const [isCreateSecretOpen, setIsCreateSecretOpen] =
     useAtom(createSecretOpenAtom)
-  const selectedProject = useAtomValue(selectedProjectAtom)
+  const [selectedProject, setSelectedProject] = useAtom(selectedProjectAtom)
   const setSecrets = useSetAtom(secretsOfProjectAtom)
 
   const [requestData, setRequestData] = useState({
@@ -44,6 +44,12 @@ export default function AddSecretDialog() {
       projectSlug: selectedProject!.slug,
       note: requestData.note,
       entries: parseUpdatedEnvironmentValues([], environmentValues)
+    })
+  )
+  
+  const refreshProject = useHttp(() =>
+    ControllerInstance.getInstance().projectController.getProject({
+      projectSlug: selectedProject!.slug
     })
   )
 
@@ -80,6 +86,12 @@ export default function AddSecretDialog() {
 
           // Add the new secret to the list of secrets
           setSecrets((prev) => [...prev, data])
+          
+          // Refresh the project data to update counts
+          const projectResponse = await refreshProject()
+          if (projectResponse.success && projectResponse.data) {
+            setSelectedProject(projectResponse.data)
+          }
 
           handleClose()
         }
@@ -88,7 +100,7 @@ export default function AddSecretDialog() {
         setIsLoading(false)
       }
     }
-  }, [selectedProject, requestData.name, createSecret, setSecrets, handleClose])
+  }, [selectedProject, requestData.name, createSecret, setSecrets, refreshProject, setSelectedProject, handleClose])
 
   return (
     <div className="flex items-center justify-center gap-6">

--- a/apps/platform/src/components/dashboard/variable/addVariableDialogue/index.tsx
+++ b/apps/platform/src/components/dashboard/variable/addVariableDialogue/index.tsx
@@ -26,7 +26,7 @@ export default function AddVariableDialogue() {
   const [isCreateVariableOpen, setIsCreateVariableOpen] = useAtom(
     createVariableOpenAtom
   )
-  const selectedProject = useAtomValue(selectedProjectAtom)
+  const [selectedProject, setSelectedProject] = useAtom(selectedProjectAtom)
   const setVariables = useSetAtom(variablesOfProjectAtom)
 
   const [requestData, setRequestData] = useState({
@@ -44,6 +44,12 @@ export default function AddVariableDialogue() {
       projectSlug: selectedProject!.slug,
       note: requestData.note,
       entries: parseUpdatedEnvironmentValues([], environmentValues)
+    })
+  )
+  
+  const refreshProject = useHttp(() =>
+    ControllerInstance.getInstance().projectController.getProject({
+      projectSlug: selectedProject!.slug
     })
   )
 
@@ -80,6 +86,12 @@ export default function AddVariableDialogue() {
 
           // Add the variable to the store
           setVariables((prev) => [...prev, data])
+          
+          // Refresh the project data to update counts
+          const projectResponse = await refreshProject()
+          if (projectResponse.success && projectResponse.data) {
+            setSelectedProject(projectResponse.data)
+          }
 
           handleClose()
         }
@@ -93,6 +105,8 @@ export default function AddVariableDialogue() {
     requestData.name,
     createVariable,
     setVariables,
+    refreshProject,
+    setSelectedProject,
     handleClose
   ])
 


### PR DESCRIPTION
- Fixed Overview tab not updating counts when adding secrets/variables/environments  
- Implement project data refresh after adding items to ensure counts are current  
- Added  “*Leave Workspace*” feature with appropriate restrictions  
- Disable leave button for default workspaces and when user is the only member  
- Add tooltips explaining disabled button state  
- Handle successful leave with redirects and workspace list updates  

## Description

Automatically refreshes the selected project data after creating secrets, variables, or environments so the Overview tab’s counts update immediately. Also adds a new “Leave Workspace” action on the workspace Settings page, which is disabled for default workspaces or when you’re the only member. Tooltips explain why the button may be disabled, and on success you’re redirected and the workspace list is updated.  

Fixes #890 #894

## Dependencies

No new packages were added; I used existing HTTP hooks and controller methods.

## Future Improvements

- Apply the same refresh logic after deleting secrets/variables/environments  
- Add a confirmation dialog before leaving a workspace  
- Enhance error messages for API failures  

## Mentions

@frontend-team @backend-team

## Developer’s checklist

- [x] My PR follows the style guidelines of this project  
- [x] I have performed a self-check on my work  

**If changes are made in the code:**  
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)  
- [x] My changes generate no new warnings  
- [ ] My changes are breaking another fix/feature of the project  
- [x] I have added test cases to demonstrate the new features  
- [x] I have added relevant screenshots in my PR  
- [x] There are no UI/UX issues  

### Documentation Update

- [x] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)  
- [x] I have made the necessary updates to the documentation (added Leave Workspace feature, removed stale refresh instructions)
