### PR TITLE
fix(platform): mobile detection logic and conditional rendering for overlay

### DIFF
--- a/apps/platform/src/components/common/mobile-overlay.tsx
+++ b/apps/platform/src/components/common/mobile-overlay.tsx
@@ -1,14 +1,54 @@
+'use client'
+
 import { LogoSVG } from '@public/svg/dashboard'
 import { MobileScreenSVG } from '@public/svg/shared'
+import { useEffect, useState } from 'react'
 
 export default function MobileOverlay() {
-  return (
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-[#0E0E0E] pb-[160px] md:hidden">
-      <LogoSVG className="mb-8" />
-      <MobileScreenSVG className="text-gray-400" />
-      <p className="px-4 text-center">
-        Please log-in through <br /> desktop to use Keyshade.
-      </p>
-    </div>
-  )
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    function checkMobile() {
+      // Check if device supports touch
+      const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+      const smallerDimension = Math.min(window.innerWidth, window.innerHeight);
+      const isSmallDevice = smallerDimension <= 768;
+      
+      const isMobileDevice = isTouchDevice && isSmallDevice;
+      
+      setIsMobile(isMobileDevice);
+    }
+
+    checkMobile();
+
+    window.addEventListener('resize', checkMobile);
+    
+    screen.orientation.addEventListener('change', checkMobile);
+
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+      screen.orientation.removeEventListener('change', checkMobile);
+    };
+  }, []);
+
+  // Do not render overlay during initial render to avoid hydration mismatch
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  if (isMobile) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-[#0E0E0E]">
+        <LogoSVG className="mb-8" />
+        <MobileScreenSVG className="text-gray-400" />
+        <div className="px-4 text-center">
+          <p className="text-lg">
+            Please log-in through <br /> desktop to use Keyshade.
+          </p>
+        </div>
+      </div>
+    )
+  }
+  
+  return null;
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where the mobile overlay was incorrectly hidden in landscape mode on mobile devices. The previous implementation relied solely on Tailwind’s `md:hidden` class, which is based on viewport width, not actual device type or orientation.

Now we check innerWidth, if its supports touch input & maxTouchPoints (> 0 means the device has a touchscreen (e.g., 10 for iPhones, 0 for most desktops).

Fixes #996 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b 

## Screenshots of relevant screens

https://github.com/user-attachments/assets/6496bb53-3043-4ba5-9fb1-a034498085d4


## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ x My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues