### PR TITLE
fix: route to dashboard on selection of different workspace

### DIFF
--- a/apps/platform/src/components/ui/workspace-list-item.tsx
+++ b/apps/platform/src/components/ui/workspace-list-item.tsx
@@ -28,7 +28,7 @@ export function WorkspaceListItem({
   const handleSelect = () => {
     setSelectedWorkspace(workspace)
     setSelectedWorkspaceToStorage(workspace);
-    router.refresh()
+    router.push('/')
     onClose()
   }
 


### PR DESCRIPTION
## Description
Users are now redirected to the dashboard of the newly selected workspace

Fixes #947 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens
https://github.com/user-attachments/assets/69de07dc-1770-4a2d-9e9a-e475ea8cec61

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues