### PR TITLE
feat(platform): add copy to clipboard button in workspace overview page

### DIFF
--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx
@@ -24,7 +24,8 @@ import ConfirmDeleteKeyDialog from '@/components/dashboard/overview/confirmDelet
 import ViewAndDownloadProjectKeysDialog from '@/components/dashboard/project/viewAndDownloadKeysDialog'
 import { useProjectPrivateKey } from '@/hooks/use-fetch-privatekey'
 import { PageTitle } from '@/components/common/page-title'
-import CopyToClipboard from '@/components/common/copy-to-clipboard';
+import HiddenContent from '@/components/shared/dashboard/hidden-content'
+
 
 
 function OverviewPage(): React.JSX.Element {
@@ -228,10 +229,10 @@ function OverviewPage(): React.JSX.Element {
   </div>
 
  
-  {projectPrivateKey ? <div className="flex items-center gap-2">
-      <CopyToClipboard text={projectPrivateKey} />
-      <span className="text-xs text-white/50">Copy private key</span>
-    </div> : null}
+  {projectPrivateKey ? (
+  <HiddenContent text={projectPrivateKey} />
+) : null}
+
 
  
   <ServerKeySetup

--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx
@@ -24,6 +24,8 @@ import ConfirmDeleteKeyDialog from '@/components/dashboard/overview/confirmDelet
 import ViewAndDownloadProjectKeysDialog from '@/components/dashboard/project/viewAndDownloadKeysDialog'
 import { useProjectPrivateKey } from '@/hooks/use-fetch-privatekey'
 import { PageTitle } from '@/components/common/page-title'
+import CopyToClipboard from '@/components/common/copy-to-clipboard';
+
 
 function OverviewPage(): React.JSX.Element {
   const selectedProject = useAtomValue(selectedProjectAtom)
@@ -214,25 +216,34 @@ function OverviewPage(): React.JSX.Element {
           </div>
 
           <div className="flex flex-1 flex-col gap-3 rounded-lg bg-white/10 p-5">
-            <div className="flex flex-col gap-1">
-              <p className="text-xl font-semibold">
-                Store private key with us?
-              </p>
-              <p className="ext-sm text-white/60">
-                This allows you and your team to access project secrets without
-                setup, making collaboration easier. However, it also increases
-                the risk of accidental leaks.
-              </p>
-            </div>
-            <ServerKeySetup
-              isStoredOnServer={hasServerStoredKey}
-              onDelete={() => setDeleteKeyDialogOpen(true)}
-              onKeyStored={() => setHasServerStoredKey(true)}
-              onOpenStoreDialog={() => setServerKeyDialogOpen(true)}
-              privateKey={projectPrivateKey}
-              projectSlug={selectedProject.slug}
-            />
-          </div>
+  <div className="flex flex-col gap-1">
+    <p className="text-xl font-semibold">
+      Store private key with us?
+    </p>
+    <p className="text-sm text-white/60">
+      This allows you and your team to access project secrets without
+      setup, making collaboration easier. However, it also increases
+      the risk of accidental leaks.
+    </p>
+  </div>
+
+ 
+  {projectPrivateKey ? <div className="flex items-center gap-2">
+      <CopyToClipboard text={projectPrivateKey} />
+      <span className="text-xs text-white/50">Copy private key</span>
+    </div> : null}
+
+ 
+  <ServerKeySetup
+    isStoredOnServer={hasServerStoredKey}
+    onDelete={() => setDeleteKeyDialogOpen(true)}
+    onKeyStored={() => setHasServerStoredKey(true)}
+    onOpenStoreDialog={() => setServerKeyDialogOpen(true)}
+    privateKey={projectPrivateKey}
+    projectSlug={selectedProject.slug}
+  />
+</div>
+
         </div>
       </div>
 

--- a/apps/platform/src/components/dashboard/overview/LocalKeySetup/index.tsx
+++ b/apps/platform/src/components/dashboard/overview/LocalKeySetup/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
-import { AddSVG, EyeOpenSVG, EyeSlashSVG, TrashSVG } from '@public/svg/shared'
+import React from 'react'
+import { AddSVG, TrashSVG } from '@public/svg/shared'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import HiddenContent from '@/components/shared/dashboard/hidden-content'
+
 
 interface LocalKeySetupProps {
   privateKey: string | null
@@ -16,30 +17,11 @@ function LocalKeySetup({
   onOpenSetupDialog,
   onDelete
 }: LocalKeySetupProps): React.JSX.Element {
-  const [isRevealed, setIsRevealed] = useState<boolean>(false)
-
-  const handleToggleReveal = () => setIsRevealed((prev) => !prev)
-
+  
   if (privateKey && !isStoredOnServer) {
     return (
-      <div className="flex gap-1">
-        <Input
-          className="px-4 py-6"
-          readOnly
-          type="text"
-          value={
-            isRevealed
-              ? privateKey
-              : privateKey.replace(/./g, '*').substring(0, 20)
-          }
-        />
-        <Button
-          className="flex items-center justify-center bg-neutral-800 px-4 py-6"
-          onClick={handleToggleReveal}
-          type="button"
-        >
-          {isRevealed ? <EyeSlashSVG /> : <EyeOpenSVG />}
-        </Button>
+      <div className="flex flex-col gap-3">
+        <HiddenContent text={privateKey} />
         <Button
           className="flex items-center justify-center bg-neutral-800 px-4 py-6"
           onClick={onDelete}
@@ -50,6 +32,7 @@ function LocalKeySetup({
       </div>
     )
   }
+  
   return (
     <Button
       className="w-fit px-4 py-6"


### PR DESCRIPTION
### **User description**
## Description

Added a "Copy to Clipboard" button in the "Store private key with us?" section inside the Workspace Overview page.

Fixes #905

## Dependencies

No new dependencies/packages were added.

## Future Improvements

Could add a toast notification like "Copied!" after the copy action for better UX.

## Mentions

@rajdip-b (issue author)  
@Allan2000-Git (initial assignee)

## Screenshots of relevant screens

_No UI screenshot added as functionality was added in code. Copy button will be visible next to private key once private key is available._

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [x] My changes are not breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works (no test framework visible for frontend)
- [x] I have added relevant screenshots in my PR (explained in text)
- [x] There are no UI/UX issues

### Documentation Update

- [x] This PR does not require documentation updates


___

### **PR Type**
Enhancement


___

### **Description**
- Added "Copy to Clipboard" button for project private key.

- Integrated `CopyToClipboard` component in workspace overview.

- Displayed copy button only when private key is available.

- Improved UI for easier private key copying.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add copy-to-clipboard functionality for project private key</code></dd></summary>
<hr>

apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx

<li>Imported and integrated <code>CopyToClipboard</code> component.<br> <li> Added conditional rendering for copy button when private key exists.<br> <li> Enhanced UI to include "Copy private key" label next to button.<br> <li> Refactored section for improved clarity and usability.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/909/files#diff-c0b170943d4abee3d4aed9ebcaec39b9ee76dd2684c5706a252bd4ae809da27e">+30/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>