### PR TITLE
fix(cli): Crash on secret decryption due to missing private key

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -206,3 +206,9 @@
 - Updated `keyshade run` command to parse command without quotes
 - Run command exits when the command passed is a one-time only command
 - Updated `keyshade run` command to kill child command upon ctrl+c
+
+## 3.2.1-stage.1
+
+### Patches
+
+- Fixed decryption error on `keyshade secret list` and `keyshade secret revisions` commands

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyshade/cli",
-  "version": "3.2.0",
+  "version": "3.2.1-stage.1",
   "description": "CLI for keyshade",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",

--- a/apps/cli/src/commands/secret/list.secret.ts
+++ b/apps/cli/src/commands/secret/list.secret.ts
@@ -75,7 +75,7 @@ export default class ListSecret extends BaseCommand {
             createdBy
           } of values) {
             Logger.info(
-              `  | ${environment.name} (${environment.slug}): ${projectPrivateKey !== null ? await decrypt(projectPrivateKey, value) : 'Hidden'} (version ${version})`
+              `  | ${environment.name} (${environment.slug}): ${projectPrivateKey ? await decrypt(projectPrivateKey, value) : 'Hidden'} (version ${version})`
             )
             Logger.info(
               `  | Created on ${formatDate(createdOn)} by ${createdBy.name}`

--- a/apps/cli/src/commands/secret/revisions.secret.ts
+++ b/apps/cli/src/commands/secret/revisions.secret.ts
@@ -85,7 +85,7 @@ export default class FetchSecretRevisions extends BaseCommand {
 
         for (const revision of revisions) {
           Logger.info(
-            `  | ${privateKey !== null ? await decrypt(privateKey, revision.value) : 'Hidden'} (version ${revision.version})`
+            `  | ${privateKey ? await decrypt(privateKey, revision.value) : 'Hidden'} (version ${revision.version})`
           )
           Logger.info(
             `  | Created on ${formatDate(revision.createdOn)} by ${revision.createdBy.name}`


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed CLI crash when decrypting secrets without private key

- Changed null checks to truthy checks for private key validation

- Updated version to 3.2.1-stage.1 with changelog entry


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Private Key Check"] --> B["Decrypt Secret"]
  A --> C["Show 'Hidden'"]
  B --> D["Display Secret Value"]
  C --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list.secret.ts</strong><dd><code>Fix private key validation in list command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/secret/list.secret.ts

<li>Changed <code>projectPrivateKey !== null</code> to <code>projectPrivateKey</code> for truthy <br>check<br> <li> Prevents crash when private key is undefined or falsy


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1037/files#diff-2a60ffa339c54c754c130fc45b4cda2ef7dd8cc472e8e18c2c329f8f3031ae7b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>revisions.secret.ts</strong><dd><code>Fix private key validation in revisions command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/src/commands/secret/revisions.secret.ts

<li>Changed <code>privateKey !== null</code> to <code>privateKey</code> for truthy check<br> <li> Prevents crash when private key is undefined or falsy


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1037/files#diff-0b575c1e43ab2c04990c8ace09b297dfacea73fc89d29342ed63024deed1f5d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document decryption error fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/CHANGELOG.md

<li>Added entry for version 3.2.1-stage.1<br> <li> Documented fix for decryption error in secret commands


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1037/files#diff-e5e66a9bbb347b2c1a619881324c0a648d4e84523f1fb588dc0f3455db461eed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version to 3.2.1-stage.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/cli/package.json

- Updated version from 3.2.0 to 3.2.1-stage.1


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1037/files#diff-1625a7848c01883721bcd146381e2a6bff3c03814d4586559265d8e54a0c9565">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>