### PR TITLE
fix: validate config names

### DIFF
--- a/apps/api/src/decorators/config-name.decorator.ts
+++ b/apps/api/src/decorators/config-name.decorator.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common'
+import { Matches, MinLength } from 'class-validator'
+import {
+  CONFIG_NAME_ERROR_MESSAGE,
+  CONFIG_NAME_REGEX
+} from '@keyshade/schema/raw'
+import { TrimmedString } from '@/decorators/trimmed-string.decorator'
+
+export function ConfigName(minLength?: number) {
+  const decorators: Array<
+    ClassDecorator | MethodDecorator | PropertyDecorator
+  > = [
+    TrimmedString(),
+    Matches(CONFIG_NAME_REGEX, {
+      message: CONFIG_NAME_ERROR_MESSAGE
+    })
+  ]
+
+  if (minLength) {
+    decorators.push(MinLength(minLength))
+  }
+
+  return applyDecorators(...decorators)
+}

--- a/apps/api/src/environment/dto/create.environment/create.environment.spec.ts
+++ b/apps/api/src/environment/dto/create.environment/create.environment.spec.ts
@@ -1,7 +1,33 @@
 import { CreateEnvironment } from './create.environment'
+import { plainToInstance } from 'class-transformer'
+import { validateSync } from 'class-validator'
 
 describe('CreateEnvironment', () => {
   it('should be defined', () => {
     expect(new CreateEnvironment()).toBeDefined()
+  })
+
+  it('should allow alphanumeric names with underscores', () => {
+    const dto = plainToInstance(CreateEnvironment, {
+      name: 'dev_Env2'
+    })
+
+    expect(validateSync(dto)).toHaveLength(0)
+  })
+
+  it('should reject names with unsupported characters', () => {
+    const dto = plainToInstance(CreateEnvironment, {
+      name: 'dev-env'
+    })
+
+    expect(validateSync(dto)).not.toHaveLength(0)
+  })
+
+  it('should reject names shorter than three characters', () => {
+    const dto = plainToInstance(CreateEnvironment, {
+      name: 'qa'
+    })
+
+    expect(validateSync(dto)).not.toHaveLength(0)
   })
 })

--- a/apps/api/src/environment/dto/create.environment/create.environment.ts
+++ b/apps/api/src/environment/dto/create.environment/create.environment.ts
@@ -1,8 +1,7 @@
 import { IsOptional, IsString } from 'class-validator'
-import { TrimmedMinLengthString } from '@/decorators/trimmed-minlength-string.decorator'
+import { ConfigName } from '@/decorators/config-name.decorator'
 export class CreateEnvironment {
-  @IsString()
-  @TrimmedMinLengthString(3)
+  @ConfigName(3)
   name: string
 
   @IsString()

--- a/apps/api/src/secret/dto/create.secret/create.secret.spec.ts
+++ b/apps/api/src/secret/dto/create.secret/create.secret.spec.ts
@@ -1,7 +1,33 @@
 import { CreateSecret } from './create.secret'
+import { plainToInstance } from 'class-transformer'
+import { validateSync } from 'class-validator'
 
 describe('CreateSecret', () => {
   it('should be defined', () => {
     expect(new CreateSecret()).toBeDefined()
+  })
+
+  it('should allow alphanumeric names with underscores', () => {
+    const dto = plainToInstance(CreateSecret, {
+      name: 'API_KEY_19'
+    })
+
+    expect(validateSync(dto)).toHaveLength(0)
+  })
+
+  it('should reject names with unsupported characters', () => {
+    const dto = plainToInstance(CreateSecret, {
+      name: 'API-KEY'
+    })
+
+    expect(validateSync(dto)).not.toHaveLength(0)
+  })
+
+  it('should reject unicode names', () => {
+    const dto = plainToInstance(CreateSecret, {
+      name: 'ключ'
+    })
+
+    expect(validateSync(dto)).not.toHaveLength(0)
   })
 })

--- a/apps/api/src/secret/dto/create.secret/create.secret.ts
+++ b/apps/api/src/secret/dto/create.secret/create.secret.ts
@@ -7,11 +7,11 @@ import {
   Length,
   ValidateNested
 } from 'class-validator'
-import { NonEmptyTrimmedString } from '@/decorators/non-empty-trimmed-string.decorator'
+import { ConfigName } from '@/decorators/config-name.decorator'
 import { Entry } from '@/common/dto/entry.dto'
 
 export class CreateSecret {
-  @NonEmptyTrimmedString()
+  @ConfigName()
   name: string
 
   @IsOptional()

--- a/apps/api/src/variable/dto/create.variable/create.variable.spec.ts
+++ b/apps/api/src/variable/dto/create.variable/create.variable.spec.ts
@@ -1,7 +1,33 @@
 import { CreateVariable } from './create.variable'
+import { plainToInstance } from 'class-transformer'
+import { validateSync } from 'class-validator'
 
 describe('CreateVariable', () => {
   it('should be defined', () => {
     expect(new CreateVariable()).toBeDefined()
+  })
+
+  it('should allow alphanumeric names with underscores', () => {
+    const dto = plainToInstance(CreateVariable, {
+      name: 'PORT_NUMBER_19'
+    })
+
+    expect(validateSync(dto)).toHaveLength(0)
+  })
+
+  it('should reject names with unsupported characters', () => {
+    const dto = plainToInstance(CreateVariable, {
+      name: 'PORT NUMBER'
+    })
+
+    expect(validateSync(dto)).not.toHaveLength(0)
+  })
+
+  it('should reject unicode names', () => {
+    const dto = plainToInstance(CreateVariable, {
+      name: 'ポート'
+    })
+
+    expect(validateSync(dto)).not.toHaveLength(0)
   })
 })

--- a/apps/api/src/variable/dto/create.variable/create.variable.ts
+++ b/apps/api/src/variable/dto/create.variable/create.variable.ts
@@ -2,9 +2,10 @@ import 'reflect-metadata'
 import { Type } from 'class-transformer'
 import { IsArray, IsOptional, Length, ValidateNested } from 'class-validator'
 import { NonEmptyTrimmedString } from '@/decorators/non-empty-trimmed-string.decorator'
+import { ConfigName } from '@/decorators/config-name.decorator'
 
 export class CreateVariable {
-  @NonEmptyTrimmedString()
+  @ConfigName()
   name: string
 
   @IsOptional()

--- a/apps/platform/src/components/dashboard/environment/addEnvironmentDialogue/index.tsx
+++ b/apps/platform/src/components/dashboard/environment/addEnvironmentDialogue/index.tsx
@@ -20,6 +20,10 @@ import {
 } from '@/store'
 import ControllerInstance from '@/lib/controller-instance'
 import { useHttp } from '@/hooks/use-http'
+import {
+  CONFIG_NAME_ERROR_MESSAGE,
+  isValidConfigName
+} from '@/lib/config-name-validation'
 
 export default function AddEnvironmentDialogue(): React.JSX.Element {
   const [isCreateEnvironmentOpen, setIsCreateEnvironmentOpen] = useAtom(
@@ -38,11 +42,11 @@ export default function AddEnvironmentDialogue(): React.JSX.Element {
   })
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
-  // Check if environment name is empty/only whitespace and whether is at least 3 chars length
   const MIN_ENV_NAME_LENGTH = 3
-  const isInvalidEnvironmentName =
-    newEnvironmentData.environmentName.trim() === '' ||
-    newEnvironmentData.environmentName.trim().length < MIN_ENV_NAME_LENGTH
+  const isInvalidEnvironmentName = !isValidConfigName(
+    newEnvironmentData.environmentName,
+    MIN_ENV_NAME_LENGTH
+  )
 
   const createEnvironment = useHttp(() =>
     ControllerInstance.getInstance().environmentController.createEnvironment({
@@ -55,11 +59,10 @@ export default function AddEnvironmentDialogue(): React.JSX.Element {
   const handleAddEnvironment = useCallback(async () => {
     if (selectedProject) {
       if (isInvalidEnvironmentName) {
-        toast.error('Environment name is required', {
+        toast.error('Environment name is invalid', {
           description: (
             <p className="text-xs text-red-300">
-              Please provide a valid name for the environment (not blank and at
-              least has 3 chars).
+              {CONFIG_NAME_ERROR_MESSAGE}. It must be at least 3 characters.
             </p>
           )
         })

--- a/apps/platform/src/components/dashboard/environment/editEnvironmentSheet/index.tsx
+++ b/apps/platform/src/components/dashboard/environment/editEnvironmentSheet/index.tsx
@@ -23,6 +23,7 @@ import {
   environmentsOfProjectAtom
 } from '@/store'
 import { useHttp } from '@/hooks/use-http'
+import { isValidConfigName } from '@/lib/config-name-validation'
 
 export default function EditEnvironmentDialogue(): React.JSX.Element {
   const [isEditEnvironmentOpen, setIsEditEnvironmentOpen] = useAtom(
@@ -110,6 +111,9 @@ export default function EditEnvironmentDialogue(): React.JSX.Element {
     setIsEditEnvironmentOpen
   ])
 
+  const isSaveDisabled =
+    isLoading || !isValidConfigName(requestData.name || '', 3)
+
   return (
     <Sheet
       onOpenChange={(open) => {
@@ -154,7 +158,7 @@ export default function EditEnvironmentDialogue(): React.JSX.Element {
               <div className="flex justify-end">
                 <Button
                   className="rounded-lg border-white/10 bg-[#E0E0E0] text-xs font-semibold text-black hover:bg-gray-200"
-                  disabled={isLoading}
+                  disabled={isSaveDisabled}
                   onClick={handleUpdateEnvironment}
                   variant="secondary"
                 >

--- a/apps/platform/src/components/dashboard/secret/addSecretDialogue/index.tsx
+++ b/apps/platform/src/components/dashboard/secret/addSecretDialogue/index.tsx
@@ -22,6 +22,10 @@ import {
 import { useHttp } from '@/hooks/use-http'
 import { parseUpdatedEnvironmentValues } from '@/lib/utils'
 import EnvironmentValueEditor from '@/components/common/environment-value-editor'
+import {
+  CONFIG_NAME_ERROR_MESSAGE,
+  isValidConfigName
+} from '@/lib/config-name-validation'
 
 export default function AddSecretDialog() {
   const [isCreateSecretOpen, setIsCreateSecretOpen] =
@@ -62,8 +66,12 @@ export default function AddSecretDialog() {
 
   const handleAddSecret = useCallback(async () => {
     if (selectedProject) {
-      if (requestData.name.trim() === '') {
-        toast.error('Please enter a secret name')
+      if (!isValidConfigName(requestData.name)) {
+        toast.error('Secret name is invalid', {
+          description: (
+            <p className="text-xs text-red-300">{CONFIG_NAME_ERROR_MESSAGE}</p>
+          )
+        })
         return
       }
 

--- a/apps/platform/src/components/dashboard/secret/editSecretSheet/index.tsx
+++ b/apps/platform/src/components/dashboard/secret/editSecretSheet/index.tsx
@@ -29,6 +29,7 @@ import {
   mergeExistingEnvironments,
   parseUpdatedEnvironmentValues
 } from '@/lib/utils'
+import { isValidConfigName } from '@/lib/config-name-validation'
 
 export default function EditSecretSheet(): JSX.Element {
   const [isEditSecretSheetOpen, setIsEditSecretSheetOpen] =
@@ -189,7 +190,7 @@ export default function EditSecretSheet(): JSX.Element {
     []
   )
 
-  const isSaveDisabled = isLoading || !hasChanges
+  const isSaveDisabled = isLoading || !hasChanges || !isValidConfigName(name)
 
   return (
     <Sheet onOpenChange={setIsEditSecretSheetOpen} open={isEditSecretSheetOpen}>

--- a/apps/platform/src/components/dashboard/variable/addVariableDialogue/index.tsx
+++ b/apps/platform/src/components/dashboard/variable/addVariableDialogue/index.tsx
@@ -22,6 +22,10 @@ import {
 import { useHttp } from '@/hooks/use-http'
 import { parseUpdatedEnvironmentValues } from '@/lib/utils'
 import EnvironmentValueEditor from '@/components/common/environment-value-editor'
+import {
+  CONFIG_NAME_ERROR_MESSAGE,
+  isValidConfigName
+} from '@/lib/config-name-validation'
 
 export default function AddVariableDialogue(): React.JSX.Element {
   const [isCreateVariableOpen, setIsCreateVariableOpen] = useAtom(
@@ -63,8 +67,12 @@ export default function AddVariableDialogue(): React.JSX.Element {
 
   const handleAddVariable = useCallback(async () => {
     if (selectedProject) {
-      if (requestData.name.trim() === '') {
-        toast.error('Variable name is required')
+      if (!isValidConfigName(requestData.name)) {
+        toast.error('Variable name is invalid', {
+          description: (
+            <p className="text-xs text-red-300">{CONFIG_NAME_ERROR_MESSAGE}</p>
+          )
+        })
         return
       }
 

--- a/apps/platform/src/components/dashboard/variable/editVariableSheet/index.tsx
+++ b/apps/platform/src/components/dashboard/variable/editVariableSheet/index.tsx
@@ -28,6 +28,7 @@ import {
   mergeExistingEnvironments,
   parseUpdatedEnvironmentValues
 } from '@/lib/utils'
+import { isValidConfigName } from '@/lib/config-name-validation'
 
 export default function EditVariablSheet() {
   const [isEditVariableOpen, setIsEditVariableOpen] =
@@ -208,7 +209,7 @@ export default function EditVariablSheet() {
         <SheetFooter>
           <SheetClose asChild>
             <Button
-              disabled={isLoading || !hasChanges}
+              disabled={isLoading || !hasChanges || !isValidConfigName(name)}
               onClick={handleSave}
               variant="secondary"
             >

--- a/apps/platform/src/lib/config-name-validation.ts
+++ b/apps/platform/src/lib/config-name-validation.ts
@@ -1,0 +1,14 @@
+import {
+  CONFIG_NAME_ERROR_MESSAGE,
+  CONFIG_NAME_REGEX
+} from '@keyshade/schema/raw'
+
+export { CONFIG_NAME_ERROR_MESSAGE }
+
+export function isValidConfigName(name: string, minLength = 1): boolean {
+  const trimmedName = name.trim()
+
+  return (
+    trimmedName.length >= minLength && CONFIG_NAME_REGEX.test(trimmedName)
+  )
+}

--- a/packages/schema/src/common/index.ts
+++ b/packages/schema/src/common/index.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const CONFIG_NAME_REGEX = /^[A-Za-z0-9_]+$/
+
+export const CONFIG_NAME_ERROR_MESSAGE =
+  'Name can only contain letters, numbers, and underscores'
+
+export const ConfigNameSchema = z
+  .string()
+  .trim()
+  .regex(CONFIG_NAME_REGEX, CONFIG_NAME_ERROR_MESSAGE)

--- a/packages/schema/src/environment/index.ts
+++ b/packages/schema/src/environment/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { PageRequestSchema, PageResponseSchema } from '@/pagination'
+import { ConfigNameSchema } from '@/common'
 
 export const EnvironmentSchema = z.object({
   id: z.string(),
@@ -28,7 +29,7 @@ export const EnvironmentSchema = z.object({
 })
 
 export const CreateEnvironmentRequestSchema = z.object({
-  name: EnvironmentSchema.shape.name,
+  name: ConfigNameSchema.min(3),
   description: z.string().optional(),
   projectSlug: z.string()
 })

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,6 +1,7 @@
 //Export all Schemas
 
 export * from './pagination'
+export * from './common'
 export * from './auth'
 export * from './enums'
 export * from './environment'

--- a/packages/schema/src/secret/index.ts
+++ b/packages/schema/src/secret/index.ts
@@ -3,6 +3,7 @@ import { PageRequestSchema, PageResponseSchema } from '@/pagination'
 import { rotateAfterEnum } from '@/enums'
 import { EnvironmentSchema } from '@/environment'
 import { UserSchema } from '@/user'
+import { ConfigNameSchema } from '@/common'
 
 export const SecretRevisionSchema = z.object({
   value: z.string(),
@@ -46,7 +47,7 @@ export const SecretSchema = z.object({
 
 export const CreateSecretRequestSchema = z.object({
   projectSlug: z.string(),
-  name: z.string(),
+  name: ConfigNameSchema,
   note: z.string().optional(),
   rotateAfter: rotateAfterEnum.optional(),
   entries: z

--- a/packages/schema/src/variable/index.ts
+++ b/packages/schema/src/variable/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { PageRequestSchema, PageResponseSchema } from '@/pagination'
 import { EnvironmentSchema } from '@/environment'
 import { UserSchema } from '@/user'
+import { ConfigNameSchema } from '@/common'
 
 export const VariableRevisionSchema = z.object({
   version: z.number(),
@@ -44,7 +45,7 @@ export const VariableSchema = z.object({
 })
 export const CreateVariableRequestSchema = z.object({
   projectSlug: z.string(),
-  name: z.string(),
+  name: ConfigNameSchema,
   note: z.string().optional(),
   entries: z
     .array(
@@ -83,7 +84,7 @@ export const BulkCreateVariableResponseSchema = z.object({
 
 export const UpdateVariableRequestSchema = z.object({
   variableSlug: z.string(),
-  name: z.string().optional(),
+  name: ConfigNameSchema.optional(),
   note: z.string().optional(),
   entries: z
     .array(


### PR DESCRIPTION
## Description

Introduce a shared regex/schema for validating config names, restricting them to `a-z`, `A-Z`, `0-9`, and `_`.

Applied this validation across environment, secret, and variable create/update request schemas to ensure consistency.

Added API-level DTO validation with tests covering valid, invalid, and unicode inputs.

Also implemented platform-side validation in create/edit flows to prevent invalid submissions early.

Fixes #1056

## Dependencies

No new external dependencies introduced.  
Relies on existing validation tooling in the codebase.

## Future Improvements

- Centralize validation logic further to avoid duplication between API and platform layers  
- Improve error messaging for invalid names (more user-friendly feedback)  
- Consider supporting additional characters if future requirements change  

## Mentions

_None_

## Screenshots of relevant screens

N/A (no UI changes beyond validation feedback)

## Developer's checklist

- [x] My PR follows the style guidelines of this project  
- [x] I have performed a self-check on my work  

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)  
- [x] My changes in code generate no new warnings  
- [ ] My changes are breaking another fix/feature of the project  
- [x] I have added test cases to show that my feature works  
- [ ] I have added relevant screenshots in my PR  
- [x] There are no UI/UX issues  

### Documentation Update

- [ ] This PR requires an update to the documentation at https://docs.keyshade.io  
- [x] I have made the necessary updates to the documentation, or no documentation changes are required.  