### PR TITLE
fix: reset secret scan regex state

### DIFF
--- a/packages/secret-scan/src/index.ts
+++ b/packages/secret-scan/src/index.ts
@@ -16,6 +16,7 @@ class SecretDetector {
    */
   detect(input: string): SecretResult {
     for (const regex of this.patterns) {
+      regex.lastIndex = 0
       // If the regex has a filter, use it for post-processing
       if ((regex as any).filter) {
         const matches = input.match(regex)

--- a/packages/secret-scan/src/test/secret.test.ts
+++ b/packages/secret-scan/src/test/secret.test.ts
@@ -126,6 +126,25 @@ describe('Detect Secrets from string', () => {
     testSecret(jwt.testcases)
   })
 
+  it('should detect global regex patterns consistently across repeated scans', () => {
+    jest.isolateModules(() => {
+      jest.doMock('@/denylist', () => ({
+        __esModule: true,
+        default: {
+          test: [/secret_[a-z]+/g]
+        }
+      }))
+
+      const detector = require('@/index').default
+      const token = 'secret_token'
+
+      expect(detector.detect(token).found).toBe(true)
+      expect(detector.detect(token).found).toBe(true)
+    })
+
+    jest.dontMock('@/denylist')
+  })
+
   it(testcaseTitleTemplate('Cloudflare Key'), () => {
     testSecret(cloudflare.testcases)
   })


### PR DESCRIPTION
## Summary
Reset each secret scan regex's `lastIndex` before evaluation so repeated scans remain deterministic when global or sticky regex patterns are reused.

## Why
Global regex patterns retain state between `.test()` calls. Since `SecretDetector` reuses configured regex instances, repeated scans of the same input can otherwise return inconsistent results.

## Changes
- Reset `regex.lastIndex` before each scan
- Add a regression test for repeated detection with a global regex pattern

## Testing
- `pnpm test:secret-scan`