### PR TITLE
fix(platform): Close search model after selecting a link

### DIFF
--- a/apps/platform/src/components/shared/navbar/searchModel/index.tsx
+++ b/apps/platform/src/components/shared/navbar/searchModel/index.tsx
@@ -152,7 +152,10 @@ function SearchModel({
                   {searchResults.workspaces.map(workspace => (
                     <CommandItem
                     key={workspace.id}
-                    onClick={() => handleChangeWorkspace(workspace)}
+                      onClick={() => {
+                        handleChangeWorkspace(workspace)
+                        setIsOpen(false)
+                      }}
                     >
                       <span>{workspace.name}</span>
                       {workspace.slug ? <span className="text-sm text-gray-200 ml-2">
@@ -172,6 +175,7 @@ function SearchModel({
                     <Link
                     href={`/${selectedWorkspace!.slug}/${secret.project?.slug ?? selectedProject?.slug}?tab=secret&highlight=${secret.slug}`}
                     key={secret.slug}
+                    onClick={() => setIsOpen(false)}
                     >
                       <CommandItem>
                         <span>{secret.slug}</span>
@@ -193,6 +197,7 @@ function SearchModel({
                     <Link
                     href={`/${selectedWorkspace!.slug}/${project.slug}?tab=secret`}
                     key={project.slug}
+                    onClick={() => setIsOpen(false)}
                     >
                       <CommandItem key={project.slug}>
                         <span>{project.slug}</span>
@@ -214,6 +219,7 @@ function SearchModel({
                     <Link
                     href={`/${selectedWorkspace!.slug}/${environment.project?.slug ?? selectedProject?.slug}?tab=environment&highlight=${environment.slug}`}
                     key={environment.slug}
+                    onClick={() => setIsOpen(false)}
                     >
                       <CommandItem>
                         <span>{environment.slug}</span>
@@ -234,6 +240,7 @@ function SearchModel({
                   <Link
                   href={`/${selectedWorkspace!.slug}/${variable.project?.slug ?? selectedProject?.slug}?tab=variable&highlight=${variable.slug}`}
                   key={variable.slug}
+                  onClick={() => setIsOpen(false)}
                   >
                     <CommandItem>
                       <span>{variable.name}</span>


### PR DESCRIPTION
### **User description**
## Description

Added setIsOpen(false) to OnClick of buttons on Search Component.

Fixes #873 

## Screenshots of relevant screens

https://github.com/user-attachments/assets/881443d1-18aa-4782-9b88-02ced7134be9


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix


___

### **Description**
- Close global search modal when an item is selected

- Add `setIsOpen(false)` to all relevant item click handlers

- Ensure consistent modal closing for workspaces, secrets, projects, environments, and variables


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Ensure search modal closes on all item selections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/shared/navbar/searchModel/index.tsx

<li>Added <code>setIsOpen(false)</code> to workspace, secret, project, environment, and <br>variable selection handlers<br> <li> Ensured modal closes when any search result is clicked<br> <li> Updated both <code>CommandItem</code> and <code>Link</code> click events for consistency


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/896/files#diff-25f0cc4368d8e7de650937503f9f7e18fe7e0efdc54b36d5d38c2d4f35bc5ba6">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>