### PR TITLE
fix(platform): Vercel integration was created using wrong environment metadata

### DIFF
--- a/apps/api/src/integration/integration.types.ts
+++ b/apps/api/src/integration/integration.types.ts
@@ -76,7 +76,7 @@ export interface VercelIntegrationMetadata extends IntegrationMetadata {
 
   // Vercel environments mapping with keyshade environment names
   environments: Record<
-    Environment['name'],
+    Environment['slug'],
     {
       vercelSystemEnvironment?: 'production' | 'preview' | 'development'
       vercelCustomEnvironmentId?: string

--- a/apps/platform/src/components/integrations/ProjectEnvironmentMapping/index.tsx
+++ b/apps/platform/src/components/integrations/ProjectEnvironmentMapping/index.tsx
@@ -158,10 +158,10 @@ export default function ProjectEnvironmentMapping({
       updateMappings((prevMappings) => {
         const updated = { ...prevMappings }
         if (isSelected) {
-          const { [environment.name]: _removed, ...rest } = updated
+          const { [environment.slug]: _removed, ...rest } = updated
           return rest
         }
-        updated[environment.name] = { vercelSystemEnvironment: 'development' }
+        updated[environment.slug] = { vercelSystemEnvironment: 'development' }
         return updated
       })
 
@@ -180,44 +180,44 @@ export default function ProjectEnvironmentMapping({
   }
 
   const handleVercelEnvironmentChange = (
-    envName: string,
+    envSlug: string,
     systemEnvironment: string
   ) => {
     updateMappings((prev) => ({
       ...prev,
-      [envName]: {
-        ...prev[envName],
+      [envSlug]: {
+        ...prev[envSlug],
         vercelSystemEnvironment:
           systemEnvironment === 'custom'
             ? undefined
             : (systemEnvironment as VercelSystemEnvironment),
         vercelCustomEnvironmentId:
           systemEnvironment === 'custom'
-            ? prev[envName].vercelCustomEnvironmentId || ''
+            ? prev[envSlug].vercelCustomEnvironmentId || ''
             : undefined
       }
     }))
   }
 
-  const handleCustomIdChange = (envName: string, customId: string) => {
+  const handleCustomIdChange = (envSlug: string, customId: string) => {
     updateMappings((prev) => ({
       ...prev,
-      [envName]: {
-        ...prev[envName],
+      [envSlug]: {
+        ...prev[envSlug],
         vercelCustomEnvironmentId: customId
       }
     }))
   }
 
-  const getVercelEnvironmentType = (envName: string) => {
-    const mapping = environmentMappings[envName]
+  const getVercelEnvironmentType = (envSlug: string) => {
+    const mapping = environmentMappings[envSlug]
     return mapping.vercelCustomEnvironmentId !== undefined
       ? 'custom'
       : mapping.vercelSystemEnvironment || 'development'
   }
 
-  const getCustomId = (envName: string) =>
-    environmentMappings[envName].vercelCustomEnvironmentId || ''
+  const getCustomId = (envSlug: string) =>
+    environmentMappings[envSlug].vercelCustomEnvironmentId || ''
 
   const isEnvironmentSelected = (envId: string) =>
     selectedEnvironments.some((env) => env.id === envId)
@@ -342,9 +342,9 @@ export default function ProjectEnvironmentMapping({
                       </label>
                       <Select
                         onValueChange={(value) =>
-                          handleVercelEnvironmentChange(env.name, value)
+                          handleVercelEnvironmentChange(env.slug, value)
                         }
-                        value={getVercelEnvironmentType(env.name)}
+                        value={getVercelEnvironmentType(env.slug)}
                       >
                         <SelectTrigger
                           className="h-8 border-white/20 bg-white/10 text-sm text-white"
@@ -365,7 +365,7 @@ export default function ProjectEnvironmentMapping({
                       </Select>
                     </div>
 
-                    {getVercelEnvironmentType(env.name) === 'custom' && (
+                    {getVercelEnvironmentType(env.slug) === 'custom' && (
                       <div>
                         <label
                           className="mb-1 block text-sm text-white/70"
@@ -377,11 +377,11 @@ export default function ProjectEnvironmentMapping({
                           className="h-8 border-white/20 bg-white/10 text-sm text-white placeholder-white/50"
                           id={`custom-env-id-${env.id}`}
                           onChange={(e) =>
-                            handleCustomIdChange(env.name, e.target.value)
+                            handleCustomIdChange(env.slug, e.target.value)
                           }
                           placeholder="Enter custom environment ID"
                           type="text"
-                          value={getCustomId(env.name)}
+                          value={getCustomId(env.slug)}
                         />
                       </div>
                     )}

--- a/packages/common/src/integration.ts
+++ b/packages/common/src/integration.ts
@@ -26,7 +26,7 @@ interface GroupItem {
 }
 
 export interface VercelEnvironmentMapping {
-  [environmentName: string]: {
+  [environmentSlug: string]: {
     vercelSystemEnvironment?: 'production' | 'preview' | 'development'
     vercelCustomEnvironmentId?: string
   }


### PR DESCRIPTION
### **User description**
…pping

## Description

Fixed incorrect env mapping in vercel

## Mentions

@rajdip-b @kriptonian1 

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect environment mapping in Vercel integration

- Changed from using environment `name` to `slug` for consistency

- Updated type definitions and UI components accordingly


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Environment Name"] -- "changed to" --> B["Environment Slug"]
  B --> C["Type Definitions"]
  B --> D["UI Components"]
  B --> E["Integration Metadata"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration.types.ts</strong><dd><code>Update integration metadata type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/integration/integration.types.ts

<li>Updated <code>VercelIntegrationMetadata</code> interface to use <code>Environment['slug']</code> <br>instead of <code>Environment['name']</code>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1066/files#diff-226ba7c5a595a3a29d8c322e431bfcdb3d33069f9d8c9178fe9128f1c97ae812">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>integration.ts</strong><dd><code>Update environment mapping interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/common/src/integration.ts

<li>Changed <code>VercelEnvironmentMapping</code> interface key from <code>environmentName</code> to <br><code>environmentSlug</code>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1066/files#diff-19867476d3703dd9e7d8fe0cf901bfdb317d8604e415e50aaaf6b1216481933f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Update UI component to use environment slug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/platform/src/components/integrations/ProjectEnvironmentMapping/index.tsx

<li>Replaced all references from <code>environment.name</code> to <code>environment.slug</code><br> <li> Updated function parameters from <code>envName</code> to <code>envSlug</code><br> <li> Modified mapping operations to use slug instead of name


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1066/files#diff-051d52e43c8395df5bfa733dea7a375e0b4d84cc935e4dfed7d818deaac2e894">+18/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>