### PR TITLE
fix: updated the logic for leaving workspace deletion & enhanced tooltip messages

### DIFF
--- a/apps/platform/src/app/(main)/(settings)/[workspace]/settings/page.tsx
+++ b/apps/platform/src/app/(main)/(settings)/[workspace]/settings/page.tsx
@@ -72,7 +72,7 @@ export default function WorkspaceSettingsPage(): JSX.Element {
     name: selectedWorkspace?.name || '',
     icon: selectedWorkspace?.icon || '🔥'
   })
-  const isDisableLeave =
+  const isLeaveDisabled =
     memberCount === 1 ||
     selectedWorkspace?.isDefault ||
     user?.id === selectedWorkspace?.ownerId
@@ -81,7 +81,7 @@ export default function WorkspaceSettingsPage(): JSX.Element {
   const isAuthorizedToDelete = selectedWorkspace?.entitlements.canDelete
 
   const isDeleteWorkspaceDisabled =
-    isLoading || selectedWorkspace?.isDefault || !isAuthorizedToDelete
+    isLoading || isLeaveDisabled || !isAuthorizedToDelete
 
   function handleEmojiSelect(emojiData: string) {
     setWorkspaceData({
@@ -329,7 +329,7 @@ export default function WorkspaceSettingsPage(): JSX.Element {
                 </Button>
               </TooltipTrigger>
 
-              {isDisableLeave ? (
+              {isLeaveDisabled ? (
                 <TooltipContent
                   className="max-w-[350px] border-white/20 bg-white/10 text-white backdrop-blur-xl"
                   sideOffset={7}
@@ -338,11 +338,10 @@ export default function WorkspaceSettingsPage(): JSX.Element {
                     <p>This is your default workspace. You can not leave it.</p>
                   ) : user?.id === selectedWorkspace?.ownerId ? (
                     <p>
-                      You are the owner of this workspace. You can not leave
-                      workspace without transferring ownership.
+                      You are currently the admin of the workspace. Transfer the ownership to someone else if you would like to leave this workspace
                     </p>
                   ) : memberCount === 1 ? (
-                    <p>You are the only member of this workspace.</p>
+                    <p>You are the only member of this workspace. You might want to delete the workspace</p>
                   ) : null}
                 </TooltipContent>
               ) : null}


### PR DESCRIPTION
## Description
This PR fixes the following:
- Renamed `isDisableLeave` to `isLeaveDisabled` for better readability.
- Updated the logic for disabling workspace deletion to use the new variable.
- Enhanced tooltip messages to provide clearer guidance for users regarding workspace ownership and deletion.

Fixes #1118 

## Dependencies
N/A

## Future Improvements
N/A

## Mentions
@rajdip-b

## Developer's checklist
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**
- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues