### PR TITLE
fix: added validations for admin role updation

### DIFF
--- a/apps/platform/src/components/common/authority-selector.tsx
+++ b/apps/platform/src/components/common/authority-selector.tsx
@@ -1,5 +1,6 @@
 import type { AuthorityEnum } from '@keyshade/schema'
 import { Checkbox } from '../ui/checkbox'
+import { cn } from '@/lib/utils'
 
 interface ChecklistItem {
   id: AuthorityEnum // the authority id in prisma schema
@@ -430,7 +431,8 @@ interface AuthoritySelectorProps {
     React.SetStateAction<Set<AuthorityEnum>>
   >
   isSheet?: boolean
-  parent: 'API_KEY' | 'ROLES'
+  parent: 'API_KEY' | 'ROLES',
+  isAdminRole?: boolean
 }
 
 function extractAuthoritiesFromGroupItem(
@@ -481,6 +483,7 @@ export default function AuthoritySelector({
   selectedPermissions,
   setSelectedPermissions,
   isSheet,
+  isAdminRole,
   parent
 }: AuthoritySelectorProps): React.JSX.Element {
   const handleGroupToggle = (groupItem: GroupItem, checked: boolean) => {
@@ -530,7 +533,7 @@ export default function AuthoritySelector({
     group: GroupItem
   ) {
     return (
-      <>
+      <div key={group.name}>
         <div
           className={`space-y-2 ml-[${currentLevel * 20}px]`}
           key={group.name}
@@ -593,7 +596,7 @@ export default function AuthoritySelector({
         {group.subgroups?.map((subgroup) =>
           renderAuthorityGroupsRecursively(currentLevel + 1, subgroup)
         )}
-      </>
+      </div>
     )
   }
 
@@ -604,7 +607,9 @@ export default function AuthoritySelector({
       <label className="w-[9rem] text-base font-semibold" htmlFor="authorities">
         Authorities
       </label>
-      <div className="mt-2 h-full w-full space-y-4">
+      <div className={cn("mt-2 h-full w-full space-y-4", {
+        'opacity-50 pointer-events-none cursor-none': isAdminRole
+      })}>
         {authorityGroups
           .filter((group) => {
             if (group.explicitToApiKey) {

--- a/apps/platform/src/components/roles/editRoleSheet/index.tsx
+++ b/apps/platform/src/components/roles/editRoleSheet/index.tsx
@@ -69,7 +69,7 @@ export default function EditRoleSheet() {
   const [editRoleData, setEditRoleData] = useState({
     name: selectedRole?.name ?? '',
     description: selectedRole?.description ?? '',
-    colorCode: selectedRole?.colorCode ?? '#000000'
+    colorCode: selectedRole?.authorities.includes('WORKSPACE_ADMIN') ? COLORS_LIST[2].color : (selectedRole?.colorCode || '#000000')
   })
 
   useEffect(() => {
@@ -83,7 +83,7 @@ export default function EditRoleSheet() {
         }
       }
 
-      setProjectEnvironmentSelection(selections)
+    setProjectEnvironmentSelection(selections)
     }
   }, [selectedRole])
 
@@ -190,6 +190,7 @@ export default function EditRoleSheet() {
               </Label>
               <Input
                 className="col-span-3 h-[2.25rem] w-[20rem] "
+                disabled={selectedRole?.authorities.includes('WORKSPACE_ADMIN')}
                 id="name"
                 onChange={(e) =>
                   setEditRoleData((prev) => ({
@@ -269,6 +270,7 @@ export default function EditRoleSheet() {
 
             {/* Authority Selection */}
             <AuthoritySelector
+              isAdminRole={selectedRole?.authorities.includes('WORKSPACE_ADMIN')}
               parent="ROLES"
               selectedPermissions={selectedPermissions}
               setSelectedPermissions={setSelectedPermissions}


### PR DESCRIPTION
### **User description**
## Description
This PR solves the following:
1. Admin role has default indigo color
2. User can only edit the description and color of the admin role
3. Disabled name & authority selector for admin role
4. Add relevant test coverage in the backend.

Fixes #928 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens
https://github.com/user-attachments/assets/70ce5ac7-02d8-4ede-86ef-419d58447cbf

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ x My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Prevent modification of admin role name and authorities in backend
  - Only description and color can be updated for admin role
  - Return clear error if name or authorities are changed

- Update frontend to disable name and authority selector for admin role
  - Authority selector and name input are disabled if editing admin role
  - Admin role color defaults to indigo

- Add backend tests for admin role update restrictions
  - Ensure authorities and name cannot be changed for admin role
  - Test duplicate name update for admin role


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace-role.service.ts</strong><dd><code>Enforce admin role update restrictions in service logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace-role/workspace-role.service.ts

<li>Added logic to detect admin role based on authorities.<br> <li> Prevented updates to admin role's name or authorities.<br> <li> Allowed only description and color updates for admin role.<br> <li> Improved error messages for admin role update attempts.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/941/files#diff-5401308ebcabca69186b52b93a1e3c3febadf3da5ed61d2880e797eb5d9fb2aa">+36/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace-role.e2e.spec.ts</strong><dd><code>Add tests for admin role update restrictions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/workspace-role/workspace-role.e2e.spec.ts

<li>Added tests to ensure admin role authorities and name cannot be <br>changed.<br> <li> Tested error responses for invalid admin role updates.<br> <li> Added test for duplicate name update attempt on admin role.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/941/files#diff-8cb77aad66a47879970bb3d9086df36f7477e273caf90a319c589e7a221cd30b">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Disable name and authority editing for admin role in UI</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/roles/editRoleSheet/index.tsx

<li>Disabled name input when editing admin role.<br> <li> Set admin role color to default indigo.<br> <li> Passed admin role status to authority selector.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/941/files#diff-345d93fe581931f23a020573c079c5f2f5de8d098c2dbfb2234f69514e18b4ca">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>authority-selector.tsx</strong><dd><code>Disable authority selector for admin role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/common/authority-selector.tsx

<li>Added <code>isAdminRole</code> prop to disable authority selection for admin role.<br> <li> Applied UI changes to visually disable authority selector for admin <br>role.<br> <li> Improved component structure for admin role handling.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/941/files#diff-dd7370011f0b0c3eb8b207a3ccb188f388fb29a05eaff54e719d9abe35c59c5f">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>