### PR TITLE
feat(api): Add totalTriggers to integration response and schema

### DIFF
--- a/apps/api/src/common/hydration.service.ts
+++ b/apps/api/src/common/hydration.service.ts
@@ -1,7 +1,4 @@
-import {
-  HydratedIntegration,
-  RawIntegration
-} from '@/integration/integration.types'
+import { HydratedIntegration } from '@/integration/integration.types'
 import { PrismaService } from '@/prisma/prisma.service'
 import { AuthenticatedUser } from '@/user/user.types'
 import { Injectable, Logger } from '@nestjs/common'
@@ -51,7 +48,7 @@ type RootHydrationParams = {
 }
 
 type IntegrationHydrationParams = RootHydrationParams & {
-  integration: RawIntegration
+  integration: HydratedIntegration
 }
 
 type SecretHydrationParams = RootHydrationParams & {
@@ -145,7 +142,10 @@ export class HydrationService {
 
     return {
       ...integration,
-      entitlements
+      entitlements,
+      totalTriggers: Array.isArray(integration.notifyOn)
+        ? integration.notifyOn.length
+        : 0
     }
   }
 

--- a/apps/api/src/integration/integration.types.ts
+++ b/apps/api/src/integration/integration.types.ts
@@ -116,6 +116,14 @@ export interface HydratedIntegration extends Integration {
     name: string
     slug: string
   }[]
+  /** Integration triggers/events */
+  notifyOn: string[]
+  /** Integration slug */
+  slug: string
+  /** Workspace ID for the integration */
+  workspaceId: string
+  /** Total number of triggers for this integration */
+  totalTriggers: number
 }
 
 export interface RawIntegration

--- a/packages/schema/src/integration/index.ts
+++ b/packages/schema/src/integration/index.ts
@@ -45,7 +45,9 @@ export const IntegrationSchema = z.object({
   entitlements: z.object({
     canUpdate: z.boolean(),
     canDelete: z.boolean()
-  })
+  }),
+  /** Total number of triggers for this integration */
+  totalTriggers: z.number()
 })
 
 export const IntegrationRunSchema = z.object({


### PR DESCRIPTION
## PR Description:
- Adds totalTriggers field to HydratedIntegration and IntegrationSchema
- Updates hydration logic to compute totalTriggers from the notifyOn array.
- Prepares for issue #1169 (integration triggers count in API response).

## Description

- This PR introduces a new field, totalTriggers to the integration API response and shared schema.
- The field represents the total number of triggers/events configured for an integration, computed from the notifyOn array.
- This change helps clients easily display or use the number of triggers associated with each integration.

Fixes #1169 

## Future Improvements

Add more granular trigger details if needed.
Extend tests for edge cases involving triggers.

## Developer's checklist

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [ ] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.
