### PR TITLE
fix: issue #953 , Error message changed from backend for Invalid OTP

### DIFF
--- a/apps/api/src/auth/service/auth.service.ts
+++ b/apps/api/src/auth/service/auth.service.ts
@@ -117,7 +117,7 @@ export class AuthService {
       throw new UnauthorizedException(
         constructErrorBody(
           'Invalid OTP',
-          'Please enter a valid 6 digit alphanumeric OTP.'
+          'The OTP you entered is invalid or has expired. Please try again.'
         )
       )
     }


### PR DESCRIPTION
### **User description**
## Description

Updated the OTP validation logic to return a more user-friendly and descriptive error message when the OTP is invalid or has expired. <br />

Fixes #953 

## Screenshots of relevant screens

Before
<img width="384" alt="before" src="https://github.com/user-attachments/assets/9063c084-5552-49b5-8350-f82979c4efe3" />
After
<img width="516" alt="after" src="https://github.com/user-attachments/assets/d0701e73-d42c-4ba0-bf1b-9d7d5a30b61f" />


**If changes are made in the code:**


- ✅ My changes in code generate no new warnings
- ✅ I have added relevant screenshots in my PR
- ✅ There are no UI/UX issues


___

### **PR Type**
Bug fix


___

### **Description**
- Updated error message for invalid or expired OTP.

- Improved user feedback for incorrect OTP entry.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.service.ts</strong><dd><code>Clarify error message for invalid or expired OTP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/auth/service/auth.service.ts

<li>Changed the error message for invalid OTP scenarios.<br> <li> Message now clarifies if OTP is invalid or expired.


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/969/files#diff-b133cdd3d1772bc73698061218512fd024ce1ed7cd9eaeb27858e6acb444b90b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>