### PR TITLE
fix: use scoped secret scan filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "test:web": "turbo run test --filter=@keyshade/web",
     "test:platform": "turbo run test --filter=@keyshade/platform",
     "test:api-client": "pnpm run --filter=@keyshade/api-client test",
-    "test:secret-scan": "pnpm run --filter=secret-scan test",
+    "test:secret-scan": "pnpm run --filter=@keyshade/secret-scan test",
     "db:seed": "pnpm run --filter=@keyshade/api db:seed",
     "db:generate-types": "pnpm run --filter=@keyshade/api db:generate-types",
     "db:generate-migrations": "pnpm run --filter=@keyshade/api db:generate-migrations",


### PR DESCRIPTION
## Summary
Use the scoped package name when running the secret-scan test script from the root package.

## Why
Other workspace scripts use scoped package filters. This keeps the secret-scan test script consistent and points directly at `@keyshade/secret-scan`.

## Testing
- `pnpm test:secret-scan`