### PR TITLE
fix: prevent project card layout breaking with long descriptions.

### DIFF
--- a/apps/platform/src/components/dashboard/project/projectCard/index.tsx
+++ b/apps/platform/src/components/dashboard/project/projectCard/index.tsx
@@ -109,7 +109,7 @@ export default function ProjectCard({
             </div>
             <div className="flex min-w-0 flex-col overflow-hidden">
               <div className="truncate font-semibold">{name}</div>
-              <span className="truncate text-xs font-semibold text-white/60">
+              <span className="line-clamp-2 text-xs font-semibold text-white/60 leading-tight">
                 {description}
               </span>
             </div>


### PR DESCRIPTION
## Description

Code Change
Before: className="truncate text-xs font-semibold text-white/60"
After: className="line-clamp-2 text-xs font-semibold text-white/60 leading-tight"

What This Fix Does
✅ Limits text to 2 lines maximum instead of 1 line
✅ Adds ellipsis (...) when text is longer than 2 lines
✅ Maintains consistent card heights across all project cards
✅ Prevents layout breaking regardless of description length
✅ Improves readability by showing more content (2 lines vs 1)<br />

Fixes #[1172]

## Dependencies

_Mention any dependencies/packages used_

## Future Improvements

_Mention any improvements to be done in future related to any file/feature_

## Mentions

_Mention and tag the people_

## Screenshots of relevant screens

_Add screenshots of relevant screens_

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.
