### PR TITLE
fix: resolved members refresh issue after member removal

### DIFF
--- a/apps/platform/src/app/(main)/members/@joined/page.tsx
+++ b/apps/platform/src/app/(main)/members/@joined/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import type { GetMembersResponse } from '@keyshade/schema'
 import TransferOwnershipDialog from '@/components/members/transferOwnershipDialog'
@@ -18,7 +18,8 @@ import {
   removeMemberOpenAtom,
   selectedMemberAtom,
   selectedWorkspaceAtom,
-  transferOwnershipOpenAtom
+  transferOwnershipOpenAtom,
+  membersRefreshAtom
 } from '@/store'
 import { InfiniteScrollList } from '@/components/ui/infinite-scroll-list'
 import ControllerInstance from '@/lib/controller-instance'
@@ -32,7 +33,14 @@ export default function JoinedMembersTable(): React.JSX.Element {
     transferOwnershipOpenAtom
   )
   const currentWorkspace = useAtomValue(selectedWorkspaceAtom)
+  const membersRefresh = useAtomValue(membersRefreshAtom)
+  const [resetKey, setResetKey] = useState(0)
   const [isEditMemberOpen, setIsEditMemberOpen] = useAtom(editMemberOpenAtom)
+
+  // If membersRefresh changes, increment ResetKey
+  useEffect(() => {
+    setResetKey(prev => prev + 1)
+  }, [membersRefresh])
 
   const fetchMembers = useCallback(
     async ({ page, limit }: { page: number; limit: number }) => {
@@ -130,6 +138,7 @@ export default function JoinedMembersTable(): React.JSX.Element {
               itemComponent={renderMemberRow}
               itemKey={(member) => member.id}
               itemsPerPage={10}
+              key={resetKey} // For remounting of list
             />
           </TableBody>
         </Table>

--- a/apps/platform/src/components/members/removeMemberDialog/index.tsx
+++ b/apps/platform/src/components/members/removeMemberDialog/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import {
   membersOfWorkspaceAtom,
+  membersRefreshAtom,
   removeMemberOpenAtom,
   selectedMemberAtom,
   selectedWorkspaceAtom,
@@ -29,6 +30,7 @@ export default function RemoveMemberDialog() {
   const [isRemoveMemberOpen, setIsRemoveMemberOpen] =
     useAtom(removeMemberOpenAtom)
   const setMembers = useSetAtom(membersOfWorkspaceAtom)
+  const setMembersRefresh = useSetAtom(membersRefreshAtom)
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const removeMember = useHttp(() =>
@@ -50,6 +52,7 @@ export default function RemoveMemberDialog() {
       try {
         if (success) {
           setMemberCount((prevCount) => prevCount - 1)
+          setMembersRefresh(prev => prev + 1)
           toast.success('Member removed successfully', {
             description: (
               <p className="text-xs text-emerald-300">
@@ -78,7 +81,8 @@ export default function RemoveMemberDialog() {
     handleClose,
     selectedMember,
     setSelectedMember,
-    setMemberCount
+    setMemberCount,
+    setMembersRefresh
   ])
 
   return (

--- a/apps/platform/src/store/index.ts
+++ b/apps/platform/src/store/index.ts
@@ -219,6 +219,7 @@ export const removeMemberOpenAtom = atom<boolean>(false)
 export const transferOwnershipOpenAtom = atom<boolean>(false)
 export const editMemberOpenAtom = atom<boolean>(false)
 export const cancelInviteOpenAtom = atom<boolean>(false)
+export const membersRefreshAtom = atom<number>(0)
 
 export const deleteAccountOpenAtom = atom<boolean>(false)
 


### PR DESCRIPTION
## Description

Fixed the Members refresh issue — previously, when a member was removed, the members list was not updating automatically.
Now, using resetKey tied to membersRefreshAtom, the InfiniteScrollList remounts and refetches the members list seamlessly without a full page refresh.

Fixes #1120

## Dependencies

No new dependencies were added.

## Future Improvements

_Mention any improvements to be done in future related to any file/feature_

## Mentions

@rajdip-b @jackcamerano 

## Screenshots of relevant screens

_Add screenshots of relevant screens_

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.xyz](https://docs.keyshade.xyz)
- [ ] I have made the necessary updates to the documentation, or no documentation changes are required.
