### PR TITLE
docs: Fixed Naming of Guide Docs Under Integrations

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,8 +25,8 @@
 ## Integrations 
 
 - Frameworks
-  - [Set up Keyshade with Next.js](integration/frameworks/set-up-with-nextjs.md)
-  - [Set up Keyshade with Node.js](integration/frameworks/set-up-with-nodejs.md)
+  - [Next.js](integration/frameworks/set-up-with-nextjs.md)
+  - [Node.js](integration/frameworks/set-up-with-nodejs.md)
 - Languages
   - [Go](integration/languages/set-up-with-go.md)
   - [Python](integration/languages/set-up-with-python.md)

--- a/docs/integration/frameworks/set-up-with-nextjs.md
+++ b/docs/integration/frameworks/set-up-with-nextjs.md
@@ -1,5 +1,5 @@
 ---
-description: How to set up Keyshade in a Next.js app for secure runtime secrets — no more .env files.
+description: How to set up Keyshade in a Next.js app.
 ---
 
 # Set up Keyshade with Next.js

--- a/docs/integration/frameworks/set-up-with-nodejs.md
+++ b/docs/integration/frameworks/set-up-with-nodejs.md
@@ -1,5 +1,5 @@
 ---
-description: How to set up Keyshade in a Node.js app for secure runtime secrets — no more .env files.
+description: How to set up Keyshade in a Node.js app.
 ---
 
 # Set up Keyshade with Node.js

--- a/docs/integration/languages/set-up-with-go.md
+++ b/docs/integration/languages/set-up-with-go.md
@@ -1,5 +1,5 @@
 ---
-description: How to set up Keyshade in a Go app for secure runtime secrets — no more .env files.
+description: How to set up Keyshade in a Go app.
 ---
 
 # Set up Keyshade with Go

--- a/docs/integration/languages/set-up-with-python.md
+++ b/docs/integration/languages/set-up-with-python.md
@@ -1,5 +1,5 @@
 ---
-description: How to set up Keyshade in a Python app for secure runtime secrets — no more .env files.
+description: How to set up Keyshade in a Python app.
 ---
 
 # Set up Keyshade with Python

--- a/docs/integration/languages/set-up-with-rust.md
+++ b/docs/integration/languages/set-up-with-rust.md
@@ -1,5 +1,5 @@
 ---
-description: How to set up Keyshade in a Rust app for secure runtime secrets — no more .env files.
+description: How to set up Keyshade in a Rust app.
 ---
 
 # Set up Keyshade with Rust


### PR DESCRIPTION
## Description

Changed naming and description of docs under Integration.

## Mentions

@kriptonian1 @rajdip-b 

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

### Documentation Update

- [x] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
