### PR TITLE
fix: resolve hero image overlap with secret section text

### DIFF
--- a/apps/web/src/components/hero/index.tsx
+++ b/apps/web/src/components/hero/index.tsx
@@ -9,7 +9,7 @@ function Hero(): React.JSX.Element {
   return (
     <>
       <Toaster />
-      <div className="relative -top-8 flex h-screen w-full flex-col items-center justify-center  bg-[url(/hero/colour-bg.svg)]  bg-cover bg-no-repeat md:pt-[36rem]">
+      <div className="relative -top-8 flex min-h-screen w-full flex-col items-center justify-center  bg-[url(/hero/colour-bg.svg)]  bg-cover bg-no-repeat pb-4 md:pt-[36rem]">
         <section className="flex flex-col items-center gap-8 py-[6.88rem] ">
           <h1
             className={` text-brandBlue w-[25rem] text-center text-4xl md:w-auto md:text-7xl`}

--- a/apps/web/src/components/secretSection/index.tsx
+++ b/apps/web/src/components/secretSection/index.tsx
@@ -51,7 +51,7 @@ const cardData = [
 
 function SecretSection(): React.JSX.Element {
   return (
-    <section className="mt-[10vw] flex min-h-[50vh] w-full flex-col items-center gap-y-[5rem] p-6 sm:mt-[1vh] md:gap-y-[9.69rem] landscape:mt-[30vh]">
+    <section className="mt-[4vw] flex min-h-[50vh] w-full flex-col items-center gap-y-[5rem] p-6 sm:mt-[1vh] md:mt-[2vh] md:gap-y-[9.69rem] landscape:mt-[2vh]">
       <div className="text-brandBlue/80 flex flex-col gap-y-[0.81rem]">
         <h2
           className={`${GeistSans.className}  text-center text-4xl md:text-5xl`}


### PR DESCRIPTION
## Description

Fixed hero image overlap issue where the hero image was partially obscuring the "Secure Your Configurations with Confidence" text on various devices including iPad Pro, Surface Pro 9, and Asus Zenbook fold. Adjusted spacing and margins to create proper visual separation while maintaining a cohesive layout.

Fixes #1160 

## Dependencies

No new dependencies added. Changes made using existing Tailwind CSS classes for responsive design.

## Future Improvements

Consider adding animation transitions when scrolling between sections

## Mentions

@rajdip-b  Please review the responsive design changes across different device breakpoints

## Screenshots of relevant screens

<img width="1480" height="1250" alt="image" src="https://github.com/user-attachments/assets/ccdaae2e-c19d-4449-8ecf-0c7d8f46264a" />

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [x] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
