### PR TITLE
fix: improve homepage layout on small mobile screens

### DIFF
--- a/apps/web/src/components/hero/index.tsx
+++ b/apps/web/src/components/hero/index.tsx
@@ -12,12 +12,12 @@ function Hero(): React.JSX.Element {
       <div className="relative -top-8 flex min-h-screen w-full flex-col items-center justify-center  bg-[url(/hero/colour-bg.svg)]  bg-cover bg-no-repeat pb-4 md:pt-[10rem]">
         <section className="flex flex-col items-center gap-8 py-[6.88rem] ">
           <h1
-            className={` text-brandBlue w-[25rem] text-center text-4xl md:w-auto md:text-7xl`}
+            className={` text-brandBlue w-full text-center text-4xl md:w-auto md:text-7xl`}
             style={{ textShadow: '0px 4px 4px rgba(202, 236, 241, 0.25)' }}
           >
             The better .env file replacement
           </h1>
-          <span className="text-brandBlue/80 flex w-[20rem] flex-col justify-center text-center text-sm md:w-[35rem] md:text-xl md:leading-[2rem]">
+          <span className="text-brandBlue/80 flex w-full max-w-md flex-col justify-center text-center text-sm md:w-[35rem] md:text-xl md:leading-[2rem]">
             <p>Stop DMing your Environment variables</p>
             <p>And start syncing them securely & instantly </p>
           </span>

--- a/apps/web/src/components/secretSection/index.tsx
+++ b/apps/web/src/components/secretSection/index.tsx
@@ -51,7 +51,7 @@ const cardData = [
 
 function SecretSection(): React.JSX.Element {
   return (
-    <section className="mt-[4vw] flex min-h-[50vh] w-full flex-col items-center gap-y-[5rem] p-6 sm:mt-[1vh] md:mt-[2vh] md:gap-y-[9.69rem] landscape:mt-[2vh]">
+    <section className="mt-[4vw] flex min-h-[50vh] w-full flex-col items-center gap-y-[5rem] py-6 sm:mt-[1vh] md:mt-[2vh] md:gap-y-[9.69rem] landscape:mt-[2vh]">
       <div className="text-brandBlue/80 flex flex-col gap-y-[0.81rem]">
         <h2
           className={`${GeistSans.className}  text-center text-4xl md:text-5xl`}


### PR DESCRIPTION
### **User description**
## Description

This PR fixes #1230 - the unresponsive homepage layout on small mobile devices like the iPhone SE. The changes ensure that content is fluid, readable, and well-spaced by replacing fixed-width elements with responsive utilities and standardizing component padding.

## Dependencies

No new dependencies or packages were added.

## Future Improvements

A broader audit of responsive styling across other pages could be beneficial to ensure a consistent mobile experience throughout the entire application.

## Screenshots of relevant screens

| Before (iPhone SE) | After (iPhone SE) |
| :---: | :---: |
| <img width="656" height="637" alt="screenshot" src="https://github.com/user-attachments/assets/40675444-9cf3-4bd1-bff6-6d69a37466be" /> | <img width="658" height="638" alt="screenshot" src="https://github.com/user-attachments/assets/bcc7a5db-13df-413a-b4e4-5fc880b54070" /> |

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues

### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.io](https://docs.keyshade.io)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace fixed-width elements with responsive utilities on homepage

- Change hero title from `w-[25rem]` to `w-full` for mobile

- Update hero subtitle with `max-w-md` constraint for better responsiveness

- Standardize section padding from `p-6` to `py-6` for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed-width elements<br/>w-[25rem], w-[20rem]"] -- "Replace with responsive" --> B["Fluid width utilities<br/>w-full, max-w-md"]
  C["Inconsistent padding<br/>p-6"] -- "Standardize to" --> D["Vertical padding only<br/>py-6"]
  B --> E["Mobile-friendly homepage<br/>iPhone SE compatible"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Make hero section responsive with fluid widths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/hero/index.tsx

<ul><li>Changed hero title width from fixed <code>w-[25rem]</code> to responsive <code>w-full</code><br> <li> Updated hero subtitle width from fixed <code>w-[20rem]</code> to <code>w-full max-w-md</code> <br>for better mobile responsiveness<br> <li> Maintains responsive behavior on larger screens with <code>md:</code> breakpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1231/files#diff-7613ce5c9e898c20a2427ba5bf13810f61bb0a532139896e00a54cd0285ad40c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Standardize section padding to vertical only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/secretSection/index.tsx

<ul><li>Changed section padding from <code>p-6</code> to <code>py-6</code> to standardize vertical <br>padding only<br> <li> Improves consistency in component spacing across different screen <br>sizes</ul>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1231/files#diff-e42a662789f9e2bea79e3dcf930ced9a457453fc06e433151aa446b65c78ba8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

