### PR TITLE
feat: keyshade run --show-process shows the parent-child relationship tree view of PIDs of the processes - CLI

### DIFF
--- a/apps/cli/src/commands/run.command.ts
+++ b/apps/cli/src/commands/run.command.ts
@@ -35,8 +35,6 @@ export default class RunCommand extends BaseCommand {
   private childProcess = null
   private showProcess = false
 
-  // TODO: implement --show-process PIDS
-
   getName(): string {
     return 'run'
   }

--- a/apps/cli/src/commands/run.command.ts
+++ b/apps/cli/src/commands/run.command.ts
@@ -34,6 +34,8 @@ export default class RunCommand extends BaseCommand {
 
   private childProcess = null
 
+  // TODO: implement --show-process PIDS
+
   getName(): string {
     return 'run'
   }

--- a/apps/cli/src/commands/run.command.ts
+++ b/apps/cli/src/commands/run.command.ts
@@ -33,6 +33,7 @@ export default class RunCommand extends BaseCommand {
   private command: string
 
   private childProcess = null
+  private showProcess = false
 
   getName(): string {
     return 'run'
@@ -71,6 +72,13 @@ export default class RunCommand extends BaseCommand {
         short: '-f',
         long: '--config-file <path>',
         description: 'Path to config file (default: keyshade.json)'
+      },
+      {
+        short: '-s',
+        long: '--show-process',
+        description:
+          'Show PID information for the keyshade runner and the spawned subprocess',
+        defaultValue: false
       }
     ]
   }
@@ -84,6 +92,9 @@ export default class RunCommand extends BaseCommand {
     // @ts-expect-error -- false positive, might be an error on commander.js
     // args return string[][] instead of string[]
     this.command = args[0].join(' ')
+
+    // Whether to show process IDs for debugging / UX
+    this.showProcess = Boolean(options.showProcess)
 
     // Pass all relevant options to fetchConfigurations for proper precedence handling
     const configurations = await this.fetchConfigurations({
@@ -331,6 +342,17 @@ export default class RunCommand extends BaseCommand {
     })
   }
 
+  private logProcessTree(childPid?: number) {
+    if (!this.showProcess) return
+
+    const parentPid = process.pid
+    const childPidString = childPid ? String(childPid) : 'N/A'
+
+    log.info(
+      `Process tree:\n  keyshade run (parent) PID: ${parentPid}\n  └─ subcommand PID: ${childPidString}`
+    )
+  }
+
   private async sleep(ms: number) {
     return await new Promise((resolve) => {
       setTimeout(resolve, ms)
@@ -389,6 +411,8 @@ export default class RunCommand extends BaseCommand {
       },
       detached: !isWin // only on POSIX
     })
+
+    this.logProcessTree(this.childProcess.pid)
 
     // Allow parent to exit independently of child on POSIX process groups
     if (!isWin && this.childProcess?.pid) {

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -35,6 +35,7 @@ The `run` command supports the following options for runtime configuration overr
 
 - `-f, --config-file <path>`  
   Specify a different configuration file instead of the default `keyshade.json`. Useful for maintaining different configurations for different environments.
+  
 - `-s, --show-process`
   Show PID information for Keyshade runner and the spawned subprocess.
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -35,6 +35,8 @@ The `run` command supports the following options for runtime configuration overr
 
 - `-f, --config-file <path>`  
   Specify a different configuration file instead of the default `keyshade.json`. Useful for maintaining different configurations for different environments.
+- `-s, --show-process`
+  Show PID information for Keyshade runner and the spawned subprocess.
 
 ### Flag Precedence
 


### PR DESCRIPTION
## Description

Added a new CLI command where running keyshade run --show-process will show the parent-child relationship of the PIDs
Fixes #1102

## Mentions
@DarienArthur-Gocken 
@AhmedIhsan123

## Screenshots of relevant screens

_Add screenshots of relevant screens_
<img width="589" height="226" alt="image" src="https://github.com/user-attachments/assets/698dc006-079d-4194-876f-92a90be9ba68" />

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues


### Documentation Update

- [x] This PR requires an update to the documentation at [docs.keyshade.io](https://docs.keyshade.io)
- [x] I have made the necessary updates to the documentation.
