### PR TITLE
feat(platform): Add ability to leave workspace and fix project overview counts

### DIFF
--- a/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx
+++ b/apps/platform/src/app/(main)/(project)/[workspace]/[project]/@overview/page.tsx
@@ -7,6 +7,9 @@ import Avvvatars from 'avvvatars-react'
 import Link from 'next/link'
 import OverviewLoader from '@/components/dashboard/overview/overviewLoader'
 import {
+  projectEnvironmentCountAtom,
+  projectSecretCountAtom,
+  projectVariableCountAtom,
   selectedProjectAtom,
   viewAndDownloadProjectKeysOpenAtom
 } from '@/store'
@@ -31,6 +34,9 @@ function OverviewPage(): React.JSX.Element {
     isViewAndDownloadProjectKeysDialogOpen,
     setIsViewAndDownloadProjectKeysDialogOpen
   ] = useAtom(viewAndDownloadProjectKeysOpenAtom)
+  const secretCount = useAtomValue(projectSecretCountAtom)
+  const variableCount = useAtomValue(projectVariableCountAtom)
+  const environmentCount = useAtomValue(projectEnvironmentCountAtom)
 
   const [localKeyDialogOpen, setLocalKeyDialogOpen] = useState<boolean>(false)
   const [serverKeyDialogOpen, setServerKeyDialogOpen] = useState<boolean>(false)
@@ -117,7 +123,7 @@ function OverviewPage(): React.JSX.Element {
             </div>
             <div className="flex gap-2 rounded-lg bg-black/40 p-2">
               <SecretSVG width={16} />
-              {selectedProject.secretCount}
+              {secretCount}
             </div>
           </Link>
 
@@ -133,7 +139,7 @@ function OverviewPage(): React.JSX.Element {
             </div>
             <div className="flex gap-2 rounded-lg bg-[#262626] p-2">
               <VariableSVG width={16} />
-              {selectedProject.variableCount}
+              {variableCount}
             </div>
           </Link>
 
@@ -149,7 +155,7 @@ function OverviewPage(): React.JSX.Element {
             </div>
             <div className="flex gap-2 rounded-lg bg-[#262626] p-2">
               <EnvironmentSVG width={16} />
-              {selectedProject.environmentCount}
+              {environmentCount}
             </div>
           </Link>
         </div>

--- a/apps/platform/src/app/(main)/(settings)/[workspace]/page.tsx
+++ b/apps/platform/src/app/(main)/(settings)/[workspace]/page.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import React, { useCallback, useEffect, useState } from 'react'
-import { useAtom, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import {
   allWorkspacesAtom,
   deleteWorkspaceOpenAtom,
-  selectedWorkspaceAtom
+  leaveWorkspaceOpenAtom,
+  selectedWorkspaceAtom,
+  workspaceMemberCountAtom
 } from '@/store'
 import ConfirmDeleteWorkspace from '@/components/dashboard/workspace/confirmDeleteWorkspace'
 import CopyToClipboard from '@/components/common/copy-to-clipboard'
@@ -28,14 +30,15 @@ import {
   EmojiPicker,
   EmojiPickerSearch,
   EmojiPickerContent,
-  EmojiPickerFooter,
-} from "@/components/ui/emoji-picker";
+  EmojiPickerFooter
+} from '@/components/ui/emoji-picker'
 import {
   Popover,
   PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  PopoverTrigger
+} from '@/components/ui/popover'
 import { PageTitle } from '@/components/common/page-title'
+import ConfirmLeaveWorkspace from '@/components/dashboard/workspace/confirmLeaveWorkspace'
 
 export default function WorkspaceSettingsPage(): JSX.Element {
   const router = useRouter()
@@ -46,8 +49,12 @@ export default function WorkspaceSettingsPage(): JSX.Element {
   const [isDeleteWorkspaceOpen, setIsDeleteWorkspaceOpen] = useAtom(
     deleteWorkspaceOpenAtom
   )
+  const [isLeaveWorkspaceOpen, setIsLeaveWorkspaceOpen] = useAtom(
+    leaveWorkspaceOpenAtom
+  )
 
   const setAllWorkspaces = useSetAtom(allWorkspacesAtom)
+  const memberCount = useAtomValue(workspaceMemberCountAtom)
 
   const [showPicker, setShowPicker] = useState(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -259,7 +266,7 @@ export default function WorkspaceSettingsPage(): JSX.Element {
           <div className="flex flex-row justify-end gap-x-4">
             <Popover onOpenChange={setShowPicker} open={showPicker}>
               <PopoverTrigger asChild>
-                <div className="flex aspect-square h-[60px] w-[60px] items-center justify-center rounded-[0.3125rem] bg-[#0B0D0F] p-[0.62rem] text-xl cursor-pointer">
+                <div className="flex aspect-square h-[60px] w-[60px] cursor-pointer items-center justify-center rounded-[0.3125rem] bg-[#0B0D0F] p-[0.62rem] text-xl">
                   {workspaceData.icon}
                 </div>
               </PopoverTrigger>
@@ -290,6 +297,50 @@ export default function WorkspaceSettingsPage(): JSX.Element {
           <div className="w-2/5 rounded-lg border-[1px] border-white/50 px-4 py-3 text-center">
             Coming Soon
           </div>
+        </section>
+
+        <Separator className="bg-white/20" />
+
+        {/* Leave Workspace */}
+        <section className="my-5 flex w-full flex-row items-center">
+          <div className="flex w-3/5 flex-col gap-y-2">
+            <span className="text-lg font-semibold">Leave Workspace</span>
+            <span className="text-sm text-white/60">
+              Your access will be lost to any of your teams and data related to
+              this workspace. This action is irreversible.
+            </span>
+          </div>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  className="flex w-2/5 items-center gap-x-2 bg-red-600 text-white/90 transition-all duration-100 ease-in-out hover:bg-red-500"
+                  disabled={
+                    isLoading ||
+                    selectedWorkspace?.isDefault ||
+                    memberCount === 1
+                  }
+                  onClick={() => setIsLeaveWorkspaceOpen(true)}
+                  role="button"
+                >
+                  <span>Leave</span>
+                </Button>
+              </TooltipTrigger>
+
+              <TooltipContent
+                className="border-white/20 bg-white/10 text-white backdrop-blur-xl"
+                sideOffset={7}
+              >
+                {selectedWorkspace?.isDefault ? (
+                  <p>This is your default workspace. You can not leave it.</p>
+                ) : null}
+
+                {memberCount === 1 ? (
+                  <p>You are the only member of this workspace.</p>
+                ) : null}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </section>
 
         <Separator className="bg-white/20" />
@@ -344,6 +395,11 @@ export default function WorkspaceSettingsPage(): JSX.Element {
       {/* Delete workspace alert dialog */}
       {isDeleteWorkspaceOpen && selectedWorkspace ? (
         <ConfirmDeleteWorkspace />
+      ) : null}
+
+      {/* Leave workspace alert dialog */}
+      {isLeaveWorkspaceOpen && selectedWorkspace ? (
+        <ConfirmLeaveWorkspace />
       ) : null}
     </main>
   )

--- a/apps/platform/src/app/(main)/(settings)/[workspace]/page.tsx
+++ b/apps/platform/src/app/(main)/(settings)/[workspace]/page.tsx
@@ -327,18 +327,20 @@ export default function WorkspaceSettingsPage(): JSX.Element {
                 </Button>
               </TooltipTrigger>
 
-              <TooltipContent
-                className="border-white/20 bg-white/10 text-white backdrop-blur-xl"
-                sideOffset={7}
-              >
-                {selectedWorkspace?.isDefault ? (
-                  <p>This is your default workspace. You can not leave it.</p>
-                ) : null}
+              {selectedWorkspace?.isDefault || memberCount === 1 ? (
+                <TooltipContent
+                  className="border-white/20 bg-white/10 text-white backdrop-blur-xl"
+                  sideOffset={7}
+                >
+                  {selectedWorkspace?.isDefault ? (
+                    <p>This is your default workspace. You can not leave it.</p>
+                  ) : null}
 
-                {memberCount === 1 ? (
-                  <p>You are the only member of this workspace.</p>
-                ) : null}
-              </TooltipContent>
+                  {memberCount === 1 ? (
+                    <p>You are the only member of this workspace.</p>
+                  ) : null}
+                </TooltipContent>
+              ) : null}
             </Tooltip>
           </TooltipProvider>
         </section>

--- a/apps/platform/src/components/dashboard/workspace/confirmLeaveWorkspace/index.tsx
+++ b/apps/platform/src/components/dashboard/workspace/confirmLeaveWorkspace/index.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import React, { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { useAtom } from 'jotai'
+import { useRouter } from 'next/navigation'
+import { TrashSVG } from '@public/svg/shared'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import {
+  allWorkspacesAtom,
+  leaveWorkspaceOpenAtom,
+  selectedWorkspaceAtom
+} from '@/store'
+import ControllerInstance from '@/lib/controller-instance'
+import { useHttp } from '@/hooks/use-http'
+import { Input } from '@/components/ui/input'
+
+export default function ConfirmLeaveWorkspace(): React.JSX.Element {
+  const [allWorkspaces, setAllWorkspaces] = useAtom(allWorkspacesAtom)
+  const [selectedWorkspace, setSelectedWorkspace] = useAtom(
+    selectedWorkspaceAtom
+  )
+  const [isLeaveWorkspaceOpen, setIsLeaveWorkspaceOpen] = useAtom(
+    leaveWorkspaceOpenAtom
+  )
+
+  const [confirmWorkspaceName, setConfirmWorkspaceName] = useState('')
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const router = useRouter()
+
+  const leaveWorkspace = useHttp(() =>
+    ControllerInstance.getInstance().workspaceMembershipController.leaveWorkspace(
+      {
+        workspaceSlug: selectedWorkspace!.slug
+      }
+    )
+  )
+
+  const handleLeaveWorkspace = async () => {
+    if (selectedWorkspace) {
+      setIsLoading(true)
+      toast.loading('Leaving workspace...')
+
+      try {
+        const { success } = await leaveWorkspace()
+
+        if (success) {
+          toast.success('Workspace left successfully', {
+            description: (
+              <p className="text-xs text-emerald-300">
+                You are no longer a member of this workspace.
+              </p>
+            )
+          })
+
+          const remainingWorkspaces = allWorkspaces.filter(
+            (workspace) => workspace.id !== selectedWorkspace.id
+          )
+          setAllWorkspaces(remainingWorkspaces)
+          setSelectedWorkspace(remainingWorkspaces[0])
+        }
+      } finally {
+        handleClose()
+        setIsLoading(false)
+        toast.dismiss()
+        router.push('/')
+      }
+    }
+  }
+
+  const handleClose = useCallback(() => {
+    setIsLeaveWorkspaceOpen(false)
+  }, [setIsLeaveWorkspaceOpen])
+
+  return (
+    <AlertDialog
+      aria-hidden={!isLeaveWorkspaceOpen}
+      open={isLeaveWorkspaceOpen}
+    >
+      <AlertDialogContent className="rounded-lg border border-white/25 bg-[#18181B] ">
+        <AlertDialogHeader>
+          <div className="flex items-center gap-x-3">
+            <TrashSVG />
+            <AlertDialogTitle className="text-lg font-semibold">
+              Do you want to leave this workspace?
+            </AlertDialogTitle>
+          </div>
+          <AlertDialogDescription className="text-sm font-normal leading-5 text-[#71717A]">
+            This action cannot be undone. You will loss the access to this
+            workspace.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="flex w-full flex-col gap-y-5 text-sm">
+          To confirm that you really want to leave this workspace, please type
+          in the name of the workspace below.
+          <Input
+            className="w-full"
+            disabled={isLoading}
+            onChange={(e) => setConfirmWorkspaceName(e.target.value)}
+            placeholder={selectedWorkspace?.name}
+            type="text"
+            value={confirmWorkspaceName}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            className="rounded-md bg-[#F4F4F5] text-black hover:bg-[#F4F4F5]/80 hover:text-black"
+            onClick={handleClose}
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="rounded-md bg-[#DC2626] text-white hover:bg-[#DC2626]/80"
+            disabled={
+              isLoading ||
+              allWorkspaces.length === 1 ||
+              confirmWorkspaceName !== selectedWorkspace?.name
+            }
+            onClick={handleLeaveWorkspace}
+          >
+            Yes, leave the workspace
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/platform/src/store/index.ts
+++ b/apps/platform/src/store/index.ts
@@ -147,6 +147,7 @@ export const createEnvironmentOpenAtom = atom<boolean>(false)
 export const editEnvironmentOpenAtom = atom<boolean>(false)
 export const deleteEnvironmentOpenAtom = atom<boolean>(false)
 export const deleteWorkspaceOpenAtom = atom<boolean>(false)
+export const leaveWorkspaceOpenAtom = atom<boolean>(false)
 
 export const createApiKeyOpenAtom = atom<boolean>(false)
 export const editApiKeyOpenAtom = atom<boolean>(false)


### PR DESCRIPTION
…
## Description

_Added Leave button on workspace settings to leave the workspace, disable if it's the default workspace, or you are the only member of it
Also fix the bug of not updating counts of secret, variable, and environment on the  overview tab
_ <br />

Fixes #890 
Fixes #894 

## Screenshots of relevant screens
![Screenshot from 2025-04-29 13-35-30](https://github.com/user-attachments/assets/08754c7b-b5cd-4584-93a7-50fa9a07ca12)
![Screenshot from 2025-04-29 13-46-33](https://github.com/user-attachments/assets/187c7d11-d50a-4563-8252-2ac7b49c093d)

![Screenshot from 2025-04-29 13-33-58](https://github.com/user-attachments/assets/13e77756-638f-42d9-9c00-19cfecac6ddc)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work