### PR TITLE
fix(billing): round compounded price to 2 decimal places and add billing period label

### DIFF
--- a/apps/platform/src/components/billing/currentBillDetails/billingDetail/index.tsx
+++ b/apps/platform/src/components/billing/currentBillDetails/billingDetail/index.tsx
@@ -57,10 +57,12 @@ export default function BillingDetail({
     return amount * seats
   }
 
-  const calculateCompoundedPrice = () => {
+  const calculateCompoundedPrice = (): string => {
     const isAnnual = currentSubscription?.isAnnual
     const monthsPaid = isAnnual ? 12 : 1
-    return calculateTotalSeatPrice() * monthsPaid
+    const total = calculateTotalSeatPrice() * monthsPaid
+    const billingLabel = isAnnual ? '12 months' : '1 month'
+    return `$${total.toFixed(2)} (${billingLabel})`
   }
 
   const planPrice = (): `$${number}` => {
@@ -213,7 +215,7 @@ export default function BillingDetail({
           />
           <BillingDetailRow
             label="Compounded price"
-            value={`$${calculateCompoundedPrice()}`}
+            value={calculateCompoundedPrice()}
           />
           <BillingDetailRow
             label="Next Billing Date"


### PR DESCRIPTION
## Description

Round the compounded price to 2 decimal places and append the billing period label (e.g. "(1 month)" for monthly, "(12 months)" for annual) to the value displayed in the billing details panel.

Fixes #1130

## Dependencies

None

## Future Improvements

The price calculation could be moved server-side so the API returns a pre-formatted `compoundedPrice` field directly on the subscription object.

## Mentions

_N/A_

## Screenshots of relevant screens

- Before: `$239.75999999999999`
- After: `$239.76 (12 months)` / `$19.98 (1 month)`

## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
- [x] There are no UI/UX issues

### Documentation Update

- [ ] This PR requires an update to the documentation at [docs.keyshade.io](https://docs.keyshade.io)
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.