### PR TITLE
fix(platfrom): Projct overview & secret-variable revision screen

### DIFF
--- a/apps/platform/src/components/dashboard/overview/LocalKeySetup/index.tsx
+++ b/apps/platform/src/components/dashboard/overview/LocalKeySetup/index.tsx
@@ -22,22 +22,12 @@ function LocalKeySetup({
   onOpenSetupDialog,
   onDelete
 }: LocalKeySetupProps): React.JSX.Element {
-  if (privateKey && !isStoredOnServer) {
-    return (
-      <div className="flex justify-between gap-1">
-        <HiddenContent isPrivateKey value={privateKey} />
-        <Button
-          className="flex items-center justify-center bg-neutral-800 p-2"
-          onClick={onDelete}
-          type="button"
-        >
-          <TrashSVG />
-        </Button>
-      </div>
-    )
-  }
+  const isPrivateKeyStored = privateKey && !isStoredOnServer
+
   return (
-    <div className="flex justify-between gap-1.5 rounded-lg bg-white/10 p-3">
+    <div
+      className={`flex justify-between gap-2 rounded-lg bg-white/10 p-3 ${isPrivateKeyStored && 'flex-col gap-3'}`}
+    >
       <div>
         <h1 className="text-lg font-medium text-white">
           Do you wanna setup private key?{' '}
@@ -54,16 +44,29 @@ function LocalKeySetup({
           </Tooltip>
         </h1>
       </div>
-      <Button
-        className="flex w-fit items-center gap-1 rounded-md bg-neutral-800 px-3 py-5 text-sm text-white/70"
-        disabled={Boolean(privateKey !== null && isStoredOnServer)}
-        onClick={onOpenSetupDialog}
-        type="button"
-        variant="default"
-      >
-        <Plus />
-        <div className="font-bold">Setup Private Key</div>
-      </Button>
+      {isPrivateKeyStored ? (
+        <div className="flex items-center justify-between gap-1">
+          <HiddenContent isPrivateKey value={privateKey} />
+          <Button
+            className="flex items-center justify-center bg-neutral-800 p-2"
+            onClick={onDelete}
+            type="button"
+          >
+            <TrashSVG />
+          </Button>
+        </div>
+      ) : (
+        <Button
+          className="flex w-fit items-center gap-1 rounded-md bg-neutral-800 px-3 py-5 text-sm text-white/70"
+          disabled={Boolean(privateKey !== null && isStoredOnServer)}
+          onClick={onOpenSetupDialog}
+          type="button"
+          variant="default"
+        >
+          <Plus />
+          <div className="font-bold">Setup Private Key</div>
+        </Button>
+      )}
     </div>
   )
 }

--- a/apps/platform/src/components/dashboard/overview/ServerKeySetup/index.tsx
+++ b/apps/platform/src/components/dashboard/overview/ServerKeySetup/index.tsx
@@ -48,23 +48,12 @@ function ServerKeySetup({
       onOpenStoreDialog()
     }
   }
+  const isPrivateKeyStored = privateKey && isStoredOnServer
 
-  if (privateKey && isStoredOnServer) {
-    return (
-      <div className="flex justify-between gap-1">
-        <HiddenContent isPrivateKey value={privateKey} />
-        <Button
-          className="flex items-center justify-center bg-neutral-800 p-2"
-          onClick={onDelete}
-          type="button"
-        >
-          <TrashSVG />
-        </Button>
-      </div>
-    )
-  }
   return (
-    <div className="flex justify-between gap-1.5 rounded-lg bg-white/10 p-3">
+    <div
+      className={`flex justify-between gap-2 rounded-lg bg-white/10 p-3 ${isPrivateKeyStored && 'flex-col gap-3'}`}
+    >
       <div>
         <h1 className="text-lg font-medium text-white">
           Share project private key with us?{' '}
@@ -80,15 +69,28 @@ function ServerKeySetup({
           </Tooltip>
         </h1>
       </div>
-      <Button
-        className="flex w-fit items-center gap-1 rounded-md bg-neutral-800 px-3 py-5 text-sm text-white/70"
-        onClick={handleStorePrivateKey}
-        type="button"
-        variant="default"
-      >
-        <Plus />
-        Store Private Key
-      </Button>
+      {isPrivateKeyStored ? (
+        <div className="flex items-center justify-between gap-1">
+          <HiddenContent isPrivateKey value={privateKey} />
+          <Button
+            className="flex items-center justify-center bg-neutral-800 p-2"
+            onClick={onDelete}
+            type="button"
+          >
+            <TrashSVG />
+          </Button>
+        </div>
+      ) : (
+        <Button
+          className="flex w-fit items-center gap-1 rounded-md bg-neutral-800 px-3 py-5 text-sm text-white/70"
+          onClick={handleStorePrivateKey}
+          type="button"
+          variant="default"
+        >
+          <Plus />
+          Store Private Key
+        </Button>
+      )}
     </div>
   )
 }

--- a/apps/platform/src/components/dashboard/variable/variableRevisionsSheet/index.tsx
+++ b/apps/platform/src/components/dashboard/variable/variableRevisionsSheet/index.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { Environment, VariableVersion } from '@keyshade/schema'
 import dayjs from 'dayjs'
 import { RollbackSVG } from '@public/svg/shared'
@@ -14,7 +14,6 @@ import {
   environmentsOfProjectAtom,
   selectedVariableAtom,
   variableRevisionsOpenAtom,
-  selectedProjectAtom,
   rollbackVariableOpenAtom,
   selectedVariableEnvironmentAtom,
   selectedVariableRollbackVersionAtom,
@@ -44,7 +43,6 @@ export default function VariableRevisionsSheet(): React.JSX.Element {
   )
   const selectedVariable = useAtomValue(selectedVariableAtom)
   const environments = useAtomValue(environmentsOfProjectAtom)
-  const selectedProject = useAtomValue(selectedProjectAtom)
   const setIsRollbackVariableOpen = useSetAtom(rollbackVariableOpenAtom)
   const setSelectedVariableEnvironment = useSetAtom(
     selectedVariableEnvironmentAtom
@@ -55,11 +53,6 @@ export default function VariableRevisionsSheet(): React.JSX.Element {
   const [revisions, setRevisions] = useAtom(revisionsOfVariableAtom)
 
   const [isLoading, setIsLoading] = useState(true)
-
-  const isDecrypted = useMemo(
-    () => selectedProject?.storePrivateKey === true || false,
-    [selectedProject]
-  )
 
   const getAllRevisionsOfVariable = useHttp(
     (environmentSlug: Environment['slug']) =>
@@ -170,7 +163,7 @@ export default function VariableRevisionsSheet(): React.JSX.Element {
                           >
                             <div className="flex w-full flex-row justify-between">
                               <div className="font-semibold">
-                                {isDecrypted ? revision.value : 'Hidden'}
+                                {revision.value}
                               </div>
                               <div className="rounded-lg bg-sky-500/30 px-2 text-sky-500">
                                 v{revision.version}


### PR DESCRIPTION
## Description
This PR fixes following issues-
-  the value of variable should be vissible on revision screen on all cases
-  the values in secret revision screen were encrypted
-  in overview page, if private key is saved(either on db or atom) was breaking the layout a bit
 
## Screenshots of relevant screens
<img width="1050" alt="Screenshot 2025-07-03 at 4 11 51 PM" src="https://github.com/user-attachments/assets/10d74f47-2d47-46d9-81b2-d63ef0209953" />
<img width="1099" alt="Screenshot 2025-07-03 at 4 10 36 PM" src="https://github.com/user-attachments/assets/f37099a8-5dfb-4733-87b2-0e55be887822" />
<img width="632" alt="Screenshot 2025-07-03 at 4 09 48 PM" src="https://github.com/user-attachments/assets/19e3ca3a-ff33-44fb-8104-f0e207fd3266" />

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work