### PR TITLE
feat(platform, web): implement tier-based redirect logic and disable heavy API calls

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,3 +2,7 @@
 
 open_collective: keyshade
 custom: ["https://console.algora.io/bounties/new"]
+
+# .github/funding.yml
+github: keyshade-xyz
+custom: ["https://github.com/sponsors/keyshade-xyz"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.34.0-stage.9](https://github.com/keyshade-xyz/keyshade/compare/v2.34.0-stage.8...v2.34.0-stage.9) (2025-09-03)
+
+### 🚀 Features
+
+* **web:** add book a demo ([#1139](https://github.com/keyshade-xyz/keyshade/issues/1139)) ([193b08d](https://github.com/keyshade-xyz/keyshade/commit/193b08d0228a154b0584e1873b52663b5b04db1d))
+
 ## [2.34.0-stage.8](https://github.com/keyshade-xyz/keyshade/compare/v2.34.0-stage.7...v2.34.0-stage.8) (2025-09-02)
 
 ### 🚀 Features

--- a/apps/web/src/components/shared/navbar/index.tsx
+++ b/apps/web/src/components/shared/navbar/index.tsx
@@ -45,6 +45,15 @@ function Navbar(): React.JSX.Element {
             Blog
           </a>
         </li>
+        <li className="text-white/70">
+          <a
+            href="https://cal.com/keyshade/demo"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Book a Demo
+          </a>
+        </li>
       </ul>
       <div className="flex items-center gap-x-4">
         <a href="https://git.new/keyshade">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyshade-xyz",
-  "version": "2.34.0-stage.8",
+  "version": "2.34.0-stage.9",
   "license": "MPL-2.0",
   "private": true,
   "engineStrict": false,


### PR DESCRIPTION
feat(pricing): wire up tier-based button behavior on pricing page

- Redirect **Free** tier button to `https://app.keyshade.xyz/`
- For **Enterprise** tier, open default email client to contact sales
- For other **Paid** tiers:
  - If user has an account: redirect to `https://app.keyshade.xyz/<workspaceSlug>/billing`
  - If user does not have an account: send to the authentication page
- Temporarily comment out `disable` variable and `secret` feature to stop excessive API calls