### PR TITLE
chore(scoop): update to 2.34.0-stage.13

### DIFF
--- a/bucket/keyshade.json
+++ b/bucket/keyshade.json
@@ -1,16 +1,13 @@
 {
-  "version": "2.34.0-stage.13",
+  "version": "3.3.0-stage.2",
   "description": "Keyshade CLI - Secure, real-time secret and configuration management",
   "homepage": "https://keyshade.xyz",
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/keyshade-xyz/keyshade/releases/download/v0.0.0/keyshade-cli.exe",
-      "hash": "",
+      "url": "https://github.com/keyshade-xyz/keyshade/releases/download/v3.3.0-stage.2/keyshade-cli.exe",
+      "hash": "6bf96b19c8a9076087d372fc3db553ceeffb7d421ad388ae421e3bf7a5d59547",
       "bin": "keyshade-cli.exe"
     }
-  },
-  "bin": {
-    "hash": "6bf96b19c8a9076087d372fc3db553ceeffb7d421ad388ae421e3bf7a5d59547"
   }
 }


### PR DESCRIPTION
### **User description**
Automated scoop manifest update.


___

### **PR Type**
Other


___

### **Description**
- Update Keyshade CLI version from 2.34.0-stage.13 to 3.3.0-stage.2

- Fix download URL to point to correct release tag

- Move hash value to correct architecture section

- Remove redundant bin hash configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version 2.34.0-stage.13"] --> B["Version 3.3.0-stage.2"]
  C["Incorrect URL"] --> D["Fixed Release URL"]
  E["Misplaced Hash"] --> F["Corrected Hash Location"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keyshade.json</strong><dd><code>Update Scoop manifest for new CLI version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bucket/keyshade.json

<ul><li>Version bumped from 2.34.0-stage.13 to 3.3.0-stage.2<br> <li> Download URL updated to match new version tag<br> <li> Hash value moved from separate bin section to architecture section<br> <li> Removed redundant bin hash configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1148/files#diff-28abf1592aede86e535b55c6a62ec6a34120063eb72b4ef3ee5cade9cd92f86b">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

