### PR TITLE
feat: adding an endpoint to fetch vercel environments

### DIFF
--- a/apps/api/src/integration/integration.controller.ts
+++ b/apps/api/src/integration/integration.controller.ts
@@ -141,4 +141,20 @@ export class IntegrationController {
       integrationSlug
     )
   }
+
+  @Put(':integrationSlug/vercel/environments')
+  @RequiredApiKeyAuthorities(
+    Authority.READ_PROJECT,
+    Authority.READ_ENVIRONMENT,
+    Authority.READ_INTEGRATION
+  )
+  async getVercelEnvironments(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('integrationSlug') integrationSlug: string
+  ) {
+    return await this.integrationService.getVercelEnvironments(
+      user,
+      integrationSlug
+    )
+  }
 }

--- a/apps/api/src/integration/integration.service.ts
+++ b/apps/api/src/integration/integration.service.ts
@@ -34,6 +34,7 @@ import { BaseIntegration } from './plugins/base.integration'
 import { HydrationService } from '@/common/hydration.service'
 import { InclusionQuery } from '@/common/inclusion-query'
 import { HydratedIntegration } from './integration.types'
+import { VercelIntegration } from './plugins/vercel.integration'
 
 @Injectable()
 export class IntegrationService {
@@ -43,7 +44,8 @@ export class IntegrationService {
     private readonly prisma: PrismaService,
     private readonly authorizationService: AuthorizationService,
     private readonly slugGenerator: SlugGenerator,
-    private readonly hydrationService: HydrationService
+    private readonly hydrationService: HydrationService,
+    private readonly vercelIntegration: VercelIntegration
   ) {}
 
   /**
@@ -423,6 +425,19 @@ export class IntegrationService {
     // @ts-expect-error -- We expect the metadata to be in JSON format
     integration.metadata = decryptMetadata(integration.metadata)
     return integration
+  }
+
+  async getVercelEnvironments(
+    user: AuthenticatedUser,
+    integrationSlug: string
+  ) {
+    this.logger.log(
+      `User ${user.id} fetching Vercel environments for integration ${integrationSlug}`
+    )
+
+    const { project } = await this.getIntegration(user, integrationSlug)
+
+    return this.vercelIntegration.getVercelEnvironments(project.id)
   }
 
   /* istanbul ignore next */

--- a/packages/api-client/src/controllers/integration.ts
+++ b/packages/api-client/src/controllers/integration.ts
@@ -12,7 +12,9 @@ import {
   UpdateIntegrationRequest,
   UpdateIntegrationResponse,
   ValidateIntegrationConfigurationRequest,
-  ValidateIntegrationConfigurationResponse
+  ValidateIntegrationConfigurationResponse,
+  GetVercelEnvironmentsRequest,
+  GetVercelEnvironmentsResponse
 } from '@keyshade/schema'
 import { APIClient } from '@api-client/core/client'
 import { ClientResponse } from '@keyshade/schema'
@@ -83,6 +85,18 @@ export default class IntegrationController {
     )
     const response = await this.apiClient.get(url, headers)
     return await parseResponse<GetAllIntegrationRunsResponse>(response)
+  }
+
+  async getVercelEnvironments(
+    request: GetVercelEnvironmentsRequest,
+    headers?: Record<string, string>
+  ): Promise<ClientResponse<GetVercelEnvironmentsResponse>> {
+    const response = await this.apiClient.put(
+      `/api/integration/${request.integrationSlug}/vercel/environments`,
+      headers
+    )
+
+    return await parseResponse<GetVercelEnvironmentsResponse>(response)
   }
 
   async deleteIntegration(

--- a/packages/schema/src/integration/index.ts
+++ b/packages/schema/src/integration/index.ts
@@ -129,3 +129,16 @@ export const ValidateIntegrationConfigurationRequestSchema =
 export const ValidateIntegrationConfigurationResponseSchema = z.object({
   success: z.literal(true)
 })
+
+export const GetVercelEnvironmentsRequestSchema = z.object({
+  integrationSlug: IntegrationSchema.shape.slug
+})
+
+export const GetVercelEnvironmentsResponseSchema = z.record(
+  z.object({
+    vercelSystemEnvironment: z
+      .enum(['production', 'preview', 'development'])
+      .optional(),
+    vercelCustomEnvironmentId: z.string().optional()
+  })
+)

--- a/packages/schema/src/integration/index.types.ts
+++ b/packages/schema/src/integration/index.types.ts
@@ -14,7 +14,9 @@ import {
   GetAllIntegrationRunsRequestSchema,
   GetAllIntegrationRunsResponseSchema,
   ValidateIntegrationConfigurationRequestSchema,
-  ValidateIntegrationConfigurationResponseSchema
+  ValidateIntegrationConfigurationResponseSchema,
+  GetVercelEnvironmentsRequestSchema,
+  GetVercelEnvironmentsResponseSchema
 } from '.'
 import { z } from 'zod'
 
@@ -74,4 +76,12 @@ export type ValidateIntegrationConfigurationRequest = z.infer<
 
 export type ValidateIntegrationConfigurationResponse = z.infer<
   typeof ValidateIntegrationConfigurationResponseSchema
+>
+
+export type GetVercelEnvironmentsRequest = z.infer<
+  typeof GetVercelEnvironmentsRequestSchema
+>
+
+export type GetVercelEnvironmentsResponse = z.infer<
+  typeof GetVercelEnvironmentsResponseSchema
 >


### PR DESCRIPTION
## Description

- Added a new API endpoint that returns all of the vercel envs ( both default / custom )
- Added controller details to `@keyshade/api-client` and `@keyshade/schema` 
- I didn't update the docs as that wasn't mentioned in the issue, but would be open to doing it

Fixes #1029


## Future Improvements

- Probably some restructuring could be done to not have Vercel specific code in the root parts of integrations, but that's not a critical thing for this particular task

## Mentions

@rajdip-b tagging you as you created the issue

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [x] My changes are breaking another fix/feature of the project



### Documentation Update

- [x] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.
