### PR TITLE
fix: resolve multiple layout overflows on tablet screens

### DIFF
--- a/apps/web/src/components/colabEasy/index.tsx
+++ b/apps/web/src/components/colabEasy/index.tsx
@@ -10,7 +10,7 @@ import { FollowerPointerCard } from '../ui/following-pointer'
 
 function ColabEasy(): React.JSX.Element {
   return (
-    <section className="mt-[10vw] flex flex-col items-center gap-y-[5rem] md:gap-y-[9.69rem]">
+    <section className="mt-[10vw] flex flex-col items-center gap-y-[5rem] px-4 md:gap-y-[9.69rem]">
       <div className="text-brandBlue/80 flex flex-col gap-y-[0.81rem]">
         <h2
           className={`${GeistSans.className}  text-center text-4xl md:text-5xl`}
@@ -44,7 +44,7 @@ function ColabEasy(): React.JSX.Element {
                 Fine-tune Permissions, for allocated Team Members
               </span>
             </div>
-            <CustomrollSVG className="w-[18rem] translate-x-[8vw] py-12 md:w-[21rem] md:translate-x-[4rem] md:py-0 md:pt-10" />
+            <CustomrollSVG className="w-full p-4" />
           </Card>
         </article>
         <article className="row-span-1">

--- a/apps/web/src/components/shared/card/index.tsx
+++ b/apps/web/src/components/shared/card/index.tsx
@@ -12,7 +12,7 @@ export default function Card({
 }: CardProps): React.JSX.Element {
   return (
     <div
-      className={`flex ${widthFull ? 'w-[20rem] md:w-full' : 'w-[20rem] md:w-[25rem]'} h-full flex-col justify-end rounded-2xl backdrop-blur-2xl`}
+      className={`flex ${widthFull ? 'w-[20rem] md:w-full' : 'w-full'} h-full flex-col justify-end rounded-2xl backdrop-blur-2xl`}
       style={{
         background:
           'linear-gradient(180deg, rgba(52, 52, 52, 0.20) 0%, rgba(0, 0, 0, 0.00) 100%), rgba(17, 18, 27, 0.24)',

--- a/apps/web/src/components/shared/navbar/index.tsx
+++ b/apps/web/src/components/shared/navbar/index.tsx
@@ -7,7 +7,7 @@ import { isUserLoggedIn } from '@/utils/is-user-logged-in'
 function Navbar(): React.JSX.Element {
   return (
     <nav
-      className="mx-10 mt-5 flex w-full items-center justify-between rounded-full border border-[#728689]/60 px-2 py-1 md:w-[79.625rem] md:px-[2.94rem]"
+      className="mx-10 mt-5 flex w-full items-center justify-between rounded-full border border-[#728689]/60 px-2 py-1 lg:w-[79.625rem] lg:px-[2.94rem]"
       style={{
         background:
           'linear-gradient(180deg, rgba(226, 232, 255, 0.15) 0%, rgba(226, 232, 255, 0.03) 100%)'
@@ -17,7 +17,7 @@ function Navbar(): React.JSX.Element {
         <Logo className="hidden md:flex" />
         <LogoM className="flex md:hidden" />
       </Link>
-      <ul className="hidden gap-x-4 text-white/60 md:flex">
+      <ul className="hidden gap-x-4 text-white/60 lg:flex">
         <li>
           <a
             href="https://docs.keyshade.io/"
@@ -58,7 +58,7 @@ function Navbar(): React.JSX.Element {
       <div className="flex items-center gap-x-4">
         <a href="https://git.new/keyshade">
           <button
-            className="hidden rounded-full border border-white/50 px-4 py-2 text-white/80 md:flex"
+            className="hidden rounded-full border border-white/50 px-4 py-2 text-white/80 lg:flex"
             type="button"
           >
             View GitHub


### PR DESCRIPTION
### **User description**
## Description

This PR fixes #1232 - the responsive layout issues on the homepage, specifically targeting tablet-sized viewports (`md` breakpoint / ~768px) where multiple components were overflowing horizontally.

The changes ensure a clean and fully responsive user experience on devices like the iPad Mini, addressing layout breaks in the **Navbar**, the **"Secure Your Configurations with Confidence"** grid, and the **"Collaboration made easy"** grid.

## Dependencies

No new dependencies were added.

## Future Improvements

While these fixes address the overflow issues, the "Collaboration made easy" section could potentially benefit from a review of its complex grid structure (`row-span`, `col-span`) for even more predictable responsive behavior in the future.

## Screenshots of relevant screens

| Before (iPad Mini) | After (iPad Mini) |
| :---: | :---: |
| <img width="656" height="637" alt="screenshot" src="https://github.com/user-attachments/assets/28695f34-f3a2-49dc-a4f4-ac8ff33ba35d" /> | <img width="658" height="638" alt="screenshot" src="https://github.com/user-attachments/assets/b4288a2a-c700-4c42-93ac-8902164f2261" /> |

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [x] My changes are not breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works *(UI changes verified via manual responsive testing)*
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues

### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.io](https://docs.keyshade.io)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix tablet layout overflows by adjusting responsive breakpoints

- Change navbar and grid components from `md` to `lg` breakpoint

- Add horizontal padding to collaboration section and SVG components

- Normalize card widths for consistent responsive behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tablet Overflow Issues"] --> B["Navbar Breakpoint"]
  A --> C["ColabEasy Section"]
  A --> D["Card Component"]
  B -- "md → lg breakpoint" --> E["Fixed Layout"]
  C -- "Add px-4 padding" --> E
  C -- "Simplify SVG styling" --> E
  D -- "Normalize widths" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add padding and simplify SVG styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/colabEasy/index.tsx

<ul><li>Add horizontal padding (<code>px-4</code>) to section for tablet spacing<br> <li> Simplify CustomrollSVG styling from complex transforms to <code>w-full p-4</code><br> <li> Remove viewport-width-based translations that caused overflow</ul>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1233/files#diff-bb0ee8872c7642b1cf4cfcf2c20485d8989b412e6144542efa7b2ff84d357196">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Normalize card width for responsive scaling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/shared/card/index.tsx

<ul><li>Change default card width from <code>md:w-[25rem]</code> to <code>w-full</code><br> <li> Ensures cards scale responsively without fixed width constraints<br> <li> Maintains conditional <code>widthFull</code> behavior for full-width cards</ul>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1233/files#diff-04d5bb19ea2b84b515f1db105c78c36d3e5353d407e338cd37b1fd5bd3a27fcf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Shift navbar breakpoints from md to lg</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/shared/navbar/index.tsx

<ul><li>Change navbar width breakpoint from <code>md</code> to <code>lg</code> for tablet compatibility<br> <li> Change navbar padding breakpoint from <code>md</code> to <code>lg</code><br> <li> Change navigation menu visibility from <code>md</code> to <code>lg</code> breakpoint<br> <li> Change GitHub button visibility from <code>md</code> to <code>lg</code> breakpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/keyshade-xyz/keyshade/pull/1233/files#diff-a71b18cda285f7612ae761e5afa0d2bde17b72326efe1a205551718c2a66ebbb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

